### PR TITLE
bugfix/IIA-852 The search result is not displayed while dragging and dropping a concept in the pattern.

### DIFF
--- a/framework/src/main/java/dev/ikm/komet/framework/dnd/DragImageMaker.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/dnd/DragImageMaker.java
@@ -118,8 +118,6 @@ public class DragImageMaker implements DraggableWithImage {
 
         // Create SnapshotParameters with scaling
         SnapshotParameters snapshotParameters = new SnapshotParameters();
-        snapshotParameters.setTransform(Transform.scale(scaleFactor, scaleFactor));
-        snapshotParameters.setFill(Color.TRANSPARENT);
 
         // Create a WritableImage with the scaled dimensions
         WritableImage writableImage = new WritableImage(width, height);

--- a/framework/src/main/java/dev/ikm/komet/framework/dnd/DragImageMaker.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/dnd/DragImageMaker.java
@@ -116,7 +116,7 @@ public class DragImageMaker implements DraggableWithImage {
         final int width = (int) Math.max(Math.ceil(scaledWidth), 1);
         final int height = (int) Math.max(Math.ceil(scaledHeight), 1);
 
-        // Create SnapshotParameters with scaling
+        // Create SnapshotParameters without scaling
         SnapshotParameters snapshotParameters = new SnapshotParameters();
 
         // Create a WritableImage with the scaled dimensions


### PR DESCRIPTION
https://ikmdev.atlassian.net/browse/IIA-852

JPro's fix did show the search result while dragging but it scaled the draggable image (search result) larger.  This preserves the original size and the drop to the large drop area still works as expected.

![image](https://github.com/user-attachments/assets/b88c3ffa-df2a-4ea9-a44d-ff8441ac6efd)

![image](https://github.com/user-attachments/assets/8819d6c0-64e9-47e9-b547-ab05d5afaf20)


