### PR TITLE
Implement scrollbars for scalable desktop

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
@@ -108,7 +108,6 @@ import static dev.ikm.komet.kview.events.JournalTileEvent.UPDATE_JOURNAL_TILE;
 import static dev.ikm.komet.kview.events.MakeConceptWindowEvent.OPEN_CONCEPT_FROM_CONCEPT;
 import static dev.ikm.komet.kview.events.MakeConceptWindowEvent.OPEN_CONCEPT_FROM_SEMANTIC;
 import static dev.ikm.komet.kview.fxutils.SlideOutTrayHelper.setupSlideOutTrayPane;
-import static dev.ikm.komet.kview.fxutils.ViewportHelper.clipChildren;
 import static dev.ikm.komet.kview.lidr.mvvm.viewmodel.LidrViewModel.*;
 import static dev.ikm.komet.kview.mvvm.viewmodel.DescrNameViewModel.MODULES_PROPERTY;
 import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.CREATE;
@@ -249,9 +248,6 @@ public class JournalController {
      */
     @FXML
     public void initialize() {
-        // According to the JavaFX docs an ordinary Pane does not clip region. TODO infinite workspace
-        clipChildren(desktopSurfacePane, 0);
-
         reasonerNodePanel = new BorderPane();
 
         // When user clicks on sidebar tray's toggle buttons.

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/journal/journal.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/journal/journal.fxml
@@ -20,6 +20,8 @@
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.shape.Rectangle?>
 <?import javafx.scene.shape.SVGPath?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.layout.AnchorPane?>
 
 <BorderPane fx:id="journalBorderPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.journal.JournalController">
    <center>
@@ -134,11 +136,12 @@
                         </HBox>
                      </top>
                      <center>
-                        <Pane fx:id="desktopSurfacePane" prefHeight="200.0" prefWidth="200.0" styleClass="desktop-area">
-                           <children>
-                              <Region fx:id="dropAnimationRegion" layoutX="32.0" layoutY="30.0" mouseTransparent="true" prefHeight="200.0" prefWidth="200.0" styleClass="search-drop-region" />
-                           </children>
-                        </Pane>
+                        <ScrollPane fx:id="desktopSurfaceScrollPane" focusTraversable="true" styleClass="desktop-scroll-pane">
+                           <AnchorPane fx:id="desktopSurfacePane" maxWidth="2800.0" maxHeight="1800.0" prefWidth="2800.0" prefHeight="1800.0" styleClass="desktop-area">
+                              <Region fx:id="dropAnimationRegion" layoutX="32.0" layoutY="30.0" mouseTransparent="true"
+                                      prefHeight="200.0" prefWidth="200.0" styleClass="search-drop-region"/>
+                           </AnchorPane>
+                        </ScrollPane>
                      </center>
                   </BorderPane>
                </center>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -1006,8 +1006,98 @@ selected(active) - dark black
 
 .desktop-area {
     /*-fx-background-image: url("journal/grid-2x2-segment.png");*/
-    -fx-background-color: #828d9fff;
+    -fx-background-color: transparent; /* #828d9fff */
 }
+
+.desktop-scroll-pane {
+    -fx-background-color: #cad3e2; /* #cad3e2 */
+    -fx-background-insets: 0;
+    -fx-padding: 0 -12 -12 0;
+}
+
+.desktop-scroll-pane > .viewport {
+    -fx-background-color: transparent;
+    -fx-padding: 0;
+}
+
+.desktop-scroll-pane > .corner {
+    -fx-background-color: transparent;
+}
+
+.desktop-scroll-pane > .scroll-bar {
+    -fx-background-color: transparent;
+}
+
+.desktop-scroll-pane > .scroll-bar:vertical {
+    -fx-min-width: 0;
+    -fx-pref-width: 0;
+    -fx-max-width: 0;
+    -fx-padding: 3 3 3 -12;
+}
+
+.desktop-scroll-pane > .scroll-bar:horizontal {
+    -fx-min-height: 0;
+    -fx-pref-height: 0;
+    -fx-max-height: 0;
+    -fx-padding: -12 3 3 3;
+}
+
+.desktop-scroll-pane > .scroll-bar .track {
+    -fx-background-color: transparent;
+}
+
+.desktop-scroll-pane > .scroll-bar:vertical .track {
+    -fx-background-insets: 0 12 0 0;
+}
+
+.desktop-scroll-pane > .scroll-bar:horizontal .track {
+    -fx-background-insets: 0 0 12 0;
+}
+
+.desktop-scroll-pane > .scroll-bar .thumb {
+     -fx-background-color: -Grey-1, rgba(0, 0, 0, 0.4);
+     -fx-background-insets: 0, 1;
+     -fx-background-radius: 6px;
+    -fx-padding: 0;
+}
+
+.desktop-scroll-pane > .scroll-bar:hover .thumb {
+    -fx-background-color: -Grey-1, rgba(0, 0, 0, 0.5);
+}
+
+.desktop-scroll-pane > .scroll-bar .increment-button,
+.desktop-scroll-pane > .scroll-bar .decrement-button {
+    -fx-background-insets: 0;
+    -fx-min-width: 0;
+    -fx-pref-width: 0;
+    -fx-min-height: 0;
+    -fx-pref-height: 0;
+    -fx-padding: 0;
+}
+
+.desktop-scroll-pane > .scroll-bar .increment-arrow,
+.desktop-scroll-pane > .scroll-bar .decrement-arrow {
+    -fx-shape: " ";
+    -fx-padding: 0;
+}
+
+/*.scroll-pane.scroll-area > .scroll-bar:horizontal,*/
+/*.scroll-pane.scroll-area:focused > .scroll-bar:horizontal {*/
+/*    -fx-pref-height: 196px;*/
+/*    -fx-background-color: -Grey-3;*/
+/*    -fx-background-insets: 0;*/
+/*    -fx-background-radius: 0;*/
+/*    -fx-padding: 0;*/
+/*}*/
+
+/*.scroll-pane.scroll-area > .viewport,*/
+/*.scroll-pane.scroll-area:focused > .viewport {*/
+/*    -fx-pref-height: 196px;*/
+/*    -fx-background-color: -Grey-3;*/
+/*    -fx-background-insets: 0;*/
+/*    -fx-background-radius: 0;*/
+/*    -fx-padding: 0;*/
+/*}*/
 
 .chapter-block-bar-stack {
     -icon-paint: -Grey-10;

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -1081,24 +1081,6 @@ selected(active) - dark black
     -fx-padding: 0;
 }
 
-/*.scroll-pane.scroll-area > .scroll-bar:horizontal,*/
-/*.scroll-pane.scroll-area:focused > .scroll-bar:horizontal {*/
-/*    -fx-pref-height: 196px;*/
-/*    -fx-background-color: -Grey-3;*/
-/*    -fx-background-insets: 0;*/
-/*    -fx-background-radius: 0;*/
-/*    -fx-padding: 0;*/
-/*}*/
-
-/*.scroll-pane.scroll-area > .viewport,*/
-/*.scroll-pane.scroll-area:focused > .viewport {*/
-/*    -fx-pref-height: 196px;*/
-/*    -fx-background-color: -Grey-3;*/
-/*    -fx-background-insets: 0;*/
-/*    -fx-background-radius: 0;*/
-/*    -fx-padding: 0;*/
-/*}*/
-
 .chapter-block-bar-stack {
     -icon-paint: -Grey-10;
     -default-height: 48px;

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -1006,11 +1006,11 @@ selected(active) - dark black
 
 .desktop-area {
     /*-fx-background-image: url("journal/grid-2x2-segment.png");*/
-    -fx-background-color: transparent; /* #828d9fff */
+    -fx-background-color: transparent;
 }
 
 .desktop-scroll-pane {
-    -fx-background-color: #cad3e2; /* #cad3e2 */
+    -fx-background-color: #cad3e2;
     -fx-background-insets: 0;
     -fx-padding: 0 -12 -12 0;
 }


### PR DESCRIPTION
A first implementation of the scrollbars for scalable desktop.
As a user, I want to scroll vertically and horizontally within the Journal View workspace so that when more than three concepts are open, I can view all concepts outside the current view by scrolling.

**Specifications:**
* Scrollbars
  - Implement a vertical scrollbar on the right side of the Journal View.
  - Implement a horizontal scrollbar at the bottom of the Journal View.
* Canvas Size:
  - The maximum canvas size for the Journal View is 2800 pixels (width) by 1800 pixels (height).

Currently, the panning (scrolling) functionality is activated by pressing either `Control` or `Command: ⌘` key on macOS and `Ctrl` or `Alt` key on Windows. While holding the key, use the mouse primary button to drag the viewport. The cursor will change to show that panning is enabled (**Open Hand** icon) and dragging can be done (**Closed Hand** icon).