### PR TITLE
Reducing Evrete cold start time by an order of magnitude.

### DIFF
--- a/framework/src/main/java/dev/ikm/komet/framework/rulebase/RuleServiceFinder.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/rulebase/RuleServiceFinder.java
@@ -22,7 +22,7 @@ import dev.ikm.tinkar.common.service.PluggableService;
 
 public enum RuleServiceFinder {
     INSTANCE;
-    RuleService service;
+    final RuleService service;
 
     RuleServiceFinder() {
         Optional<RuleService> optionalService = PluggableService.load(RuleService.class).findFirst();

--- a/framework/src/main/java/dev/ikm/komet/framework/rulebase/RuleServiceFinder.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/rulebase/RuleServiceFinder.java
@@ -15,8 +15,6 @@
  */
 package dev.ikm.komet.framework.rulebase;
 
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <owlapi.groupId>dev.ikm.owlapi</owlapi.groupId>
         <owlapi.version>4.7.0</owlapi.version>
         <ikm-evrete.groupId>org.evrete</ikm-evrete.groupId>
-        <ikm-evrete.version>4.0.2</ikm-evrete.version>
+        <ikm-evrete.version>4.0.3</ikm-evrete.version>
         <tinkar-jpms-deps.groupId>dev.ikm.jpms</tinkar-jpms-deps.groupId>
         <tinkar-jpms-deps.version>1.0.15</tinkar-jpms-deps.version>
         <jpms-record-builder-core.version>36-r6</jpms-record-builder-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <owlapi.groupId>dev.ikm.owlapi</owlapi.groupId>
         <owlapi.version>4.7.0</owlapi.version>
         <ikm-evrete.groupId>org.evrete</ikm-evrete.groupId>
-        <ikm-evrete.version>3.2.01</ikm-evrete.version>
+        <ikm-evrete.version>4.0.2</ikm-evrete.version>
         <tinkar-jpms-deps.groupId>dev.ikm.jpms</tinkar-jpms-deps.groupId>
         <tinkar-jpms-deps.version>1.0.15</tinkar-jpms-deps.version>
         <jpms-record-builder-core.version>36-r6</jpms-record-builder-core.version>

--- a/rules/src/main/java/dev/ikm/komet/rules/annotated/AxiomFocusedRules.java
+++ b/rules/src/main/java/dev/ikm/komet/rules/annotated/AxiomFocusedRules.java
@@ -22,40 +22,25 @@ import dev.ikm.komet.rules.actions.axiom.*;
 import dev.ikm.tinkar.common.sets.ConcurrentHashSet;
 import dev.ikm.tinkar.terms.TinkarTerm;
 import org.evrete.api.RhsContext;
-import org.evrete.dsl.annotation.FieldDeclaration;
+import org.evrete.dsl.annotation.MethodPredicate;
 import org.evrete.dsl.annotation.Rule;
 import org.evrete.dsl.annotation.RuleSet;
 import org.evrete.dsl.annotation.Where;
 
 /**
  * Rules related to axiom-related observations.
- * <p>
- * To simplify the conditions of the rules, this ruleset employs custom field declarations through
- * the use of the {@link FieldDeclaration} annotation.
- * </p>
- * <p>
- * Custom field declarations provide an additional abstraction layer for the domain classes and allow
- * for changing the conditions easily should the domain classes change. And, as a side benefit,
- * we no longer need to include now unnecessary imports via the
- * {@link org.evrete.api.Knowledge#addImport(Class)} method.
- * </p>
- * <p>
- * Custom fields are better placed in a common parent class so they could be reused
- * by multiple rulesets.
- * </p>
  */
 @RuleSet("Axiom focus rules")
 public class AxiomFocusedRules extends RulesBase {
-    //private static final Logger LOG = LoggerFactory.getLogger(AxiomFocusedRules.class);
 
     /**
      * @see RulesBase#isAxiomFocused(ObservationRecord)
      * @see RulesBase#isNotDefinitionRoot(ObservationRecord)
      */
     @Rule("Axiom of interest is not the definition root")
-    @Where({
-            "$observation.isAxiomFocused",
-            "$observation.isNotDefinitionRoot"
+    @Where(methods = {
+            @MethodPredicate(method = "isAxiomFocused", args = {"$observation"}),
+            @MethodPredicate(method = "isNotDefinitionRoot", args = {"$observation"})
     })
     public void axiomIsNotDefinitionRoot(ObservationRecord $observation) {
         // TODO would be nice if Evrete recognized the pattern variable "axiomSubject" and could pass it as a parameter.
@@ -71,9 +56,9 @@ public class AxiomFocusedRules extends RulesBase {
      * @see RulesBase#isDefinitionRoot(ObservationRecord)
      */
     @Rule("Axiom of interest is the definition root")
-    @Where({
-            "$observation.isAxiomFocused",
-            "$observation.isDefinitionRoot"
+    @Where(methods = {
+            @MethodPredicate(method = "isAxiomFocused", args = {"$observation"}),
+            @MethodPredicate(method = "isDefinitionRoot", args = {"$observation"})
     })
     public void axiomIsDefinitionRoot(ObservationRecord $observation,
                                       RhsContext ctx) {
@@ -95,9 +80,9 @@ public class AxiomFocusedRules extends RulesBase {
      * @see RulesBase#isAxiomSet(ObservationRecord)
      */
     @Rule("Axiom of interest is a set")
-    @Where({
-            "$observation.isAxiomFocused",
-            "$observation.isAxiomSet"
+    @Where(methods = {
+            @MethodPredicate(method = "isAxiomFocused", args = {"$observation"}),
+            @MethodPredicate(method = "isAxiomSet", args = {"$observation"})
     })
     public void axiomIsSet(ObservationRecord $observation,
                            RhsContext ctx) {
@@ -128,9 +113,9 @@ public class AxiomFocusedRules extends RulesBase {
      * @see RulesBase#isAxiomConcept(ObservationRecord)
      */
     @Rule("Axiom of interest is a concept axiom")
-    @Where({
-            "$observation.isAxiomFocused",
-            "$observation.isAxiomConcept"
+    @Where(methods = {
+            @MethodPredicate(method = "isAxiomFocused", args = {"$observation"}),
+            @MethodPredicate(method = "isAxiomConcept", args = {"$observation"})
     })
     public void axiomIsConceptAxiom(ObservationRecord $observation,
                                     RhsContext ctx) {
@@ -150,9 +135,9 @@ public class AxiomFocusedRules extends RulesBase {
      * @see RulesBase#isAxiomRoleGroup(ObservationRecord)
      */
     @Rule("Axiom of interest is a role group")
-    @Where({
-            "$observation.isAxiomFocused",
-            "$observation.isAxiomRoleGroup"
+    @Where(methods = {
+            @MethodPredicate(method = "isAxiomFocused", args = {"$observation"}),
+            @MethodPredicate(method = "isAxiomRoleGroup", args = {"$observation"})
     })
     public void axiomIsRoleGroup(ObservationRecord $observation,
                                  RhsContext ctx) {
@@ -168,9 +153,9 @@ public class AxiomFocusedRules extends RulesBase {
      * @see RulesBase#isAxiomRoleOnly(ObservationRecord)
      */
     @Rule("Axiom of interest is a role but not a role group")
-    @Where({
-            "$observation.isAxiomFocused",
-            "$observation.isAxiomRoleOnly"
+    @Where(methods = {
+            @MethodPredicate(method = "isAxiomFocused", args = {"$observation"}),
+            @MethodPredicate(method = "isAxiomRoleOnly", args = {"$observation"})
     })
     public void axiomIsRoleButNotARoleGroup(ObservationRecord $observation,
                                             ConcurrentHashSet<Consequence<?>> $actionList,
@@ -199,9 +184,9 @@ public class AxiomFocusedRules extends RulesBase {
      * @see RulesBase#isAxiomFeature(ObservationRecord)
      */
     @Rule("Axiom of interest is a feature")
-    @Where({
-            "$observation.isAxiomFocused",
-            "$observation.isAxiomFeature"
+    @Where(methods = {
+            @MethodPredicate(method = "isAxiomFocused", args = {"$observation"}),
+            @MethodPredicate(method = "isAxiomFeature", args = {"$observation"})
     })
     public void axiomIsFeature(ObservationRecord $observation,
                                RhsContext ctx) {
@@ -224,5 +209,4 @@ public class AxiomFocusedRules extends RulesBase {
             );
         }
     }
-
 }

--- a/rules/src/main/java/dev/ikm/komet/rules/annotated/ComponentFocusRules.java
+++ b/rules/src/main/java/dev/ikm/komet/rules/annotated/ComponentFocusRules.java
@@ -27,32 +27,13 @@ import dev.ikm.tinkar.coordinate.stamp.calculator.Latest;
 import dev.ikm.tinkar.entity.ConceptEntityVersion;
 import dev.ikm.tinkar.entity.EntityVersion;
 import dev.ikm.tinkar.terms.TinkarTerm;
-import org.evrete.dsl.annotation.FieldDeclaration;
-import org.evrete.dsl.annotation.Rule;
-import org.evrete.dsl.annotation.RuleSet;
-import org.evrete.dsl.annotation.Where;
+import org.evrete.dsl.annotation.*;
 
 /**
  * Rules related to component-related observations.
- * <p>
- * To simplify the conditions of the rules, this ruleset employs custom field declarations through
- * the use of the {@link FieldDeclaration} annotation.
- * </p>
- * <p>
- * Custom field declarations provide an additional abstraction layer for the domain classes and allow
- * for changing the conditions easily should the domain classes change. And, as a side benefit,
- * we no longer need to include now unnecessary imports via the
- * {@link org.evrete.api.Knowledge#addImport(Class)} method.
- * </p>
- * <p>
- * Custom fields are better placed in a common parent class so they could be reused
- * by multiple rulesets.
- * </p>
- *
  * Note: The java compiler needs the -parameters argument
  * see: <a href="https://www.evrete.org/docs#ajr">https://www.evrete.org/docs/#ajr</a>
  */
-
 @RuleSet("Component focus rules")
 public class ComponentFocusRules extends RulesBase {
 
@@ -63,9 +44,9 @@ public class ComponentFocusRules extends RulesBase {
      * @see RulesBase#isComponentActive(ObservationRecord)
      */
     @Rule("Component focused and active")
-    @Where({
-            "$observation.focusedComponent",
-            "$observation.isComponentActive"
+    @Where(methods = {
+            @MethodPredicate(method = "isComponentFocused", args = {"$observation"}),
+            @MethodPredicate(method = "isComponentActive", args = {"$observation"})
     })
     public void componentFocusedAndActive(ObservationRecord $observation) {
         if ($observation.subject() instanceof EntityVersion entityVersion) {
@@ -80,9 +61,9 @@ public class ComponentFocusRules extends RulesBase {
      * @see RulesBase#isComponentInactive(ObservationRecord)
      */
     @Rule("Component focused and inactive")
-    @Where({
-            "$observation.focusedComponent",
-            "$observation.isComponentInactive"
+    @Where(methods = {
+            @MethodPredicate(method = "isComponentFocused", args = {"$observation"}),
+            @MethodPredicate(method = "isComponentInactive", args = {"$observation"})
     })
     public void componentFocusedAndInactive(ObservationRecord $observation) {
         if ($observation.subject() instanceof EntityVersion entityVersion) {
@@ -97,9 +78,9 @@ public class ComponentFocusRules extends RulesBase {
      * @see RulesBase#isConceptVersion(ObservationRecord)
      */
     @Rule("Concept version focused")
-    @Where({
-            "$observation.focusedComponent",
-            "$observation.isConceptVersion"
+    @Where(methods = {
+            @MethodPredicate(method = "isComponentFocused", args = {"$observation"}),
+            @MethodPredicate(method = "isConceptVersion", args = {"$observation"})
     })
     public void conceptVersionFocused(ObservationRecord $observation) {
         //TODO see if we can get more in the @Where annotation, and maybe split into multiple rules.

--- a/rules/src/main/java/dev/ikm/komet/rules/annotated/NewConceptRules.java
+++ b/rules/src/main/java/dev/ikm/komet/rules/annotated/NewConceptRules.java
@@ -18,27 +18,10 @@ package dev.ikm.komet.rules.annotated;
 import dev.ikm.komet.framework.performance.Request;
 import dev.ikm.komet.framework.performance.Statement;
 import dev.ikm.komet.rules.actions.concept.NewConceptFromTextAction;
-import org.evrete.dsl.annotation.FieldDeclaration;
-import org.evrete.dsl.annotation.Rule;
-import org.evrete.dsl.annotation.RuleSet;
-import org.evrete.dsl.annotation.Where;
+import org.evrete.dsl.annotation.*;
 
 /**
  * Rules related to concept-related statements.
- * <p>
- * To simplify the conditions of the rules, this ruleset employs custom field declarations through
- * the use of the {@link FieldDeclaration} annotation.
- * </p>
- * <p>
- * Custom field declarations provide an additional abstraction layer for the domain classes and allow
- * for changing the conditions easily should the domain classes change. And, as a side benefit,
- * we no longer need to include now unnecessary imports via the
- * {@link org.evrete.api.Knowledge#addImport(Class)} method.
- * </p>
- * <p>
- * Custom fields are better placed in a common parent class so they could be reused
- * by multiple rulesets.
- * </p>
  */
 @RuleSet("New concept rules")
 public class NewConceptRules extends RulesBase {
@@ -48,9 +31,9 @@ public class NewConceptRules extends RulesBase {
      * @see RulesBase#requestWithStringSubject(Statement)
      */
     @Rule("New concept rule")
-    @Where({
-            "$request.isNewConceptRequest",
-            "$request.requestWithStringSubject"
+    @Where(methods = {
+            @MethodPredicate(method = "isNewConceptRequest", args = {"$request"}),
+            @MethodPredicate(method = "requestWithStringSubject", args = {"$request"})
     })
     public void newConceptRule(Statement $request) {
         if ($request instanceof Request request) {

--- a/rules/src/main/java/dev/ikm/komet/rules/annotated/NewPatternRules.java
+++ b/rules/src/main/java/dev/ikm/komet/rules/annotated/NewPatternRules.java
@@ -18,27 +18,10 @@ package dev.ikm.komet.rules.annotated;
 import dev.ikm.komet.framework.performance.Request;
 import dev.ikm.komet.framework.performance.Statement;
 import dev.ikm.komet.rules.actions.pattern.NewPatternAction;
-import org.evrete.dsl.annotation.FieldDeclaration;
-import org.evrete.dsl.annotation.Rule;
-import org.evrete.dsl.annotation.RuleSet;
-import org.evrete.dsl.annotation.Where;
+import org.evrete.dsl.annotation.*;
 
 /**
  * Rules relater to pattern-related statements
- * <p>
- * To simplify the conditions of the rules, this ruleset employs custom field declarations through
- * the use of the {@link FieldDeclaration} annotation.
- * </p>
- * <p>
- * Custom field declarations provide an additional abstraction layer for the domain classes and allow
- * for changing the conditions easily should the domain classes change. And, as a side benefit,
- * we no longer need to include now unnecessary imports via the
- * {@link org.evrete.api.Knowledge#addImport(Class)} method.
- * </p>
- * <p>
- * Custom fields are better placed in a common parent class so they could be reused
- * by multiple rulesets.
- * </p>
  */
 @RuleSet("New pattern rules")
 public class NewPatternRules extends RulesBase {
@@ -48,9 +31,9 @@ public class NewPatternRules extends RulesBase {
      * @see RulesBase#requestWithStringSubject(Statement)
      */
     @Rule("New pattern rule")
-    @Where({
-            "$request.isNewPatternRequest",
-            "$request.requestWithStringSubject"
+    @Where(methods = {
+            @MethodPredicate(method = "isNewPatternRequest", args = {"$request"}),
+            @MethodPredicate(method = "requestWithStringSubject", args = {"$request"})
     })
     public void newPatternRule(Statement $request) {
         if ($request instanceof Request request) {

--- a/rules/src/main/java/dev/ikm/komet/rules/annotated/RulesBase.java
+++ b/rules/src/main/java/dev/ikm/komet/rules/annotated/RulesBase.java
@@ -32,7 +32,8 @@ import dev.ikm.tinkar.entity.ConceptEntityVersion;
 import dev.ikm.tinkar.entity.EntityVersion;
 import dev.ikm.tinkar.terms.TinkarTerm;
 import javafx.scene.control.Menu;
-import org.evrete.dsl.annotation.EnvironmentListener;
+import org.evrete.api.events.EnvironmentChangeEvent;
+import org.evrete.dsl.annotation.EventSubscription;
 import org.evrete.dsl.annotation.FieldDeclaration;
 
 import java.util.Objects;
@@ -50,33 +51,25 @@ public abstract class RulesBase {
     private ViewProperties viewProperties;
 
     /**
-     * Instead of submitting consequences as a fact for each rule, we set it as an environment variable
+     * Environment listener
      *
-     * @param consequences the set of consequences
+     * @param event environment change event
      */
-    @EnvironmentListener(ENV_CONSEQUENCES)
-    public void onConsequences(ConcurrentHashSet<Consequence<?>> consequences) {
-        this.consequences = consequences;
-    }
-
-    /**
-     * Instead of submitting coordinates as a fact for each rule, we set it as an environment variable
-     *
-     * @param editCoordinate coordinate environment value
-     */
-    @EnvironmentListener(ENV_EDIT_COORDINATE)
-    public void onEditCoordinate(EditCoordinate editCoordinate) {
-        this.editCoordinate = editCoordinate;
-    }
-
-    /**
-     * Instead of submitting view properties as a fact for each rule, we set it as an environment variable
-     *
-     * @param viewProperties view properties environment value
-     */
-    @EnvironmentListener(ENV_VIEW_PROPERTIES)
-    public void onViewProperties(ViewProperties viewProperties) {
-        this.viewProperties = viewProperties;
+    @EventSubscription
+    @SuppressWarnings("unchecked")
+    public void onGlobalsChange(EnvironmentChangeEvent event) {
+        Object envValue = event.getValue();
+        switch (event.getProperty()) {
+            case ENV_CONSEQUENCES:
+                this.consequences = (ConcurrentHashSet<Consequence<?>>) envValue;
+                break;
+            case ENV_EDIT_COORDINATE:
+                this.editCoordinate = (EditCoordinate) envValue;
+                break;
+            case ENV_VIEW_PROPERTIES:
+                this.viewProperties = (ViewProperties) envValue;
+                break;
+        }
     }
 
     public EditCoordinate editCoordinate() {

--- a/rules/src/main/java/dev/ikm/komet/rules/annotated/RulesBase.java
+++ b/rules/src/main/java/dev/ikm/komet/rules/annotated/RulesBase.java
@@ -32,9 +32,9 @@ import dev.ikm.tinkar.entity.ConceptEntityVersion;
 import dev.ikm.tinkar.entity.EntityVersion;
 import dev.ikm.tinkar.terms.TinkarTerm;
 import javafx.scene.control.Menu;
+import org.evrete.api.annotations.RuleElement;
 import org.evrete.api.events.EnvironmentChangeEvent;
 import org.evrete.dsl.annotation.EventSubscription;
-import org.evrete.dsl.annotation.FieldDeclaration;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -101,13 +101,13 @@ public abstract class RulesBase {
     }
 
     /**
-     * Creates a new boolean field `isNotDefinitionRoot` for {@link ObservationRecord} that returns true if
+     * Condition method on {@link ObservationRecord} that returns true if
      * the given observation's subject is a {@link AxiomSubjectRecord} and not a definition root.
      *
      * @param observation the observation record
      * @return true if the observation's subject is not a definition root, false otherwise
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean isNotDefinitionRoot(ObservationRecord observation) {
         return observation.subject() instanceof AxiomSubjectRecord axiomSubject
                 &&
@@ -115,13 +115,13 @@ public abstract class RulesBase {
     }
 
     /**
-     * Creates a new boolean field `isDefinitionRoot` for {@link ObservationRecord} that returns true if
+     * Condition method on {@link ObservationRecord} that returns true if
      * the given observation's subject is a {@link AxiomSubjectRecord} and a definition root.
      *
      * @param observation the observation record
      * @return true if the observation's subject is a definition root, false otherwise
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean isDefinitionRoot(ObservationRecord observation) {
         return observation.subject() instanceof AxiomSubjectRecord axiomSubject
                 &&
@@ -129,13 +129,13 @@ public abstract class RulesBase {
     }
 
     /**
-     * Creates a new boolean field `isAxiomSet` for {@link ObservationRecord} that returns true if
+     * Condition method on {@link ObservationRecord} that returns true if
      * the given observation's subject is a {@link AxiomSubjectRecord} and a set.
      *
      * @param observation the observation record
      * @return true if the observation's subject is a set
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean isAxiomSet(ObservationRecord observation) {
         return observation.subject() instanceof AxiomSubjectRecord axiomSubject
                 &&
@@ -143,13 +143,13 @@ public abstract class RulesBase {
     }
 
     /**
-     * Creates a new boolean field `isAxiomConcept` for {@link ObservationRecord} that returns true if
+     * Condition method on {@link ObservationRecord} that returns true if
      * the given observation's subject is a {@link AxiomSubjectRecord} and a concept.
      *
      * @param observation the observation record
      * @return true if the observation's subject is a concept
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean isAxiomConcept(ObservationRecord observation) {
         return observation.subject() instanceof AxiomSubjectRecord axiomSubject
                 &&
@@ -157,13 +157,13 @@ public abstract class RulesBase {
     }
 
     /**
-     * Creates a new boolean field `isAxiomRoleGroup` for {@link ObservationRecord} that returns true if
+     * Condition method on {@link ObservationRecord} that returns true if
      * the given observation's subject is a {@link AxiomSubjectRecord} and a role group.
      *
      * @param observation the observation record
      * @return true if the observation's subject is a role group
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean isAxiomRoleGroup(ObservationRecord observation) {
         return observation.subject() instanceof AxiomSubjectRecord axiomSubject &&
                 axiomSubject.axiomMeaningNid() == TinkarTerm.ROLE_TYPE.nid()
@@ -172,13 +172,13 @@ public abstract class RulesBase {
     }
 
     /**
-     * Creates a new boolean field `isAxiomRoleOnly` for {@link ObservationRecord} that returns true if
+     * Condition method on {@link ObservationRecord} that returns true if
      * the given observation's subject is a {@link AxiomSubjectRecord} and a role (but not a role group).
      *
      * @param observation the observation record
      * @return true if the observation's subject is a role but not a role group
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean isAxiomRoleOnly(ObservationRecord observation) {
         return observation.subject() instanceof AxiomSubjectRecord axiomSubject
                 &&
@@ -188,13 +188,13 @@ public abstract class RulesBase {
     }
 
     /**
-     * Creates a new boolean field `isAxiomFeature` for {@link ObservationRecord} that returns true if
+     * Condition method on {@link ObservationRecord} that returns true if
      * the given observation's subject is a {@link AxiomSubjectRecord} and a feature.
      *
      * @param observation the observation record
      * @return true if the observation's subject is a feature
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean isAxiomFeature(ObservationRecord observation) {
         return observation.subject() instanceof AxiomSubjectRecord axiomSubject
                 &&
@@ -202,45 +202,37 @@ public abstract class RulesBase {
     }
 
     /**
-     * Creates a new boolean field `isAxiomFocused` for {@link ObservationRecord} that returns true if
+     * Condition method on {@link ObservationRecord} that returns true if
      * the given observation's topic is {@link Topic#AXIOM_FOCUSED}.
      *
      * @param observation the observation record
      * @return true if the observation's topic is {@link Topic#AXIOM_FOCUSED}
      */
-    @FieldDeclaration(name = "isAxiomFocused")
-    // In the field declaration, we use the same property name as the method's name,
-    // although it could be different.
+    @RuleElement
     public boolean isAxiomFocused(ObservationRecord observation) {
         return observation.topic() == Topic.AXIOM_FOCUSED;
     }
 
     /**
-     * Creates a new boolean field `focusedComponent` for {@link ObservationRecord} that returns true if
+     * Condition method on {@link ObservationRecord} that returns true if
      * the given observation's topic is {@link Topic#COMPONENT_FOCUSED}.
-     * <p>
-     * Please note that the optional `name` argument in the {@code @FieldDeclaration} annotation defines
-     * the name of the custom field. If this property isn't set, the field will be named after the method
-     * that defines it.
-     * </p>
      *
      * @param observation the observation record
      * @return true if the observation's topic is {@link Topic#COMPONENT_FOCUSED}
      */
-    @FieldDeclaration(name = "focusedComponent")
+    @RuleElement
     public boolean isComponentFocused(ObservationRecord observation) {
         return observation.topic() == Topic.COMPONENT_FOCUSED;
     }
 
-
     /**
-     * Creates a new boolean field `isComponentActive` for {@link ObservationRecord} that returns true if
+     * Condition method on {@link ObservationRecord} that returns true if
      * the given observation's subject is an active {@link EntityVersion}.
      *
      * @param observation the observation record
      * @return true if the observation's subject is an active {@link EntityVersion}
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean isComponentActive(ObservationRecord observation) {
         return observation.subject() instanceof EntityVersion entityVersion
                 &&
@@ -248,13 +240,13 @@ public abstract class RulesBase {
     }
 
     /**
-     * Creates a new boolean field `isComponentInactive` for {@link ObservationRecord} that returns true if
+     * Condition method on {@link ObservationRecord} that returns true if
      * the given observation's subject is an inactive {@link EntityVersion}.
      *
      * @param observation the observation record
      * @return true if the observation's subject is an inactive {@link EntityVersion}
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean isComponentInactive(ObservationRecord observation) {
         return observation.subject() instanceof EntityVersion entityVersion
                 &&
@@ -262,25 +254,25 @@ public abstract class RulesBase {
     }
 
     /**
-     * Creates a new boolean field `isConceptVersion` for {@link ObservationRecord} that returns true if
+     * Condition method on {@link ObservationRecord} that returns true if
      * the given observation's subject is a {@link ConceptEntityVersion}.
      *
      * @param observation the observation record
      * @return true if the observation's subject is a {@link ConceptEntityVersion}
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean isConceptVersion(ObservationRecord observation) {
         return observation.subject() instanceof ConceptEntityVersion;
     }
 
     /**
-     * Creates a new boolean field `requestWithStringSubject` for {@link Statement} that returns true if
+     * Condition method on {@link Statement} that returns true if
      * the given statement is a {@link Request} with a String subject.
      *
      * @param statement the statement being tested
      * @return true if the statement is a {@link Request} with a String subject
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean requestWithStringSubject(Statement statement) {
         return statement instanceof Request request
                 &&
@@ -288,25 +280,25 @@ public abstract class RulesBase {
     }
 
     /**
-     * Creates a new boolean field `isNewPatternRequest` for {@link Statement} that returns true if
+     * Condition method on {@link Statement} that returns {@code true} if
      * the given statement's topic is {@link Topic#NEW_PATTERN_REQUEST}.
      *
      * @param statement the statement being tested
      * @return true if the statement's topic is {@link Topic#NEW_PATTERN_REQUEST}.
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean isNewPatternRequest(Statement statement) {
         return statement.topic() == Topic.NEW_PATTERN_REQUEST;
     }
 
     /**
-     * Creates a new boolean field `isNewConceptRequest` for {@link Statement} that returns true if
+     * Condition method on {@link Statement} that returns true if
      * the given statement's topic is {@link Topic#NEW_CONCEPT_REQUEST}.
      *
      * @param statement the statement being tested
      * @return true if the statement's topic is {@link Topic#NEW_CONCEPT_REQUEST}.
      */
-    @FieldDeclaration
+    @RuleElement
     public boolean isNewConceptRequest(Statement statement) {
         return statement.topic() == Topic.NEW_CONCEPT_REQUEST;
     }

--- a/rules/src/main/java/dev/ikm/komet/rules/builder/AxiomFocusedRulesBuilder.java
+++ b/rules/src/main/java/dev/ikm/komet/rules/builder/AxiomFocusedRulesBuilder.java
@@ -34,11 +34,14 @@ import java.util.UUID;
 public class AxiomFocusedRulesBuilder {
     private static final Logger LOG = LoggerFactory.getLogger(AxiomFocusedRulesBuilder.class);
 
-    static KnowledgeService service = new KnowledgeService();
-    static Knowledge knowledge = service.newKnowledge();
+    static final KnowledgeService service = new KnowledgeService();
+    static final Knowledge knowledge;
 
     static {
-        knowledge.newRule("Axiom of interest is not the definition root")
+        knowledge = service
+                .newKnowledge()
+                .builder()
+                .newRule("Axiom of interest is not the definition root")
                 .forEach(
                         "$observation", ObservationRecord.class,
                         "$actionList", ConcurrentHashSet.class,
@@ -65,6 +68,7 @@ public class AxiomFocusedRulesBuilder {
                         $actionList.add(new ConsequenceAction(UUID.randomUUID(),
                                 Thread.currentThread().getStackTrace()[1].toString(), removeAxiomAction));
                     }
-                });
+                })
+                .build();
     }
 }

--- a/rules/src/main/java/dev/ikm/komet/rules/evrete/EvreteRulesService.java
+++ b/rules/src/main/java/dev/ikm/komet/rules/evrete/EvreteRulesService.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 public class EvreteRulesService implements RuleService {
@@ -47,24 +48,30 @@ public class EvreteRulesService implements RuleService {
 
     private static final Logger LOG = LoggerFactory.getLogger(EvreteRulesService.class);
 
-    private Configuration conf = new Configuration();
     private KnowledgeService service;
 
     private Knowledge knowledge;
 
     public EvreteRulesService() throws IOException {
+        Configuration conf = new Configuration();
+        conf.set(Constants.PROP_EXTEND_RULE_CLASSES, "false");
 
         for (Map.Entry<Object, Object> confEntry: conf.entrySet()) {
             LOG.info(confEntry.toString());
         }
 
-        this.service = new KnowledgeService(this.conf);
-        this.knowledge = service.newKnowledge(Constants.PROVIDER_JAVA_CLASS,
-                ComponentFocusRules.class,
-                NewConceptRules.class,
-                AxiomFocusedRules.class,
-                NewPatternRules.class
-        );
+        this.service = new KnowledgeService(conf);
+
+        this.knowledge = service.newKnowledge()
+                .importRules(
+                        Constants.PROVIDER_JAVA_CLASS,
+                        List.of(
+                                ComponentFocusRules.class,
+                                NewConceptRules.class,
+                                AxiomFocusedRules.class,
+                                NewPatternRules.class
+                        )
+                );
         LOG.info("Constructed EvreteRulesService");
     }
 

--- a/rules/src/main/java/dev/ikm/komet/rules/evrete/EvreteRulesService.java
+++ b/rules/src/main/java/dev/ikm/komet/rules/evrete/EvreteRulesService.java
@@ -50,21 +50,21 @@ public class EvreteRulesService implements RuleService {
 
     private static final Logger LOG = LoggerFactory.getLogger(EvreteRulesService.class);
 
-    private KnowledgeService service;
-
-    private Knowledge knowledge;
+    private final Knowledge knowledge;
 
     public EvreteRulesService() throws IOException {
         Instant t0 = Instant.now();
         Configuration conf = new Configuration();
-        // This will fast fail the engine in case of a literal condition
+
+        // Literal data requires the Java compiler and significantly increases build time.
+        // Setting this option will fast-fail the engine in case of a literal condition/action.
         conf.set(Configuration.DISABLE_LITERAL_DATA, "true");
 
         for (Map.Entry<Object, Object> confEntry: conf.entrySet()) {
             LOG.info(confEntry.toString());
         }
 
-        this.service = new KnowledgeService(conf);
+        KnowledgeService service = new KnowledgeService(conf);
 
         this.knowledge = service.newKnowledge()
                 .importRules(

--- a/rules/src/main/java/dev/ikm/komet/rules/evrete/EvreteRulesService.java
+++ b/rules/src/main/java/dev/ikm/komet/rules/evrete/EvreteRulesService.java
@@ -38,6 +38,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -53,8 +55,10 @@ public class EvreteRulesService implements RuleService {
     private Knowledge knowledge;
 
     public EvreteRulesService() throws IOException {
+        Instant t0 = Instant.now();
         Configuration conf = new Configuration();
-        conf.set(Constants.PROP_EXTEND_RULE_CLASSES, "false");
+        // This will fast fail the engine in case of a literal condition
+        conf.set(Configuration.DISABLE_LITERAL_DATA, "true");
 
         for (Map.Entry<Object, Object> confEntry: conf.entrySet()) {
             LOG.info(confEntry.toString());
@@ -72,7 +76,11 @@ public class EvreteRulesService implements RuleService {
                                 NewPatternRules.class
                         )
                 );
-        LOG.info("Constructed EvreteRulesService");
+        Instant t1 = Instant.now();
+
+        // Log the timing. With literal conditions disabled, the cold start time
+        // is expected to be in the range of tens of milliseconds.
+        LOG.info("Constructed EvreteRulesService, duration: {}ms", Duration.between(t0, t1).toMillis());
     }
 
     @Override


### PR DESCRIPTION
This request converts Evrete literal rule conditions into method predicates, eliminates the need for the Java compiler, and solves the "pencil problem" - the high cold start time of the rule engine.

With the current count of rules, the new build time is around **50ms**.
Previous timings (on my Mac):
Versions 4.x.x: **~600ms**
Versions 3.x.x: **~2500ms**
