### PR TITLE
IIA-954 bugfix lidr window disappears device pane when done button press

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/lidr/mvvm/view/analyte/AnalyteGroupController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/lidr/mvvm/view/analyte/AnalyteGroupController.java
@@ -147,7 +147,7 @@ public class AnalyteGroupController implements BasicController {
         // order to save/update the device and manufacturer concepts
 
         clearView();
-        doneButton.disableProperty().bind(analyteGroupViewModel.getProperty(SAVE_BUTTON_STATE));
+        doneButton.disableProperty().bind(analyteGroupViewModel.getProperty(IS_INVALID));
 
         // setup drag n drop
         setupDragNDrop(analyteSearchStackPane, (publicId) -> {
@@ -502,7 +502,7 @@ public class AnalyteGroupController implements BasicController {
     @FXML
     public void cancel(ActionEvent event) {
         // close properties bump out via event bus
-        clearView();
+        clearViewAndValidate();
         EvtBus evtBus = EvtBusFactory.getDefaultEvtBus();
         evtBus.publish(getConceptTopic(), new LidrPropertyPanelEvent(event.getSource(), CLOSE_PANEL));
     }
@@ -512,6 +512,14 @@ public class AnalyteGroupController implements BasicController {
 
     }
 
+    public void clearViewAndValidate() {
+        clearView();
+        analyteGroupViewModel.validate();
+    }
+    @FXML
+    public void clearView(ActionEvent actionEvent) {
+        clearViewAndValidate();
+    }
     @Override
     public void clearView() {
 
@@ -535,7 +543,7 @@ public class AnalyteGroupController implements BasicController {
 
         // cancel means to clear properties and the model values.
         analyteGroupViewModel.save(true);
-        analyteGroupViewModel.validate();
+
     }
 
     private void clearDragNDropZones(Pane selectedContainer, Runnable task) {

--- a/kview/src/main/java/dev/ikm/komet/kview/lidr/mvvm/viewmodel/AnalyteGroupViewModel.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/lidr/mvvm/viewmodel/AnalyteGroupViewModel.java
@@ -25,8 +25,8 @@ import dev.ikm.tinkar.entity.transaction.Transaction;
 import dev.ikm.tinkar.terms.EntityFacade;
 import dev.ikm.tinkar.terms.State;
 import dev.ikm.tinkar.terms.TinkarTerm;
-import org.carlfx.cognitive.validator.MessageType;
 import org.carlfx.cognitive.validator.ValidationMessage;
+import org.carlfx.cognitive.validator.ValidationResult;
 import org.carlfx.cognitive.viewmodel.ViewModel;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
@@ -49,35 +49,31 @@ public class AnalyteGroupViewModel extends FormViewModel {
 
     public static String SPECIMEN_ENTITIES = "specimenEntities";
 
-    public static String IS_POPULATED = "isPopulated";
-    public static String SAVE_BUTTON_STATE = "buttonState";
+    public static String IS_INVALID = "isInvalid";
 
     public AnalyteGroupViewModel() {
         super();
         addProperty(CONCEPT_TOPIC, (UUID) null)
                 .addProperty(VIEW_PROPERTIES, (ViewProperties) null)
-                .addProperty(SAVE_BUTTON_STATE, true)        // disable property (true) by default
                 .addProperty(ANALYTE_ENTITY, (EntityFacade) null)   // this is an analyte as a concept
                 .addProperty(TARGET_ENTITIES, new ArrayList<>())    // analytes have targets
                 .addProperty(RESULT_ENTITIES, new ArrayList<>())    // this represents the results as a concept
                 .addProperty(SPECIMEN_ENTITIES, new ArrayList<>()); // this is the specimen as a concept
 
         // Is Analyte Group valid? Custom validator will alter button state.
-        addValidator(IS_POPULATED, "Is Populated", (Void prop, ViewModel vm) -> {
+        this.addProperty(IS_INVALID, true)
+            .addValidator(IS_INVALID, "Is not valid", (ValidationResult result, ViewModel vm) -> {
             // if any fields are empty then it is not populated (invalid)
             if (getPropertyValue(ANALYTE_ENTITY) == null
                     || getObservableList(TARGET_ENTITIES).size() == 0
                     || getObservableList(RESULT_ENTITIES).size() == 0
                     || getObservableList(SPECIMEN_ENTITIES).size() == 0) {
-
-                // update is populated
-                setPropertyValue(SAVE_BUTTON_STATE, true); // disable is true
                 // let caller know why it is not valid
-                return new ValidationMessage(SAVE_BUTTON_STATE, MessageType.ERROR, "Analyte Group is not populated");
+                result.error("Analyte Group is not populated");
+                vm.setPropertyValue(IS_INVALID, true);
+            } else {
+                vm.setPropertyValue(IS_INVALID, false);
             }
-            // update is populated
-            setPropertyValue(SAVE_BUTTON_STATE, false); // disable is false (enabled)
-            return VALID;
         });
         //TODO figure out when to set the mode to CREATE | EDIT; possibly set by the view?
         //setValue(MODE, CREATE);

--- a/kview/src/main/java/dev/ikm/komet/kview/lidr/mvvm/viewmodel/DeviceViewModel.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/lidr/mvvm/viewmodel/DeviceViewModel.java
@@ -25,7 +25,10 @@ import dev.ikm.tinkar.entity.transaction.Transaction;
 import dev.ikm.tinkar.terms.EntityFacade;
 import dev.ikm.tinkar.terms.State;
 import dev.ikm.tinkar.terms.TinkarTerm;
+import javafx.beans.property.ObjectProperty;
 import org.carlfx.cognitive.validator.ValidationMessage;
+import org.carlfx.cognitive.validator.ValidationResult;
+import org.carlfx.cognitive.viewmodel.ViewModel;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.slf4j.Logger;
@@ -47,6 +50,7 @@ public class DeviceViewModel extends FormViewModel {
     public static String FULLY_QUALIFIED_NAME = "fqn";
 
     public static String MANUFACTURER_ENTITY = "manufacturer";
+    public static String IS_INVALID = "IS_INVALID";
 
     public DeviceViewModel() {
         super();
@@ -56,7 +60,17 @@ public class DeviceViewModel extends FormViewModel {
                 .addProperty(DEVICE_ENTITY, (EntityFacade) null) // this is/will be the device concept entity
                 // in non-manual mode, a device entity will already have a FQN
                 .addProperty(FULLY_QUALIFIED_NAME, (Object) null) // this is the FQN of the device concept
-                .addProperty(MANUFACTURER_ENTITY, (EntityFacade) null); // this is the manufacturer concept
+                .addProperty(MANUFACTURER_ENTITY, (EntityFacade) null) // this is the manufacturer concept
+                .addProperty(IS_INVALID, true)
+                .addValidator(IS_INVALID, "Is Invalid", (ValidationResult vr, ViewModel viewModel) -> {
+                    ObjectProperty<EntityFacade> deviceEntity = viewModel.getProperty(DEVICE_ENTITY);
+                    if (deviceEntity.isNull().get()) {
+                        vr.error("Device is empty. Please select a device.");
+                        viewModel.setPropertyValue(IS_INVALID, true);
+                    } else {
+                        viewModel.setPropertyValue(IS_INVALID, false);
+                    }
+                });
 
         //TODO add validations, for create LIDR_RECORD, DEVICE_ENTITY and MANUFACTURER_ENTITY all must be populated
 

--- a/kview/src/main/resources/dev/ikm/komet/kview/lidr/mvvm/view/device/device-summary.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/lidr/mvvm/view/device/device-summary.fxml
@@ -168,7 +168,7 @@
                   <Insets left="12.0" />
                </GridPane.margin>
             </Button>
-            <Button fx:id="doneButton" mnemonicParsing="false" onAction="#createDevice" styleClass="lidr-done-button" text="DONE" GridPane.columnIndex="2" GridPane.halignment="RIGHT">
+            <Button fx:id="doneButton" mnemonicParsing="false" onAction="#selectDevice" styleClass="lidr-done-button" text="DONE" GridPane.columnIndex="2" GridPane.halignment="RIGHT">
                <GridPane.margin>
                   <Insets right="12.0" />
                </GridPane.margin>


### PR DESCRIPTION
Create Lidr window will shift view (jumps) to the right of the desktop workspace when ever a user clicks on the done button on the device selection screen. This also occurs when user is pressing done in the Analyte Group window.

![Screenshot 2024-09-23 at 10 18 54 PM](https://github.com/user-attachments/assets/4cbce4c4-cbd1-45c7-94c4-7e178f984744)

Another window having the same issue. When the done button is pressed the bump out will close and jump to the scrollpane to the center or far right side instead of upper left screen.

![Screenshot 2024-09-23 at 10 19 59 PM](https://github.com/user-attachments/assets/c65ad619-1793-4de7-8902-2dcad62db08b)
