### PR TITLE
Update JavaFX dependencies to version `21.0.4`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <maven.compiler.version>3.13.0</maven.compiler.version>
         <mockito.version>5.7.0</mockito.version>
         <nsmenufx.version>3.1.0</nsmenufx.version>
-        <openjfx.version>21</openjfx.version>
+        <openjfx.version>21.0.4</openjfx.version>
         <owlapi.groupId>dev.ikm.owlapi</owlapi.groupId>
         <owlapi.version>4.7.0</owlapi.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This update brings JavaFX dependencies to the current latest long-term support release, version 21.0.4, which includes several improvements and bug fixes. Notably, it addresses a critical bug affecting macOS 14 Sonoma, as detailed in [JDK-8319066](https://bugs.openjdk.org/browse/JDK-8319066).