### PR TITLE
bugfix/IIA-923 removing date from user entered file name

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/export/ExportController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/export/ExportController.java
@@ -279,7 +279,7 @@ public class ExportController {
         }
         // if the user enters a name then use that name, e.g. test.json or test.zip
         // if the user does not enter a name, then default to komet-yyyyMMdd-HHmm.zip|.json
-        String initialFileName = exportName.getText().equals("")
+        String initialFileName = exportName.getText().isBlank()
                 ? "komet-%s".formatted(simpleDateFormat.format(new Date()))
                 : exportName.getText();
         if (exportOption.equalsIgnoreCase(CHANGE_SET)) {

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/export/ExportController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/export/ExportController.java
@@ -277,8 +277,11 @@ public class ExportController {
             fromDate = this.customFromEpochMillis == 0 ? transformStringInLocalDateTimeToEpochMillis(dateTimeFromLabel.getText()) : this.customFromEpochMillis;
             toDate = this.customToEpochMillis == 0 ? transformStringInLocalDateTimeToEpochMillis(dateTimeToLabel.getText()) : this.customToEpochMillis;
         }
-        String namePrefix = exportName.getText().equals("") ? "komet" : exportName.getText();
-        String initialFileName = "%s-%s".formatted(namePrefix, simpleDateFormat.format(new Date()));
+        // if the user enters a name then use that name, e.g. test.json or test.zip
+        // if the user does not enter a name, then default to komet-yyyyMMdd-HHmm.zip|.json
+        String initialFileName = exportName.getText().equals("")
+                ? "komet-%s".formatted(simpleDateFormat.format(new Date()))
+                : exportName.getText();
         if (exportOption.equalsIgnoreCase(CHANGE_SET)) {
             initialFileName += ".zip";
             fileChooser.setTitle("Export file name as");


### PR DESCRIPTION
We were using the user entered name with a date appended.  Now removing the date and taking the user entered name verbatim

![image](https://github.com/user-attachments/assets/6f19b33c-b76f-4d9b-ba5f-43f0fe742d82)

