### PR TITLE
Bugfix / JPRO-67 Update JPro Server Stop Command for DEV Mode Following JPro Maven Plugin Profile Configuration Change

### DIFF
--- a/application/src/main/java/dev/ikm/komet/app/WebApp.java
+++ b/application/src/main/java/dev/ikm/komet/app/WebApp.java
@@ -1146,11 +1146,11 @@ public class WebApp extends Application {
             final String[] stopScriptArgs;
             final CommandRunner stopCommandRunner;
             final File workingDir;
-            if ("dev".equals(jproMode)) {
+            if ("dev".equalsIgnoreCase(jproMode)) {
                 workingDir = new File(System.getProperty("user.dir")).getParentFile();
                 stopScriptArgs = PlatformUtils.isWindows() ?
-                        new String[]{"cmd", "/c", "mvnw.bat", "-f", "application", "jpro:stop"} :
-                        new String[]{"bash", "./mvnw", "-f", "application", "jpro:stop"};
+                        new String[]{"cmd", "/c", "mvnw.bat", "-f", "application", "-Pjpro", "jpro:stop"} :
+                        new String[]{"bash", "./mvnw", "-f", "application", "-Pjpro", "jpro:stop"};
                 stopCommandRunner = new CommandRunner(stopScriptArgs);
             } else {
                 workingDir = new File("bin");


### PR DESCRIPTION
**Background:** Komet utilizes the JPro Server for running JavaFX applications in a web environment, managed through the JPro Maven Plugin. Recently, the JPro Maven Plugin configuration was updated to use profile configurations.

**Issue:** After changing the JPro Maven Plugin to use profile configurations, the command responsible for stopping the JPro Server in DEV mode is no longer functioning as expected.

**Proposed Solution:** Update the JPro Server stop command configuration to align with the new profile-based setup of the JPro Maven Plugin.