### PR TITLE
Bugfix/JPRO-18 Incorrect Data Source on App Startup

### DIFF
--- a/application/src/main/java/dev/ikm/komet/app/SelectDataSourceController.java
+++ b/application/src/main/java/dev/ikm/komet/app/SelectDataSourceController.java
@@ -109,8 +109,13 @@ public class SelectDataSourceController {
 
         propertySheet.setPropertyEditorFactory(new KometPropertyEditorFactory(null));
 
-        Platform.runLater(() ->
-                dataSourceChoiceBox.getSelectionModel().select(controllerOptions.get(1)));
+        // Set default data service
+        controllerOptions.stream()
+                .filter(dataServiceController -> "Open SpinedArrayStore".equals(dataServiceController.controllerName()))
+                .findFirst()
+                .ifPresentOrElse(dataSourceChoiceBox.getSelectionModel()::select,
+                        // If default data service is not found, select the first one on the choice box.
+                        dataSourceChoiceBox.getSelectionModel()::selectFirst);
     }
 
     void dataSourceChanged(ObservableValue<? extends DataServiceController<?>> observable,


### PR DESCRIPTION
The new implementation allows for different data services to be added or reordered in the `controllerOptions` list without breaking the default selection logic. It also ensures that the choice box will have a selected item even if the preferred default option is unavailable.