### PR TITLE
Feature/iia 898 spike dynamic membership pattern

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/model/DataModelHelper.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/model/DataModelHelper.java
@@ -18,18 +18,36 @@ package dev.ikm.komet.kview.mvvm.model;
 import dev.ikm.komet.framework.view.ViewProperties;
 import dev.ikm.tinkar.common.id.IntIdSet;
 import dev.ikm.tinkar.common.id.PublicId;
+import dev.ikm.tinkar.common.id.PublicIds;
 import dev.ikm.tinkar.common.service.PrimitiveData;
+import dev.ikm.tinkar.common.service.TinkExecutor;
 import dev.ikm.tinkar.coordinate.Calculators;
+import dev.ikm.tinkar.coordinate.edit.EditCoordinate;
+import dev.ikm.tinkar.coordinate.edit.EditCoordinateRecord;
+import dev.ikm.tinkar.coordinate.stamp.calculator.Latest;
+import dev.ikm.tinkar.coordinate.view.ViewCoordinateRecord;
+import dev.ikm.tinkar.coordinate.view.calculator.ViewCalculator;
 import dev.ikm.tinkar.entity.ConceptEntity;
 import dev.ikm.tinkar.entity.Entity;
 import dev.ikm.tinkar.entity.EntityService;
+import dev.ikm.tinkar.entity.EntityVersion;
 import dev.ikm.tinkar.entity.PatternEntityVersion;
-import dev.ikm.tinkar.terms.EntityProxy;
+import dev.ikm.tinkar.entity.RecordListBuilder;
+import dev.ikm.tinkar.entity.SemanticRecord;
+import dev.ikm.tinkar.entity.SemanticVersionRecord;
+import dev.ikm.tinkar.entity.StampEntity;
+import dev.ikm.tinkar.entity.transaction.CommitTransactionTask;
+import dev.ikm.tinkar.entity.transaction.Transaction;
+import dev.ikm.tinkar.terms.EntityFacade;
+import dev.ikm.tinkar.terms.State;
 import dev.ikm.tinkar.terms.TinkarTerm;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static dev.ikm.tinkar.terms.TinkarTerm.*;
@@ -95,5 +113,94 @@ public class DataModelHelper {
             }
         });
         return membershipPatternList;
+    }
+
+    public static boolean isInMembershipPattern(int conceptNid, int patternNid) {
+        int[] semanticCount = PrimitiveData.get().semanticNidsForComponentOfPattern(conceptNid, patternNid);
+        // if the semantic count is empty then it is not a member of that pattern
+        return semanticCount.length > 0;
+    }
+
+    public static void addToMembershipPattern(EntityFacade concept, EntityFacade pattern, ViewCalculator viewCalculator) {
+        EditCoordinate editCoordinate = viewCalculator.viewCoordinateRecord().editCoordinate();
+        int[] semanticNidsForComponent = PrimitiveData.get().semanticNidsForComponentOfPattern(concept.nid(), pattern.nid());
+        if (semanticNidsForComponent.length == 0) {
+            // case 1: never a member
+            createSemantic(concept, pattern, editCoordinate.toEditCoordinateRecord(), viewCalculator);
+        } else {
+            // a member, need to change to inactive.
+            updateSemantic(pattern, semanticNidsForComponent[0], editCoordinate.toEditCoordinateRecord(), viewCalculator);
+        }
+    }
+
+    public static void removeFromMembershipPattern(EntityFacade concept, EntityFacade pattern, ViewCalculator viewCalculator) {
+        EditCoordinate editCoordinate = viewCalculator.viewCoordinateRecord().editCoordinate();
+        int[] semanticNidsForComponent = PrimitiveData.get().semanticNidsForComponentOfPattern(concept.nid(), pattern.nid());
+        if (semanticNidsForComponent.length == 0) {
+            // case 1: never a member
+            throw new IllegalStateException("Asking to retire element that was never a member...");
+        } else {
+            updateSemantic(pattern, semanticNidsForComponent[0], editCoordinate.toEditCoordinateRecord(), viewCalculator);
+        }
+    }
+
+    private static SemanticRecord createSemantic(EntityFacade concept, EntityFacade pattern, EditCoordinateRecord editCoordinateRecord, ViewCalculator viewCalculator) {
+        PublicId newSemanticId = PublicIds.singleSemanticId(pattern.publicId(), concept.publicId());
+        RecordListBuilder versionListBuilder = RecordListBuilder.make();
+        //FIXME will casting to PatternFacade work here??? or will pattern.toProxy() work???
+        SemanticRecord newSemantic = SemanticRecord.makeNew(newSemanticId, pattern.toProxy(), concept.nid(), versionListBuilder);
+        Transaction transaction = Transaction.make();
+        ViewCoordinateRecord viewRecord = viewCalculator.viewCoordinateRecord();
+
+        Latest<PatternEntityVersion> latestPatternVersion = viewCalculator.latestPatternEntityVersion(pattern.toProxy());
+        latestPatternVersion.ifPresentOrElse(patternEntityVersion -> {
+            StampEntity stampEntity = transaction.getStamp(State.ACTIVE, Long.MAX_VALUE, editCoordinateRecord.getAuthorNidForChanges(),
+                    patternEntityVersion.moduleNid(), viewRecord.stampCoordinate().pathNidForFilter());
+            SemanticVersionRecord newSemanticVersion = new SemanticVersionRecord(newSemantic, stampEntity.nid(), Lists.immutable.empty());
+
+            versionListBuilder.add(newSemanticVersion).build();
+            transaction.addComponent(newSemantic);
+            Entity.provider().putEntity(newSemantic);
+        }, () -> {
+            throw new IllegalStateException("No latest pattern version for: " + Entity.getFast(pattern));
+        });
+        CommitTransactionTask commitTransactionTask = new CommitTransactionTask(transaction);
+        TinkExecutor.threadPool().submit(commitTransactionTask);
+        return newSemantic;
+    }
+
+    private static void updateSemantic(EntityFacade pattern, int semanticNid, EditCoordinateRecord editCoordinateRecord, ViewCalculator viewCalculator) {
+        SemanticRecord semanticEntity = Entity.getFast(semanticNid);
+        Transaction transaction = Transaction.make();
+        ViewCoordinateRecord viewRecord = viewCalculator.viewCoordinateRecord();
+
+        Latest<PatternEntityVersion> latestPatternVersion = viewCalculator.latestPatternEntityVersion(pattern.toProxy());
+        latestPatternVersion.ifPresentOrElse(patternEntityVersion -> {
+            StampEntity stampEntity = transaction.getStamp(State.ACTIVE, Long.MAX_VALUE, editCoordinateRecord.getAuthorNidForChanges(),
+                    patternEntityVersion.moduleNid(), viewRecord.stampCoordinate().pathNidForFilter());
+            SemanticVersionRecord newSemanticVersion = new SemanticVersionRecord(semanticEntity, stampEntity.nid(), Lists.immutable.empty());
+            SemanticRecord analogue = semanticEntity.with(newSemanticVersion).build();
+            transaction.addComponent(analogue);
+            Entity.provider().putEntity(analogue);
+        }, () -> {
+            throw new IllegalStateException("No latest pattern version for: " + Entity.getFast(pattern));
+        });
+        CommitTransactionTask commitTransactionTask = new CommitTransactionTask(transaction);
+        TinkExecutor.threadPool().submit(commitTransactionTask);
+    }
+
+    public static boolean isComponentActive(EntityFacade entityFacade) {
+        return getLastEntityVersion(entityFacade).active();
+    }
+
+    public static boolean isComponentInActive(EntityFacade entityFacade) {
+        return getLastEntityVersion(entityFacade).inactive();
+    }
+
+    public static EntityVersion getLastEntityVersion(EntityFacade entityFacade) {
+        //FIXME will this work? EntityFacade and I want an EntityVersion to check active/inactive
+        Entity entity = EntityService.get().getEntityFast(entityFacade);
+        ImmutableList versions = entity.versions();
+        return  (EntityVersion) versions.getLastOptional().get();
     }
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/model/DataModelHelper.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/model/DataModelHelper.java
@@ -28,6 +28,8 @@ import dev.ikm.tinkar.coordinate.stamp.calculator.Latest;
 import dev.ikm.tinkar.coordinate.view.ViewCoordinateRecord;
 import dev.ikm.tinkar.coordinate.view.calculator.ViewCalculator;
 import dev.ikm.tinkar.entity.ConceptEntity;
+import dev.ikm.tinkar.entity.ConceptRecord;
+import dev.ikm.tinkar.entity.ConceptVersionRecord;
 import dev.ikm.tinkar.entity.Entity;
 import dev.ikm.tinkar.entity.EntityService;
 import dev.ikm.tinkar.entity.EntityVersion;

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/model/DataModelHelper.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/model/DataModelHelper.java
@@ -18,10 +18,17 @@ package dev.ikm.komet.kview.mvvm.model;
 import dev.ikm.komet.framework.view.ViewProperties;
 import dev.ikm.tinkar.common.id.IntIdSet;
 import dev.ikm.tinkar.common.id.PublicId;
+import dev.ikm.tinkar.common.service.PrimitiveData;
+import dev.ikm.tinkar.coordinate.Calculators;
 import dev.ikm.tinkar.entity.ConceptEntity;
 import dev.ikm.tinkar.entity.Entity;
 import dev.ikm.tinkar.entity.EntityService;
+import dev.ikm.tinkar.entity.PatternEntityVersion;
+import dev.ikm.tinkar.terms.EntityProxy;
+import dev.ikm.tinkar.terms.TinkarTerm;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -76,5 +83,17 @@ public class DataModelHelper {
                 .mapToObj(decendentNid -> (ConceptEntity) Entity.getFast(decendentNid))
                 .collect(Collectors.toSet());
         return allDecendents;
+    }
+
+    public static List<PatternEntityVersion> getMembershipPatterns() {
+        List<PatternEntityVersion> membershipPatternList = new ArrayList<>();
+        PrimitiveData.get().forEachPatternNid((patternNid) -> {
+            PatternEntityVersion patternEntityVersion = (PatternEntityVersion)
+                    Calculators.View.Default().stampCalculator().latest(patternNid).get();
+            if (patternEntityVersion.semanticPurposeNid() == TinkarTerm.MEMBERSHIP_SEMANTIC.nid()) {
+                membershipPatternList.add(patternEntityVersion);
+            }
+        });
+        return membershipPatternList;
     }
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/model/DataModelHelper.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/model/DataModelHelper.java
@@ -190,19 +190,4 @@ public class DataModelHelper {
         CommitTransactionTask commitTransactionTask = new CommitTransactionTask(transaction);
         TinkExecutor.threadPool().submit(commitTransactionTask);
     }
-
-    public static boolean isComponentActive(EntityFacade entityFacade) {
-        return getLastEntityVersion(entityFacade).active();
-    }
-
-    public static boolean isComponentInActive(EntityFacade entityFacade) {
-        return getLastEntityVersion(entityFacade).inactive();
-    }
-
-    public static EntityVersion getLastEntityVersion(EntityFacade entityFacade) {
-        //FIXME will this work? EntityFacade and I want an EntityVersion to check active/inactive
-        Entity entity = EntityService.get().getEntityFast(entityFacade);
-        ImmutableList versions = entity.versions();
-        return  (EntityVersion) versions.getLastOptional().get();
-    }
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/model/DataModelHelper.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/model/DataModelHelper.java
@@ -124,9 +124,9 @@ public class DataModelHelper {
         }
     }
 
-    public static void removeFromMembershipPattern(EntityFacade concept, EntityFacade pattern, ViewCalculator viewCalculator) {
+    public static void removeFromMembershipPattern(int conceptNid, EntityFacade pattern, ViewCalculator viewCalculator) {
         EditCoordinate editCoordinate = viewCalculator.viewCoordinateRecord().editCoordinate();
-        int[] semanticNidsForComponent = PrimitiveData.get().semanticNidsForComponentOfPattern(concept.nid(), pattern.nid());
+        int[] semanticNidsForComponent = PrimitiveData.get().semanticNidsForComponentOfPattern(conceptNid, pattern.nid());
         if (semanticNidsForComponent.length == 0) {
             // case 1: never a member
             throw new IllegalStateException("Asking to retire element that was never a member...");

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
@@ -341,14 +341,15 @@ public class DetailsController  {
                     menuItem.setOnAction(evt -> addToMembershipPattern(currentConceptFacade, pattern.entity(), viewCalculator));
                     removedMenuItems.add(menuItem);
                 }
-                addPlusIconToMenuItem(menuItem);
             }
             if (!addedMenuItems.isEmpty()) {
                 // sort the added (able to be removed)
                 addedMenuItems.sort(patternMenuComparator);
                 membershipContextMenu.getItems().addAll(addedMenuItems);
                 // then add a menu line separator
-                membershipContextMenu.getItems().add(new SeparatorMenuItem());
+                if (!removedMenuItems.isEmpty()) {
+                    membershipContextMenu.getItems().add(new SeparatorMenuItem());
+                }
             }
             // then add the sorted removed (that can be added)
             removedMenuItems.sort(patternMenuComparator);
@@ -469,15 +470,6 @@ public class DetailsController  {
         changeSetTypeEventSubscriber = evt -> updateAxioms();
         eventBus.subscribe(RULES_TOPIC, AxiomChangeEvent.class, changeSetTypeEventSubscriber);
 
-    }
-
-    private void addPlusIconToMenuItem(MenuItem menuItem) {
-        //TODO we anticipate creating a "minus" or "remove" icon in the future
-        Region region = new Region();
-        region.setPrefWidth(20);
-        region.setPrefHeight(20);
-        region.getStyleClass().add("concept-edit-description-menu-icon");
-        menuItem.setGraphic(region);
     }
 
     public ViewProperties getViewProperties() {

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
@@ -328,28 +328,28 @@ public class DetailsController  {
             ContextMenu membershipContextMenu = new ContextMenu();
             membershipContextMenu.getStyleClass().add("kview-context-menu");
 
-            List<MenuItem> activateMenuItems = new ArrayList<>();
-            List<MenuItem> inActivateMenuItems = new ArrayList<>();
+            List<MenuItem> addedMenuItems = new ArrayList<>();
+            List<MenuItem> removedMenuItems = new ArrayList<>();
             for (PatternEntityVersion pattern : patterns) {
                 MenuItem menuItem = new MenuItem();
                 if (isInMembershipPattern(currentConceptFacade.nid(), pattern.nid())) {
                     menuItem.setText("Remove from " + pattern.entity().description());
                     menuItem.setOnAction(evt -> removeFromMembershipPattern(currentConceptFacade, pattern.entity(), viewCalculator));
-                    activateMenuItems.add(menuItem);
+                    addedMenuItems.add(menuItem);
                 } else {
                     menuItem.setText("Add to " + pattern.entity().description());
                     menuItem.setOnAction(evt -> addToMembershipPattern(currentConceptFacade, pattern.entity(), viewCalculator));
-                    inActivateMenuItems.add(menuItem);
+                    removedMenuItems.add(menuItem);
                 }
                 addPlusIconToMenuItem(menuItem);
             }
-            // sort the active (able to be in-activated)
+            // sort the added (able to be removed)
             Comparator<MenuItem> patternMenuComparator = (m1, m2) -> m1.getText().compareToIgnoreCase(m2.getText());
-            membershipContextMenu.getItems().addAll(activateMenuItems.stream().sorted(patternMenuComparator).collect(Collectors.toList()));
+            membershipContextMenu.getItems().addAll(addedMenuItems.stream().sorted(patternMenuComparator).collect(Collectors.toList()));
             // then add a menu line separator
             membershipContextMenu.getItems().add(new SeparatorMenuItem());
-            // then add the sorted inactive (that can be activated)
-            membershipContextMenu.getItems().addAll(inActivateMenuItems.stream().sorted(patternMenuComparator).collect(Collectors.toList()));
+            // then add the sorted removed (that can be added)
+            membershipContextMenu.getItems().addAll(removedMenuItems.stream().sorted(patternMenuComparator).collect(Collectors.toList()));
 
             membershipContextMenu.show(identiconImageView, contextMenuEvent.getScreenX(),
                     contextMenuEvent.getSceneY() + identiconImageView.getFitHeight());

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
@@ -15,6 +15,7 @@
  */
 package dev.ikm.komet.kview.mvvm.view.details;
 
+import dev.ikm.komet.kview.mvvm.model.DataModelHelper;
 import dev.ikm.komet.kview.mvvm.view.stamp.StampEditController;
 import dev.ikm.komet.kview.fxutils.MenuHelper;
 import dev.ikm.komet.kview.events.*;
@@ -64,7 +65,9 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static dev.ikm.komet.kview.fxutils.MenuHelper.fireContextMenuEvent;
 import static dev.ikm.komet.kview.fxutils.SlideOutTrayHelper.slideIn;
@@ -254,6 +257,30 @@ public class DetailsController  {
 
     @FXML
     public void initialize() {
+        AtomicInteger count = new AtomicInteger();
+        identiconImageView.setOnContextMenuRequested(contextMenuEvent -> {
+            // query all available memberships (semantics having the purpose as 'membership', and no fields)
+            // query current concept's membership semantic records.
+            // build menuItems according to 'add' or 'remove' , style to look like figma designs style classes.
+            // show offset to the right of the identicon
+            EntityFacade currentConcept = conceptViewModel.getPropertyValue(CURRENT_ENTITY);
+            List<PatternEntityVersion> patterns = DataModelHelper.getMembershipPatterns();
+            ContextMenu membershipContextMenu = new ContextMenu();
+            membershipContextMenu.getStyleClass().add("kview-context-menu");
+            membershipContextMenu.getItems().addAll(patterns.stream().map(pattern -> {
+                // TODO need a check to see if currentConcept is a member of pattern
+                MenuItem menuItem = new MenuItem(pattern.entity().description());
+                Region region = new Region();
+                region.setPrefWidth(20);
+                region.setPrefHeight(20);
+                region.getStyleClass().add("concept-edit-description-menu-icon");
+                menuItem.setGraphic(region);
+                return menuItem;
+            }).collect(Collectors.toList()));
+            membershipContextMenu.show(identiconImageView, contextMenuEvent.getScreenX(),
+                    contextMenuEvent.getSceneY() + identiconImageView.getFitHeight());
+        });
+
         Tooltip.install(identifierText, identifierTooltip);
         Tooltip.install(lastUpdatedText, authorTooltip);
         Tooltip.install(fqnTitleText, conceptNameTooltip);

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
@@ -344,11 +344,13 @@ public class DetailsController  {
             }
             // sort the added (able to be removed)
             Comparator<MenuItem> patternMenuComparator = (m1, m2) -> m1.getText().compareToIgnoreCase(m2.getText());
-            membershipContextMenu.getItems().addAll(addedMenuItems.stream().sorted(patternMenuComparator).collect(Collectors.toList()));
+            addedMenuItems.sort(patternMenuComparator);
+            membershipContextMenu.getItems().addAll(addedMenuItems);
             // then add a menu line separator
             membershipContextMenu.getItems().add(new SeparatorMenuItem());
             // then add the sorted removed (that can be added)
-            membershipContextMenu.getItems().addAll(removedMenuItems.stream().sorted(patternMenuComparator).collect(Collectors.toList()));
+            removedMenuItems.sort(patternMenuComparator);
+            membershipContextMenu.getItems().addAll(removedMenuItems);
 
             membershipContextMenu.show(identiconImageView, contextMenuEvent.getScreenX(),
                     contextMenuEvent.getSceneY() + identiconImageView.getFitHeight());

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
@@ -316,7 +316,6 @@ public class DetailsController  {
 
     @FXML
     public void initialize() {
-        AtomicInteger count = new AtomicInteger();
         identiconImageView.setOnContextMenuRequested(contextMenuEvent -> {
             // query all available memberships (semantics having the purpose as 'membership', and no fields)
             // query current concept's membership semantic records.

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
@@ -15,13 +15,34 @@
  */
 package dev.ikm.komet.kview.mvvm.view.details;
 
-import dev.ikm.komet.kview.mvvm.model.DataModelHelper;
-import dev.ikm.komet.kview.mvvm.view.stamp.StampEditController;
-import dev.ikm.komet.kview.fxutils.MenuHelper;
-import dev.ikm.komet.kview.events.*;
-import dev.ikm.komet.kview.mvvm.model.DescrName;
-import dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel;
-import dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel;
+import static dev.ikm.komet.framework.events.FrameworkTopics.RULES_TOPIC;
+import static dev.ikm.komet.kview.fxutils.MenuHelper.fireContextMenuEvent;
+import static dev.ikm.komet.kview.fxutils.SlideOutTrayHelper.slideIn;
+import static dev.ikm.komet.kview.fxutils.SlideOutTrayHelper.slideOut;
+import static dev.ikm.komet.kview.fxutils.ViewportHelper.clipChildren;
+import static dev.ikm.komet.kview.mvvm.model.DataModelHelper.addToMembershipPattern;
+import static dev.ikm.komet.kview.mvvm.model.DataModelHelper.getMembershipPatterns;
+import static dev.ikm.komet.kview.mvvm.model.DataModelHelper.isInMembershipPattern;
+import static dev.ikm.komet.kview.mvvm.model.DataModelHelper.removeFromMembershipPattern;
+import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.AXIOM;
+import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.CONCEPT_STAMP_VIEW_MODEL;
+import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.CREATE;
+import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.CURRENT_ENTITY;
+import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.EDIT;
+import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.FULLY_QUALIFIED_NAME;
+import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.OTHER_NAMES;
+import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.MODE;
+import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.MODULES_PROPERTY;
+import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.MODULE_PROPERTY;
+import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.PATHS_PROPERTY;
+import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.PATH_PROPERTY;
+import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.STATUS_PROPERTY;
+import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.TIME_PROPERTY;
+import static dev.ikm.tinkar.terms.TinkarTerm.DEFINITION_DESCRIPTION_TYPE;
+import static dev.ikm.tinkar.terms.TinkarTerm.DESCRIPTION_CASE_SIGNIFICANCE;
+import static dev.ikm.tinkar.terms.TinkarTerm.FULLY_QUALIFIED_NAME_DESCRIPTION_TYPE;
+import static dev.ikm.tinkar.terms.TinkarTerm.LANGUAGE_CONCEPT_NID_FOR_DESCRIPTION;
+import static dev.ikm.tinkar.terms.TinkarTerm.REGULAR_NAME_DESCRIPTION_TYPE;
 import dev.ikm.komet.framework.Identicon;
 import dev.ikm.komet.framework.events.AxiomChangeEvent;
 import dev.ikm.komet.framework.events.EvtBus;
@@ -31,12 +52,38 @@ import dev.ikm.komet.framework.observable.ObservableField;
 import dev.ikm.komet.framework.propsheet.KometPropertySheet;
 import dev.ikm.komet.framework.propsheet.SheetItem;
 import dev.ikm.komet.framework.view.ViewProperties;
+import dev.ikm.komet.kview.events.AddFullyQualifiedNameEvent;
+import dev.ikm.komet.kview.events.AddOtherNameToConceptEvent;
+import dev.ikm.komet.kview.events.ClosePropertiesPanelEvent;
+import dev.ikm.komet.kview.events.CreateConceptEvent;
+import dev.ikm.komet.kview.events.EditConceptEvent;
+import dev.ikm.komet.kview.events.EditConceptFullyQualifiedNameEvent;
+import dev.ikm.komet.kview.events.EditOtherNameConceptEvent;
+import dev.ikm.komet.kview.events.OpenPropertiesPanelEvent;
+import dev.ikm.komet.kview.fxutils.MenuHelper;
+import dev.ikm.komet.kview.mvvm.model.DescrName;
+import dev.ikm.komet.kview.mvvm.view.stamp.StampEditController;
+import dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel;
+import dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel;
 import dev.ikm.komet.preferences.KometPreferences;
 import dev.ikm.tinkar.common.id.PublicId;
 import dev.ikm.tinkar.coordinate.stamp.calculator.Latest;
 import dev.ikm.tinkar.coordinate.view.calculator.ViewCalculator;
-import dev.ikm.tinkar.entity.*;
-import dev.ikm.tinkar.terms.*;
+import dev.ikm.tinkar.entity.ConceptEntity;
+import dev.ikm.tinkar.entity.EntityService;
+import dev.ikm.tinkar.entity.EntityVersion;
+import dev.ikm.tinkar.entity.FieldDefinitionForEntity;
+import dev.ikm.tinkar.entity.FieldDefinitionRecord;
+import dev.ikm.tinkar.entity.FieldRecord;
+import dev.ikm.tinkar.entity.PatternEntity;
+import dev.ikm.tinkar.entity.PatternEntityVersion;
+import dev.ikm.tinkar.entity.SemanticEntityVersion;
+import dev.ikm.tinkar.entity.StampEntity;
+import dev.ikm.tinkar.terms.ConceptFacade;
+import dev.ikm.tinkar.terms.EntityFacade;
+import dev.ikm.tinkar.terms.EntityProxy;
+import dev.ikm.tinkar.terms.State;
+import dev.ikm.tinkar.terms.TinkarTerm;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
@@ -45,13 +92,32 @@ import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.geometry.Side;
 import javafx.scene.Node;
-import javafx.scene.control.*;
+import javafx.scene.control.Button;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.SeparatorMenuItem;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TitledPane;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.*;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
-import org.carlfx.cognitive.loader.*;
+import org.carlfx.cognitive.loader.Config;
+import org.carlfx.cognitive.loader.FXMLMvvmLoader;
+import org.carlfx.cognitive.loader.InjectViewModel;
+import org.carlfx.cognitive.loader.JFXNode;
+import org.carlfx.cognitive.loader.NamedVm;
 import org.carlfx.cognitive.viewmodel.ValidationViewModel;
 import org.carlfx.cognitive.viewmodel.ViewModel;
 import org.controlsfx.control.PopOver;
@@ -64,22 +130,15 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
-import static dev.ikm.komet.kview.fxutils.MenuHelper.fireContextMenuEvent;
-import static dev.ikm.komet.kview.fxutils.SlideOutTrayHelper.slideIn;
-import static dev.ikm.komet.kview.fxutils.SlideOutTrayHelper.slideOut;
-import static dev.ikm.komet.kview.fxutils.ViewportHelper.clipChildren;
-import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.CREATE;
-import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.EDIT;
-import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.*;
-import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.MODE;
-import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.*;
-import static dev.ikm.komet.framework.events.FrameworkTopics.RULES_TOPIC;
-import static dev.ikm.tinkar.terms.TinkarTerm.*;
 
 public class DetailsController  {
     private static final Logger LOG = LoggerFactory.getLogger(DetailsController.class);
@@ -265,34 +324,33 @@ public class DetailsController  {
             // show offset to the right of the identicon
             ViewCalculator viewCalculator = viewProperties.calculator();
             EntityFacade currentConceptFacade = conceptViewModel.getPropertyValue(CURRENT_ENTITY);
-            List<PatternEntityVersion> patterns = DataModelHelper.getMembershipPatterns();
+            List<PatternEntityVersion> patterns = getMembershipPatterns();
             ContextMenu membershipContextMenu = new ContextMenu();
             membershipContextMenu.getStyleClass().add("kview-context-menu");
-            membershipContextMenu.getItems().addAll(patterns.stream().map(pattern -> {
-                // TODO need a check to see if currentConcept is a member of pattern
-                boolean isMember = DataModelHelper.isInMembershipPattern(currentConceptFacade.nid(), pattern.nid());
+
+            List<MenuItem> activateMenuItems = new ArrayList<>();
+            List<MenuItem> inActivateMenuItems = new ArrayList<>();
+            for (PatternEntityVersion pattern : patterns) {
                 MenuItem menuItem = new MenuItem();
-                if (isMember) {
+                if (isInMembershipPattern(currentConceptFacade.nid(), pattern.nid())) {
                     menuItem.setText("Remove from " + pattern.entity().description());
-                    menuItem.setOnAction(evt -> DataModelHelper.removeFromMembershipPattern(currentConceptFacade, pattern.entity(), viewCalculator));
+                    menuItem.setOnAction(evt -> removeFromMembershipPattern(currentConceptFacade, pattern.entity(), viewCalculator));
+                    activateMenuItems.add(menuItem);
                 } else {
                     menuItem.setText("Add to " + pattern.entity().description());
-                    menuItem.setOnAction(evt -> DataModelHelper.addToMembershipPattern(currentConceptFacade, pattern.entity(), viewCalculator));
+                    menuItem.setOnAction(evt -> addToMembershipPattern(currentConceptFacade, pattern.entity(), viewCalculator));
+                    inActivateMenuItems.add(menuItem);
                 }
                 addPlusIconToMenuItem(menuItem);
-                return menuItem;
-            }).collect(Collectors.toList()));
-            if (DataModelHelper.isComponentActive(currentConceptFacade)) {
-                MenuItem inActivateMenuItem = new MenuItem("Inactivate component");
-                addPlusIconToMenuItem(inActivateMenuItem);
-                membershipContextMenu.getItems().add(inActivateMenuItem);
-                //TODO inactivate
-            } else if (DataModelHelper.isComponentInActive(currentConceptFacade)) {
-                MenuItem activateMenuItem = new MenuItem("Activate component");
-                addPlusIconToMenuItem(activateMenuItem);
-                membershipContextMenu.getItems().add(activateMenuItem);
-                //TODO activate
             }
+            // sort the active (able to be in-activated)
+            Comparator<MenuItem> patternMenuComparator = (m1, m2) -> m1.getText().compareToIgnoreCase(m2.getText());
+            membershipContextMenu.getItems().addAll(activateMenuItems.stream().sorted(patternMenuComparator).collect(Collectors.toList()));
+            // then add a menu line separator
+            membershipContextMenu.getItems().add(new SeparatorMenuItem());
+            // then add the sorted inactive (that can be activated)
+            membershipContextMenu.getItems().addAll(inActivateMenuItems.stream().sorted(patternMenuComparator).collect(Collectors.toList()));
+
             membershipContextMenu.show(identiconImageView, contextMenuEvent.getScreenX(),
                     contextMenuEvent.getSceneY() + identiconImageView.getFitHeight());
         });

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
@@ -327,13 +327,14 @@ public class DetailsController  {
             ContextMenu membershipContextMenu = new ContextMenu();
             membershipContextMenu.getStyleClass().add("kview-context-menu");
 
+            Comparator<MenuItem> patternMenuComparator = (m1, m2) -> m1.getText().compareToIgnoreCase(m2.getText());
             List<MenuItem> addedMenuItems = new ArrayList<>();
             List<MenuItem> removedMenuItems = new ArrayList<>();
             for (PatternEntityVersion pattern : patterns) {
                 MenuItem menuItem = new MenuItem();
                 if (isInMembershipPattern(currentConceptFacade.nid(), pattern.nid())) {
                     menuItem.setText("Remove from " + pattern.entity().description());
-                    menuItem.setOnAction(evt -> removeFromMembershipPattern(currentConceptFacade, pattern.entity(), viewCalculator));
+                    menuItem.setOnAction(evt -> removeFromMembershipPattern(currentConceptFacade.nid(), pattern.entity(), viewCalculator));
                     addedMenuItems.add(menuItem);
                 } else {
                     menuItem.setText("Add to " + pattern.entity().description());
@@ -342,12 +343,13 @@ public class DetailsController  {
                 }
                 addPlusIconToMenuItem(menuItem);
             }
-            // sort the added (able to be removed)
-            Comparator<MenuItem> patternMenuComparator = (m1, m2) -> m1.getText().compareToIgnoreCase(m2.getText());
-            addedMenuItems.sort(patternMenuComparator);
-            membershipContextMenu.getItems().addAll(addedMenuItems);
-            // then add a menu line separator
-            membershipContextMenu.getItems().add(new SeparatorMenuItem());
+            if (!addedMenuItems.isEmpty()) {
+                // sort the added (able to be removed)
+                addedMenuItems.sort(patternMenuComparator);
+                membershipContextMenu.getItems().addAll(addedMenuItems);
+                // then add a menu line separator
+                membershipContextMenu.getItems().add(new SeparatorMenuItem());
+            }
             // then add the sorted removed (that can be added)
             removedMenuItems.sort(patternMenuComparator);
             membershipContextMenu.getItems().addAll(removedMenuItems);
@@ -470,6 +472,7 @@ public class DetailsController  {
     }
 
     private void addPlusIconToMenuItem(MenuItem menuItem) {
+        //TODO we anticipate creating a "minus" or "remove" icon in the future
         Region region = new Region();
         region.setPrefWidth(20);
         region.setPrefHeight(20);

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/details/concept-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/details/concept-details.fxml
@@ -38,7 +38,7 @@
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
 
-<BorderPane fx:id="detailsOuterBorderPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="456.0" prefHeight="650.0" prefWidth="727.0" styleClass="concept-detail-pane" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
+<BorderPane fx:id="detailsOuterBorderPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="456.0" prefHeight="650.0" prefWidth="727.0" styleClass="concept-detail-pane" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
    <center>
       <BorderPane fx:id="detailsCenterBorderPane" prefHeight="600.0" prefWidth="762.0">
          <top>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/details/concept-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/details/concept-details.fxml
@@ -38,7 +38,7 @@
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
 
-<BorderPane fx:id="detailsOuterBorderPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="456.0" prefHeight="650.0" prefWidth="727.0" styleClass="concept-detail-pane" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+<BorderPane fx:id="detailsOuterBorderPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="456.0" prefHeight="650.0" prefWidth="727.0" styleClass="concept-detail-pane" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
    <center>
       <BorderPane fx:id="detailsCenterBorderPane" prefHeight="600.0" prefWidth="762.0">
          <top>


### PR DESCRIPTION
Feature/iia 898 spike dynamic membership pattern

When you open an existing concept in the Journal View and right click on its identicon you get a list of membership patterns that you can add or remove to and from.  This is querying the available membership patterns for a given concept.  So the list is data driven / not hard coded.

![image](https://github.com/user-attachments/assets/cf21e184-e779-4abe-8097-6f6debe7e0da)

![image](https://github.com/user-attachments/assets/f5ab2e08-982f-4bf0-8eb6-50d0be81397c)

