### PR TITLE
Feature/JPRO-59 Make Concept Window Default Size Same as Drop Zone Area

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
@@ -697,8 +697,9 @@ public class JournalController {
 
         // If a concept window is newly launched assign it a unique id 'CONCEPT_XXX-XXXX-XX'
         Optional<String> conceptFolderName;
-        if (conceptWindowSettingsMap != null){
-            conceptFolderName = (Optional<String>) conceptWindowSettingsMap.getOrDefault(CONCEPT_PREF_NAME, CONCEPT_FOLDER_PREFIX + UUID.randomUUID());
+        if (conceptWindowSettingsMap != null) {
+            conceptFolderName = Optional.of(String.valueOf(conceptWindowSettingsMap.getOrDefault(CONCEPT_PREF_NAME,
+                    CONCEPT_FOLDER_PREFIX + UUID.randomUUID())));
         } else {
             conceptFolderName = Optional.of(CONCEPT_FOLDER_PREFIX + UUID.randomUUID());
             // create a conceptWindowSettingsMap

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
@@ -152,7 +152,7 @@ public class JournalController {
     private AnchorPane desktopSurfacePane;
 
     @FXML
-    private Region dropAnimationRegion;
+    private Region desktopDropRegion;
 
     @FXML
     private MenuItem newConceptMenuItem;
@@ -316,7 +316,7 @@ public class JournalController {
         journalEventBus.subscribe(JOURNAL_TOPIC, CloseReasonerPanelEvent.class, closeReasonerPanelEventSubscriber);
 
         // initially drop region is invisible
-        dropAnimationRegion.setVisible(false);
+        desktopDropRegion.setVisible(false);
 
         // initialize drag and drop for search results of next gen search
         setupDragNDrop(desktopSurfacePane, (publicId) -> {});
@@ -364,7 +364,7 @@ public class JournalController {
     }
 
     private void setupDragNDrop(Node node, Consumer<PublicId> consumer) {
-        node.setOnDragEntered(event -> dropAnimationRegion.setVisible(true));
+        node.setOnDragEntered(event -> desktopDropRegion.setVisible(true));
 
         node.setOnDragOver(event -> {
             /* data is dragged over the target */
@@ -378,7 +378,7 @@ public class JournalController {
             event.consume();
         });
 
-        node.setOnDragExited(event -> dropAnimationRegion.setVisible(false));
+        node.setOnDragExited(event -> desktopDropRegion.setVisible(false));
 
         node.setOnDragDropped(event -> {
             /* data dropped */
@@ -408,10 +408,10 @@ public class JournalController {
                     Entity<?> entity = EntityService.get().getEntityFast(EntityService.get().nidForPublicId(publicId));
 
                     Map<ConceptWindowSettings, Object> conceptWindowSettingsMap = new HashMap<>();
-                    conceptWindowSettingsMap.put(CONCEPT_XPOS, dropAnimationRegion.getLayoutX());
-                    conceptWindowSettingsMap.put(CONCEPT_YPOS, dropAnimationRegion.getLayoutY());
-                    conceptWindowSettingsMap.put(CONCEPT_WIDTH, dropAnimationRegion.getWidth());
-                    conceptWindowSettingsMap.put(CONCEPT_HEIGHT, dropAnimationRegion.getHeight());
+                    conceptWindowSettingsMap.put(CONCEPT_XPOS, desktopDropRegion.getLayoutX());
+                    conceptWindowSettingsMap.put(CONCEPT_YPOS, desktopDropRegion.getLayoutY());
+                    conceptWindowSettingsMap.put(CONCEPT_WIDTH, desktopDropRegion.getWidth());
+                    conceptWindowSettingsMap.put(CONCEPT_HEIGHT, desktopDropRegion.getHeight());
                     makeConceptWindow(windowView, ConceptFacade.make(entity.nid()), conceptWindowSettingsMap);
 
                     consumer.accept(publicId);
@@ -426,7 +426,7 @@ public class JournalController {
             event.setDropCompleted(success);
 
             event.consume();
-            dropAnimationRegion.setVisible(false);
+            desktopDropRegion.setVisible(false);
         });
 
         // by default hide progress toggle button

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/journal/journal.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/journal/journal.fxml
@@ -138,7 +138,7 @@
                      <center>
                         <ScrollPane fx:id="desktopSurfaceScrollPane" focusTraversable="true" styleClass="desktop-scroll-pane">
                            <AnchorPane fx:id="desktopSurfacePane" maxHeight="1800.0" maxWidth="2800.0" prefHeight="1800.0" prefWidth="2800.0" styleClass="desktop-area">
-                              <Region fx:id="dropAnimationRegion" layoutX="32.0" layoutY="30.0" mouseTransparent="true" prefHeight="200.0" prefWidth="200.0" styleClass="search-drop-region" />
+                              <Region fx:id="dropAnimationRegion" layoutX="24.0" layoutY="24.0" mouseTransparent="true" styleClass="search-drop-region" />
                            </AnchorPane>
                         </ScrollPane>
                      </center>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/journal/journal.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/journal/journal.fxml
@@ -138,7 +138,7 @@
                      <center>
                         <ScrollPane fx:id="desktopSurfaceScrollPane" focusTraversable="true" styleClass="desktop-scroll-pane">
                            <AnchorPane fx:id="desktopSurfacePane" maxHeight="1800.0" maxWidth="2800.0" prefHeight="1800.0" prefWidth="2800.0" styleClass="desktop-area">
-                              <Region fx:id="dropAnimationRegion" layoutX="24.0" layoutY="24.0" mouseTransparent="true" styleClass="search-drop-region" />
+                              <Region fx:id="desktopDropRegion" layoutX="24.0" layoutY="24.0" mouseTransparent="true" styleClass="desktop-drop-region" />
                            </AnchorPane>
                         </ScrollPane>
                      </center>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -2864,7 +2864,7 @@ Timeline Year line segment (will overlay change circles)
     -fx-min-width: 212px;
 }
 
-.search-drop-region {
+.desktop-drop-region {
     -height: 940px;
     -width: 672px;
     -fx-min-width: -width;

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -2865,19 +2865,20 @@ Timeline Year line segment (will overlay change circles)
 }
 
 .search-drop-region {
-    -height: 840px;
+    -height: 940px;
     -width: 672px;
-    -fx-min-height: -height;
-    -fx-pref-height: -height;
     -fx-min-width: -width;
+    -fx-min-height: -height;
     -fx-pref-width: -width;
-    -fx-border-radius: 8;
-    -fx-background-radius: 8;
-    -fx-stroke: -Primary-04;
+    -fx-pref-height: -height;
     -fx-border-color: -Primary-04;
+    -fx-border-radius: 8;
     -fx-border-width: 4;
-    -fx-border-style: dashed;
-    -fx-background-color: rgba(255, 255, 255, 0.50);    
+    -fx-border-style: segments(12, 16) phase -8 line-join round line-cap round;
+    -fx-background-radius: 8;
+    -fx-background-insets: 0, 4;
+    /* The second color is obtained as a result of blending the current workspace background color and the white color with 50% opacity */
+    -fx-background-color: white, #e5e9f1;
 }
 
 /* Styles title text inside the content of TitlePane. eg: DESCRIPTION , Fully Qualified Name.*/


### PR DESCRIPTION
As a User, when I open a concept, I want the concept window size to be the same size as the drop zone area.

**Acceptance Criteria**:
- When opening a concept, concept window should be the same size as drop zone area.
- Drop zone areas meets Figma specs.

**Note**:
This feature is part of the Drag and Drop functionality within the Journal window.