### PR TITLE
IIA-925 Updated stamp view models to use enums as property names

### DIFF
--- a/application/src/test/java/dev/ikm/komet/app/test/ConceptViewModelTest.java
+++ b/application/src/test/java/dev/ikm/komet/app/test/ConceptViewModelTest.java
@@ -21,6 +21,7 @@ import dev.ikm.komet.framework.view.ViewProperties;
 import dev.ikm.komet.framework.window.WindowSettings;
 import dev.ikm.komet.preferences.KometPreferences;
 import dev.ikm.komet.preferences.KometPreferencesImpl;
+import dev.ikm.tinkar.coordinate.stamp.StampFields;
 import dev.ikm.tinkar.terms.State;
 import org.carlfx.cognitive.viewmodel.ViewModel;
 
@@ -29,6 +30,9 @@ import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.CREATE;
 import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.MODE;
 import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.*;
 import static dev.ikm.komet.preferences.JournalWindowPreferences.MAIN_KOMET_WINDOW;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.PATH;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.TIME;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.STATUS;
 
 public class ConceptViewModelTest {
     public static void main(String[] args) {
@@ -44,10 +48,10 @@ public class ConceptViewModelTest {
 
         StampViewModel stampViewModel = new StampViewModel();
         stampViewModel
-                .setPropertyValue(STATUS_PROPERTY, State.ACTIVE)
-                .setPropertyValue(TIME_PROPERTY, System.currentTimeMillis())
-                .setPropertyValue(MODULE_PROPERTY, 0)
-                .setPropertyValue(PATH_PROPERTY, 0)
+                .setPropertyValue(STATUS, State.ACTIVE)
+                .setPropertyValue(TIME, System.currentTimeMillis())
+                .setPropertyValue(StampFields.MODULE, 0)
+                .setPropertyValue(PATH, 0)
                 .addProperty(MODULES_PROPERTY, stampViewModel.findAllModules(viewProperties), true)
                 .addProperty(PATHS_PROPERTY, stampViewModel.findAllPaths(viewProperties), true);
         log("--------------");

--- a/application/src/test/java/dev/ikm/komet/app/test/LidrViewModelTest.java
+++ b/application/src/test/java/dev/ikm/komet/app/test/LidrViewModelTest.java
@@ -46,6 +46,7 @@ import java.util.UUID;
 
 import static dev.ikm.komet.kview.lidr.mvvm.model.DataModelHelper.*;
 import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.*;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LidrViewModelTest {
@@ -172,11 +173,11 @@ public class LidrViewModelTest {
                 resultsConforms);
 
         StampViewModel stampViewModel = new StampViewModel();
-        stampViewModel.setPropertyValue(STATUS_PROPERTY, State.ACTIVE)
-                .setPropertyValue(AUTHOR_PROPERTY, TinkarTerm.USER)
-                .setPropertyValue(TIME_PROPERTY, System.currentTimeMillis())
-                .setPropertyValue(MODULE_PROPERTY, TinkarTerm.DEVELOPMENT_MODULE)
-                .setPropertyValue(PATH_PROPERTY, TinkarTerm.DEVELOPMENT_PATH);
+        stampViewModel.setPropertyValue(STATUS, State.ACTIVE)
+                .setPropertyValue(AUTHOR, TinkarTerm.USER)
+                .setPropertyValue(TIME, System.currentTimeMillis())
+                .setPropertyValue(MODULE, TinkarTerm.DEVELOPMENT_MODULE)
+                .setPropertyValue(PATH, TinkarTerm.DEVELOPMENT_PATH);
 
         PublicId lidrRecordPublicId = ViewModelHelper.addNewLidrRecord(lidrRecord, deviceId, stampViewModel);
         System.out.println("Created a LIDR record " + lidrRecordPublicId);

--- a/application/src/test/java/dev/ikm/komet/app/test/StampViewModelTest.java
+++ b/application/src/test/java/dev/ikm/komet/app/test/StampViewModelTest.java
@@ -25,6 +25,7 @@ import org.carlfx.cognitive.validator.ValidationMessage;
 
 import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.*;
 import static dev.ikm.komet.preferences.JournalWindowPreferences.MAIN_KOMET_WINDOW;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.*;
 
 public class StampViewModelTest {
     public static void main(String[] args) {
@@ -37,10 +38,10 @@ public class StampViewModelTest {
 
 
         StampViewModel stampViewModel = new StampViewModel();
-        stampViewModel.setPropertyValue(STATUS_PROPERTY, State.ACTIVE)
-                .setPropertyValue(TIME_PROPERTY, System.currentTimeMillis())
-                .setPropertyValue(MODULE_PROPERTY, 0)
-                .setPropertyValue(PATH_PROPERTY, 0)
+        stampViewModel.setPropertyValue(STATUS, State.ACTIVE)
+                .setPropertyValue(TIME, System.currentTimeMillis())
+                .setPropertyValue(MODULE, 0)
+                .setPropertyValue(PATH, 0)
                 .addProperty(MODULES_PROPERTY, stampViewModel.findAllModules(viewProperties), true)
                 .addProperty(PATHS_PROPERTY, stampViewModel.findAllPaths(viewProperties), true);
         log("--------------");

--- a/kview/src/main/java/dev/ikm/komet/kview/lidr/mvvm/view/details/LidrDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/lidr/mvvm/view/details/LidrDetailsController.java
@@ -91,6 +91,7 @@ import static dev.ikm.komet.kview.lidr.mvvm.viewmodel.ViewModelHelper.addNewLidr
 import static dev.ikm.komet.kview.lidr.mvvm.viewmodel.ViewModelHelper.toStampDetail;
 import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.MODE;
 import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.*;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.*;
 
 public class LidrDetailsController {
     private static final Logger LOG = LoggerFactory.getLogger(LidrDetailsController.class);
@@ -470,20 +471,20 @@ public class LidrDetailsController {
                 // add a new stamp view model to the concept view model
                 StampViewModel stampViewModel = new StampViewModel();
                 stampViewModel.setPropertyValue(MODE, EDIT)
-                        .setPropertyValue(STATUS_PROPERTY, stamp.state())
-                        .setPropertyValue(AUTHOR_PROPERTY, stamp.author())
-                        .setPropertyValue(MODULE_PROPERTY, stamp.module())
-                        .setPropertyValue(PATH_PROPERTY, stamp.path())
+                        .setPropertyValue(STATUS, stamp.state())
+                        .setPropertyValue(AUTHOR, stamp.author())
+                        .setPropertyValue(MODULE, stamp.module())
+                        .setPropertyValue(PATH, stamp.path())
                         .setPropertyValues(MODULES_PROPERTY, stampViewModel.findAllModules(getViewProperties()), true)
                         .setPropertyValues(PATHS_PROPERTY, stampViewModel.findAllPaths(getViewProperties()), true);
 
                 getLidrViewModel().setPropertyValue(STAMP_VIEW_MODEL,stampViewModel);
             } else {
                 getStampViewModel()
-                        .setPropertyValue(STATUS_PROPERTY, stamp.state())
-                        .setPropertyValue(AUTHOR_PROPERTY, stamp.author())
-                        .setPropertyValue(MODULE_PROPERTY, stamp.module())
-                        .setPropertyValue(PATH_PROPERTY, stamp.path());
+                        .setPropertyValue(STATUS, stamp.state())
+                        .setPropertyValue(AUTHOR, stamp.author())
+                        .setPropertyValue(MODULE, stamp.module())
+                        .setPropertyValue(PATH, stamp.path());
             }
 
             STAMPDetail stampDetail = toStampDetail(getStampViewModel());
@@ -580,10 +581,10 @@ public class LidrDetailsController {
         ValidationViewModel stampViewModel = getLidrViewModel().getPropertyValue(STAMP_VIEW_MODEL);
         if (getLidrViewModel().getPropertyValue(STAMP_VIEW_MODEL) != null) {
             stampViewModel.setPropertyValue(MODE, mode)
-                    .setPropertyValue(STATUS_PROPERTY, stamp.state())
-                    .setPropertyValue(MODULE_PROPERTY, stamp.module())
-                    .setPropertyValue(PATH_PROPERTY, stamp.path())
-                    .setPropertyValue(TIME_PROPERTY, stamp.time())
+                    .setPropertyValue(STATUS, stamp.state())
+                    .setPropertyValue(MODULE, stamp.module())
+                    .setPropertyValue(PATH, stamp.path())
+                    .setPropertyValue(TIME, stamp.time())
                     .save(true);
         }
     }
@@ -707,24 +708,24 @@ public class LidrDetailsController {
     }
 
     private void updateUIStamp(ViewModel stampViewModel) {
-        long time = stampViewModel.getValue(TIME_PROPERTY);
+        long time = stampViewModel.getValue(TIME);
         DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss");
         Instant stampInstance = Instant.ofEpochSecond(time/1000);
         ZonedDateTime stampTime = ZonedDateTime.ofInstant(stampInstance, ZoneOffset.UTC);
         String lastUpdated = DATE_TIME_FORMATTER.format(stampTime);
 
         lastUpdatedText.setText(lastUpdated);
-        ConceptEntity moduleEntity = stampViewModel.getValue(MODULE_PROPERTY);
+        ConceptEntity moduleEntity = stampViewModel.getValue(MODULE);
         if (moduleEntity == null) {
             LOG.warn("Must select a valid module for Stamp.");
             return;
         }
         String moduleDescr = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(moduleEntity.nid());
         moduleText.setText(moduleDescr);
-        ConceptEntity pathEntity = stampViewModel.getValue(PATH_PROPERTY);
+        ConceptEntity pathEntity = stampViewModel.getValue(PATH);
         String pathDescr = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(pathEntity.nid());
         pathText.setText(pathDescr);
-        statusText.setText(stampViewModel.getValue(STATUS_PROPERTY).toString());
+        statusText.setText(stampViewModel.getValue(STATUS).toString());
     }
 
     public void compactSizeWindow() {

--- a/kview/src/main/java/dev/ikm/komet/kview/lidr/mvvm/viewmodel/ViewModelHelper.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/lidr/mvvm/viewmodel/ViewModelHelper.java
@@ -51,6 +51,7 @@ import java.util.regex.Pattern;
 import static dev.ikm.komet.kview.lidr.mvvm.model.DataModelHelper.*;
 import static dev.ikm.komet.kview.lidr.mvvm.viewmodel.ResultsViewModel.*;
 import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.*;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.*;
 
 
 public class ViewModelHelper {
@@ -119,15 +120,15 @@ public class ViewModelHelper {
             }
             LOG.error("Error(s) with validation message(s)\n" + sb);
         }
-        State status = stampViewModel.getValue(STATUS_PROPERTY);
+        State status = stampViewModel.getValue(STATUS);
         PublicId statusPublicId = status != null ? status.publicId() : TinkarTerm.ACTIVE_STATE.publicId();
-        Concept author = stampViewModel.getValue(AUTHOR_PROPERTY);
+        Concept author = stampViewModel.getValue(AUTHOR);
         PublicId authorPublicId = author != null ? author.publicId() : TinkarTerm.USER.publicId();
-        Long time = stampViewModel.getValue(TIME_PROPERTY);
+        Long time = stampViewModel.getValue(TIME);
         long epochMillis = time == null ? System.currentTimeMillis() : time; // This may change due to when the actual record is written.
-        Concept module = stampViewModel.getValue(MODULE_PROPERTY);
+        Concept module = stampViewModel.getValue(MODULE);
         PublicId modulePublicId = module != null ? module.publicId() : TinkarTerm.DEVELOPMENT_MODULE.publicId();
-        Concept path = stampViewModel.getValue(PATH_PROPERTY);
+        Concept path = stampViewModel.getValue(PATH);
         PublicId pathPublicId = path != null ? path.publicId() : TinkarTerm.DEVELOPMENT_PATH.publicId();
 
         return new STAMPDetail(statusPublicId, epochMillis, authorPublicId, modulePublicId, pathPublicId);

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
@@ -33,11 +33,8 @@ import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.FULLY_QUALIFIE
 import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.OTHER_NAMES;
 import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.MODE;
 import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.MODULES_PROPERTY;
-import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.MODULE_PROPERTY;
 import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.PATHS_PROPERTY;
-import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.PATH_PROPERTY;
-import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.STATUS_PROPERTY;
-import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.TIME_PROPERTY;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.*;
 import static dev.ikm.tinkar.terms.TinkarTerm.DEFINITION_DESCRIPTION_TYPE;
 import static dev.ikm.tinkar.terms.TinkarTerm.DESCRIPTION_CASE_SIGNIFICANCE;
 import static dev.ikm.tinkar.terms.TinkarTerm.FULLY_QUALIFIED_NAME_DESCRIPTION_TYPE;
@@ -788,10 +785,10 @@ public class DetailsController  {
         ValidationViewModel stampViewModel = conceptViewModel.getPropertyValue(CONCEPT_STAMP_VIEW_MODEL);
         if (conceptViewModel.getPropertyValue(CONCEPT_STAMP_VIEW_MODEL) != null) {
             stampViewModel.setPropertyValue(MODE, mode)
-                    .setPropertyValue(STATUS_PROPERTY, stamp.state())
-                    .setPropertyValue(MODULE_PROPERTY, stamp.moduleNid())
-                    .setPropertyValue(PATH_PROPERTY, stamp.pathNid())
-                    .setPropertyValue(TIME_PROPERTY, stamp.time())
+                    .setPropertyValue(STATUS, stamp.state())
+                    .setPropertyValue(MODULE, stamp.moduleNid())
+                    .setPropertyValue(PATH, stamp.pathNid())
+                    .setPropertyValue(TIME, stamp.time())
                     .save(true);
         }
     }
@@ -961,7 +958,7 @@ public class DetailsController  {
         String descrSemanticStr = "%s | %s".formatted(casSigText, langText);
 
         // update date
-        long epochmillis = getStampViewModel() == null ? System.currentTimeMillis() : getStampViewModel().getValue(TIME_PROPERTY);
+        long epochmillis = getStampViewModel() == null ? System.currentTimeMillis() : getStampViewModel().getValue(TIME);
         Instant stampInstance = Instant.ofEpochSecond(epochmillis/1000);
         ZonedDateTime stampTime = ZonedDateTime.ofInstant(stampInstance, ZoneOffset.UTC);
         String time = DATE_TIME_FORMATTER.format(stampTime);
@@ -1292,24 +1289,24 @@ public class DetailsController  {
     }
 
     private void updateUIStamp(ViewModel stampViewModel) {
-        long time = stampViewModel.getValue(TIME_PROPERTY);
+        long time = stampViewModel.getValue(TIME);
         DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss");
         Instant stampInstance = Instant.ofEpochSecond(time/1000);
         ZonedDateTime stampTime = ZonedDateTime.ofInstant(stampInstance, ZoneOffset.UTC);
         String lastUpdated = DATE_TIME_FORMATTER.format(stampTime);
 
         lastUpdatedText.setText(lastUpdated);
-        ConceptEntity moduleEntity = stampViewModel.getValue(MODULE_PROPERTY);
+        ConceptEntity moduleEntity = stampViewModel.getValue(MODULE);
         if (moduleEntity == null) {
             LOG.warn("Must select a valid module for Stamp.");
             return;
         }
         String moduleDescr = viewProperties.calculator().getPreferredDescriptionTextWithFallbackOrNid(moduleEntity.nid());
         moduleText.setText(moduleDescr);
-        ConceptEntity pathEntity = stampViewModel.getValue(PATH_PROPERTY);
+        ConceptEntity pathEntity = stampViewModel.getValue(PATH);
         String pathDescr = viewProperties.calculator().getPreferredDescriptionTextWithFallbackOrNid(pathEntity.nid());
         pathText.setText(pathDescr);
-        State status = stampViewModel.getValue(STATUS_PROPERTY);
+        State status = stampViewModel.getValue(STATUS);
         String statusMsg = status == null ? "Active" : viewProperties.calculator().getPreferredDescriptionTextWithFallbackOrNid(status.nid());
         statusText.setText(statusMsg);
     }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PatternDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PatternDetailsController.java
@@ -30,6 +30,8 @@ import dev.ikm.komet.kview.mvvm.model.PatternField;
 import dev.ikm.komet.kview.mvvm.viewmodel.PatternViewModel;
 import dev.ikm.tinkar.coordinate.view.calculator.ViewCalculator;
 import dev.ikm.tinkar.entity.ConceptEntity;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.StringBinding;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.ListChangeListener;
@@ -277,6 +279,13 @@ public class PatternDetailsController {
                 }
             }
         });
+        Label fqnAddDateLabel = new Label();
+        ObjectProperty<DescrName> objectProperty = patternViewModel.getProperty(FQN_DESCRIPTION_NAME);
+        StringBinding dateStrProp = Bindings
+                .when(objectProperty.isNotNull())
+                .then(LocalDate.now().format(DateTimeFormatter.ofPattern("MMM d, yyyy")))
+                .otherwise("");
+        fqnAddDateLabel.textProperty().bind(dateStrProp);
         // Setup Properties
         setupProperties();
     }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/stamp/StampEditController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/stamp/StampEditController.java
@@ -31,6 +31,8 @@ import org.carlfx.cognitive.viewmodel.ViewModel;
 import java.util.List;
 
 import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.*;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.MODULE;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.PATH;
 
 public class StampEditController extends AbstractBasicController {
 
@@ -76,7 +78,7 @@ public class StampEditController extends AbstractBasicController {
         // When user selects a radio button
         moduleToggleGroup.selectedToggleProperty().addListener((observableValue, toggle, t1) -> {
             ConceptEntity module = (ConceptEntity) t1.getUserData();
-            getStampViewModel().setPropertyValue(MODULE_PROPERTY, module);
+            getStampViewModel().setPropertyValue(MODULE, module);
             if (module != null) {
                 moduleTitledPane.setText("Module: " + module.description());
             }
@@ -84,7 +86,7 @@ public class StampEditController extends AbstractBasicController {
 
         pathToggleGroup.selectedToggleProperty().addListener(((observableValue, toggle, t1) -> {
             ConceptEntity path = (ConceptEntity) t1.getUserData();
-            getStampViewModel().setPropertyValue(PATH_PROPERTY, path);
+            getStampViewModel().setPropertyValue(PATH, path);
             if (path != null) {
                 pathTitledPane.setText("Path: " + path.description());
             }
@@ -100,7 +102,7 @@ public class StampEditController extends AbstractBasicController {
             rb.setNodeOrientation(NodeOrientation.LEFT_TO_RIGHT);
             rb.setUserData(module);
             rb.setToggleGroup(moduleToggleGroup);
-            ObjectProperty<ConceptEntity> moduleProperty = getStampViewModel().getProperty(MODULE_PROPERTY);
+            ObjectProperty<ConceptEntity> moduleProperty = getStampViewModel().getProperty(MODULE);
             if (moduleProperty.isNotNull().get() && moduleProperty.get().nid() == module.nid()) {
                 rb.setSelected(true);
             }
@@ -115,7 +117,7 @@ public class StampEditController extends AbstractBasicController {
             rb.setNodeOrientation(NodeOrientation.LEFT_TO_RIGHT);
             rb.setUserData(path);
             rb.setToggleGroup(pathToggleGroup);
-            ObjectProperty<ConceptEntity> pathProperty = getStampViewModel().getProperty(PATH_PROPERTY);
+            ObjectProperty<ConceptEntity> pathProperty = getStampViewModel().getProperty(PATH);
             if (pathProperty.isNotNull().get() && pathProperty.get().nid() == path.nid()) {
                 rb.setSelected(true);
             }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/ConceptViewModel.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/ConceptViewModel.java
@@ -22,6 +22,7 @@ import dev.ikm.tinkar.common.id.PublicId;
 import dev.ikm.tinkar.common.id.PublicIds;
 import dev.ikm.tinkar.common.service.TinkExecutor;
 import dev.ikm.tinkar.coordinate.edit.EditCoordinateRecord;
+import dev.ikm.tinkar.coordinate.stamp.StampFields;
 import dev.ikm.tinkar.entity.*;
 import dev.ikm.tinkar.entity.graph.DiTreeEntity;
 import dev.ikm.tinkar.entity.graph.EntityVertex;
@@ -49,8 +50,7 @@ import java.util.UUID;
 
 import static dev.ikm.komet.kview.mvvm.viewmodel.DescrNameViewModel.NAME_TEXT;
 import static dev.ikm.komet.kview.mvvm.viewmodel.DescrNameViewModel.NAME_TYPE;
-import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.MODULE_PROPERTY;
-import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.PATH_PROPERTY;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.PATH;
 
 public class ConceptViewModel extends FormViewModel {
     private static final Logger LOG = LoggerFactory.getLogger(ConceptViewModel.class);
@@ -143,8 +143,8 @@ public class ConceptViewModel extends FormViewModel {
         Transaction transaction = Transaction.make("New concept for: " + fqnDescrName.getNameText());
 
         // Copy STAMP info
-        ConceptEntity module = stampViewModel.getValue(MODULE_PROPERTY);
-        ConceptEntity path = stampViewModel.getValue(PATH_PROPERTY);
+        ConceptEntity module = stampViewModel.getValue(StampFields.MODULE);
+        ConceptEntity path = stampViewModel.getValue(PATH);
 
         StampEntity stampEntity = transaction.getStamp(State.ACTIVE, editCoordinate.getAuthorNidForChanges(),
                 module.nid(), path.nid());

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/StampViewModel.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/StampViewModel.java
@@ -17,6 +17,7 @@ package dev.ikm.komet.kview.mvvm.viewmodel;
 
 import dev.ikm.komet.framework.view.ViewProperties;
 import dev.ikm.tinkar.common.id.IntIdSet;
+import dev.ikm.tinkar.coordinate.stamp.StampFields;
 import dev.ikm.tinkar.entity.*;
 import dev.ikm.tinkar.terms.State;
 import dev.ikm.tinkar.terms.TinkarTerm;
@@ -29,34 +30,32 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.*;
+
 public class StampViewModel extends FormViewModel {
-    public final static String STATUS_PROPERTY = "status";
-    public final static String TIME_PROPERTY = "time";
-    public final static String AUTHOR_PROPERTY = "author";
-    public final static String MODULE_PROPERTY = "module";
-    public final static String PATH_PROPERTY = "path";
+
     public final static String MODULES_PROPERTY = "modules";
     public final static String PATHS_PROPERTY = "paths";
     public final static String INCOMPLETE = "Incomplete";
     public StampViewModel() {
         super(); // Default to ViewMode
-        addProperty(STATUS_PROPERTY, State.ACTIVE)
-                .addProperty(AUTHOR_PROPERTY, TinkarTerm.USER)
-                .addProperty(TIME_PROPERTY, System.currentTimeMillis())
-                .addProperty(MODULE_PROPERTY, (ConceptEntity) null)
-                .addProperty(PATH_PROPERTY, (ConceptEntity) null)
+        addProperty(STATUS, State.ACTIVE)
+                .addProperty(AUTHOR, TinkarTerm.USER)
+                .addProperty(TIME, System.currentTimeMillis())
+                .addProperty(MODULE, (ConceptEntity) null)
+                .addProperty(PATH, (ConceptEntity) null)
                 .addProperty(MODULES_PROPERTY, Collections.emptyList(), true)
                 .addProperty(PATHS_PROPERTY, Collections.emptyList(), true);
 
-        addValidator(MODULE_PROPERTY, "Module", (ReadOnlyObjectProperty nidProp, ViewModel vm) -> {
+        addValidator(MODULE, "Module", (ReadOnlyObjectProperty nidProp, ViewModel vm) -> {
             if (nidProp.isNull().get()) {
-                return new ValidationMessage(MODULE_PROPERTY, MessageType.ERROR, "Stamp's ${%s} is required.".formatted(MODULE_PROPERTY));
+                return new ValidationMessage(MODULE, MessageType.ERROR, "Stamp's ${%s} is required.".formatted(MODULE));
             }
             return VALID;
         });
-        addValidator(PATH_PROPERTY, "Path", (ReadOnlyObjectProperty nidProp, ViewModel vm) -> {
+        addValidator(PATH, "Path", (ReadOnlyObjectProperty nidProp, ViewModel vm) -> {
             if (nidProp.isNull().get()) {
-                return new ValidationMessage(PATH_PROPERTY, MessageType.ERROR, "Stamp's ${%s} is required.".formatted(PATH_PROPERTY));
+                return new ValidationMessage(PATH, MessageType.ERROR, "Stamp's ${%s} is required.".formatted(PATH));
             }
             return VALID;
         });


### PR DESCRIPTION
Cognitive (MVVM) framework now allows property names to be enums which enables code to be more concise instead of declaring `public static final String PROPERTY_NAME = "some property name";`

In this branch the is the first introduction to using the new feature by using an existing enum in tinkar-core called `StampFields`.

![Screenshot 2024-09-13 at 12 49 14 PM](https://github.com/user-attachments/assets/3ae8a478-0945-4cca-9913-56c620e53585)
For example: When defining ViewModels you can add properties like so:
![Screenshot 2024-09-13 at 12 51 56 PM](https://github.com/user-attachments/assets/2a3e98ff-6b19-4c0f-847f-67e76afd8cab)

As you will notice the code above uses static imports which will make properties less verbose.

At a later time we can begin to refactor and reduce a lot of boiler plate code that represents Form Fields in UIs.