### PR TITLE
Bugfix/JPRO-45 Unable to Run Reasoner when running Komet with JPro

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
@@ -399,7 +399,7 @@ public class JournalController {
         Subscriber<ProgressEvent> progressPopupSubscriber = evt -> {
             // if summon event type, load stuff and reference task to progress popup
             if (evt.getEventType() == SUMMON) {
-                progressToggleButton.setVisible(true);
+                Platform.runLater(() -> progressToggleButton.setVisible(true));
                 Task<Void> task = evt.getTask();
                 JFXNode<Pane, ProgressController> progressJFXNode = createProgressBox(task, evt.getCancelButtonText());
                 ProgressController progressController = progressJFXNode.controller();

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
@@ -412,10 +412,7 @@ public class JournalController {
                     progressController.cleanup();
                 });
 
-                popOver.setOnHidden(windowEvent -> {
-                    progressController.cleanup();
-                });
-
+                popOver.setOnHidden(windowEvent -> progressController.cleanup());
                 popOver.setArrowLocation(PopOver.ArrowLocation.LEFT_TOP);
                 Platform.runLater(() -> popOver.show(progressToggleButton));
 
@@ -427,7 +424,7 @@ public class JournalController {
                     progressController2.cleanup();
                     progressListVBox.getChildren().remove(progressBox2);
                 });
-                Platform.runLater(()->  progressListVBox.getChildren().add(0, progressBox2));
+                Platform.runLater(()->  progressListVBox.getChildren().addFirst(progressBox2));
             }
         };
         journalEventBus.subscribe(PROGRESS_TOPIC, ProgressEvent.class, progressPopupSubscriber);

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
@@ -399,32 +399,34 @@ public class JournalController {
         Subscriber<ProgressEvent> progressPopupSubscriber = evt -> {
             // if summon event type, load stuff and reference task to progress popup
             if (evt.getEventType() == SUMMON) {
-                Platform.runLater(() -> progressToggleButton.setVisible(true));
-                Task<Void> task = evt.getTask();
-                JFXNode<Pane, ProgressController> progressJFXNode = createProgressBox(task, evt.getCancelButtonText());
-                ProgressController progressController = progressJFXNode.controller();
-                Pane progressPane = progressJFXNode.node();
-                PopOver popOver = new PopOver(progressPane);
+                Platform.runLater(() -> {
+                    progressToggleButton.setVisible(true);
+                    Task<Void> task = evt.getTask();
+                    JFXNode<Pane, ProgressController> progressJFXNode = createProgressBox(task, evt.getCancelButtonText());
+                    ProgressController progressController = progressJFXNode.controller();
+                    Pane progressPane = progressJFXNode.node();
+                    PopOver popOver = new PopOver(progressPane);
 
-                // setup close button
-                progressController.getCloseProgressButton().setOnAction(actionEvent -> {
-                    popOver.hide();
-                    progressController.cleanup();
+                    // setup close button
+                    progressController.getCloseProgressButton().setOnAction(actionEvent -> {
+                        popOver.hide();
+                        progressController.cleanup();
+                    });
+
+                    popOver.setOnHidden(windowEvent -> progressController.cleanup());
+                    popOver.setArrowLocation(PopOver.ArrowLocation.LEFT_TOP);
+                    popOver.show(progressToggleButton);
+
+                    // Create one inside the list for bump out
+                    JFXNode<Pane, ProgressController> progressJFXNode2 = createProgressBox(task, evt.getCancelButtonText());
+                    ProgressController progressController2 = progressJFXNode2.controller();
+                    Pane progressBox2 = progressJFXNode2.node();
+                    progressController2.getCloseProgressButton().setOnAction(actionEvent -> {
+                        progressController2.cleanup();
+                        progressListVBox.getChildren().remove(progressBox2);
+                    });
+                    progressListVBox.getChildren().addFirst(progressBox2);
                 });
-
-                popOver.setOnHidden(windowEvent -> progressController.cleanup());
-                popOver.setArrowLocation(PopOver.ArrowLocation.LEFT_TOP);
-                Platform.runLater(() -> popOver.show(progressToggleButton));
-
-                // Create one inside the list for bump out
-                JFXNode<Pane, ProgressController> progressJFXNode2 = createProgressBox(task, evt.getCancelButtonText());
-                ProgressController progressController2 = progressJFXNode2.controller();
-                Pane progressBox2 = progressJFXNode2.node();
-                progressController2.getCloseProgressButton().setOnAction(actionEvent -> {
-                    progressController2.cleanup();
-                    progressListVBox.getChildren().remove(progressBox2);
-                });
-                Platform.runLater(()->  progressListVBox.getChildren().addFirst(progressBox2));
             }
         };
         journalEventBus.subscribe(PROGRESS_TOPIC, ProgressEvent.class, progressPopupSubscriber);

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
@@ -425,7 +425,7 @@ public class JournalController {
                 Pane progressBox2 = progressJFXNode2.node();
                 progressController2.getCloseProgressButton().setOnAction(actionEvent -> {
                     progressController2.cleanup();
-                    Platform.runLater(()->  progressListVBox.getChildren().remove(progressBox2));
+                    progressListVBox.getChildren().remove(progressBox2);
                 });
                 Platform.runLater(()->  progressListVBox.getChildren().add(0, progressBox2));
             }


### PR DESCRIPTION
**Current behavior:**
When user runs the reasoner, nothing happens and the app freezes. This does run on the desktop app.

**Expected behavior:**
When user runs the reasoner, the following should happen:

- Reasoning process is initiated
- Activity tab shows progress of reasoning progress
- Changes from reasoning should be reflected in concept details