### PR TITLE
Feature / JPRO-65 Integrate CSSFX for Real-Time CSS Reloading

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -115,10 +115,13 @@
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-fxml -->
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>one.jpro.platform.jpms</groupId>
+            <artifactId>cssfx</artifactId>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.dlsc.gemsfx/gemsfx -->
         <dependency>

--- a/application/src/main/java/dev/ikm/komet/app/App.java
+++ b/application/src/main/java/dev/ikm/komet/app/App.java
@@ -40,8 +40,6 @@ import dev.ikm.komet.framework.window.WindowComponent;
 import dev.ikm.komet.framework.window.WindowSettings;
 import dev.ikm.komet.kview.events.CreateJournalEvent;
 import dev.ikm.komet.kview.events.JournalTileEvent;
-import dev.ikm.komet.kview.fxutils.ResourceHelper;
-import dev.ikm.komet.kview.mvvm.view.BasicController;
 import dev.ikm.komet.kview.mvvm.view.export.ExportController;
 import dev.ikm.komet.kview.mvvm.view.journal.JournalController;
 import dev.ikm.komet.kview.mvvm.view.journal.JournalViewFactory;
@@ -71,7 +69,6 @@ import javafx.event.ActionEvent;
 import javafx.fxml.FXMLLoader;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
-import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.input.KeyCode;
@@ -105,12 +102,11 @@ import java.util.function.Consumer;
 import java.util.prefs.BackingStoreException;
 
 import static dev.ikm.komet.app.AppState.*;
+import static dev.ikm.komet.app.util.CssUtils.*;
 import static dev.ikm.komet.framework.KometNodeFactory.KOMET_NODES;
 import static dev.ikm.komet.framework.window.WindowSettings.Keys.*;
 import static dev.ikm.komet.kview.events.EventTopics.JOURNAL_TOPIC;
 import static dev.ikm.komet.kview.events.JournalTileEvent.UPDATE_JOURNAL_TILE;
-import static dev.ikm.komet.kview.fxutils.CssHelper.defaultStyleSheet;
-import static dev.ikm.komet.kview.fxutils.CssHelper.refreshPanes;
 import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.VIEW_PROPERTIES;
 import static dev.ikm.komet.preferences.JournalWindowPreferences.*;
 import static dev.ikm.komet.preferences.JournalWindowSettings.*;
@@ -123,12 +119,10 @@ public class App extends Application {
     private static final String OS_NAME_MAC = "mac";
 
     private static final Logger LOG = LoggerFactory.getLogger(App.class);
-    public static final String CSS_LOCATION = "dev/ikm/komet/framework/graphics/komet.css";
     public static final SimpleObjectProperty<AppState> state = new SimpleObjectProperty<>(STARTING);
     private static Stage primaryStage;
 
     private static Stage classicKometStage;
-    private static Module graphicsModule;
     private static long windowCount = 1;
     private static KometPreferencesStage kometPreferencesStage;
 
@@ -258,10 +252,6 @@ public class App extends Application {
 //        logDirectory.mkdirs();
         LOG.info("Starting Komet");
         LoadFonts.load();
-        graphicsModule = ModuleLayer.boot()
-                .findModule("dev.ikm.komet.framework")
-                // Optional<Module> at this point
-                .orElseThrow();
 
         // get the instance of the event bus
         kViewEventBus = EvtBusFactory.getInstance(EvtBus.class);
@@ -364,11 +354,8 @@ public class App extends Application {
             SelectDataSourceController selectDataSourceController = sourceLoader.getController();
             selectDataSourceController.getCancelButton().setOnAction(actionEvent -> Platform.exit());
             Scene sourceScene = new Scene(sourceRoot);
+            addStylesheets(sourceScene, KOMET_CSS, KVIEW_CSS);
 
-
-            sourceScene.getStylesheets()
-
-                    .add(graphicsModule.getClassLoader().getResource(CSS_LOCATION).toString());
             stage.setScene(sourceScene);
             stage.setTitle("KOMET Startup");
 
@@ -393,7 +380,6 @@ public class App extends Application {
             stage.show();
             state.set(AppState.SELECT_DATA_SOURCE);
             state.addListener(this::appStateChangeListener);
-
         } catch (IOException e) {
             LOG.error(e.getLocalizedMessage(), e);
             Platform.exit();
@@ -438,13 +424,6 @@ public class App extends Application {
             LandingPageController landingPageController = landingPageLoader.getController();
             Scene sourceScene = new Scene(landingPageBorderPane, 1200, 800);
 
-            // Add Komet.css and kview css
-            sourceScene.getStylesheets().addAll(
-                    graphicsModule.getClassLoader().getResource(CSS_LOCATION).toString(), defaultStyleSheet());
-
-            // Attach a listener to provide a CSS refresher ability for each Journal window. Right double click settings button (gear)
-            attachCSSRefresher(landingPageController.getSettingsToggleButton(), landingPageBorderPane);
-
             kViewStage.setScene(sourceScene);
             kViewStage.setTitle("Landing Page");
 
@@ -488,13 +467,7 @@ public class App extends Application {
             BorderPane journalBorderPane = journalLoader.load();
             journalController = journalLoader.getController();
             Scene sourceScene = new Scene(journalBorderPane, 1200, 800);
-
-            // Add Komet.css and kview css
-            sourceScene.getStylesheets().addAll(
-                    graphicsModule.getClassLoader().getResource(CSS_LOCATION).toString(), defaultStyleSheet());
-
-            // Attach a listener to provide a CSS refresher ability for each Journal window. Right double click settings button (gear)
-            attachCSSRefresher(journalController.getSettingsToggleButton(), journalController.getJournalBorderPane());
+            addStylesheets(sourceScene, KOMET_CSS, KVIEW_CSS);
 
             journalStageWindow.setScene(sourceScene);
 
@@ -604,64 +577,6 @@ public class App extends Application {
         }
     }
 
-
-    /**
-     * This attaches a listener for the right mouse double click to refresh CSS stylesheet files.
-     * @param node The node the user will right mouse button double click
-     * @param root The root Parent node to refresh CSS stylesheets.
-     */
-    private void attachCSSRefresher(Node node, Parent root) {
-        // CSS refresher 'easter egg'. Right Click settings button to refresh Css Styling
-        node.addEventHandler(MouseEvent.MOUSE_PRESSED, mouseEvent -> {
-            if (mouseEvent.getClickCount() == 2 && mouseEvent.isSecondaryButtonDown()) {
-                handleRefreshUserCss(root);
-            }
-        });
-    }
-
-    /**
-     * Will refresh a parent root node and all children that have CSS stylesheets.
-     * komet.css and kview.css files are updated dynamically.
-     * @param root Parent node to be traversed to refresh all stylesheets.
-     */
-    private void handleRefreshUserCss(Parent root) {
-        try {
-            // "Feature" to make css editing/testing easy in the dev environment.
-            // Komet CSS file
-            String frameworkResourcesDir = System.getProperty("user.dir").replace("/application", "/framework/src/main/resources");
-            String kometCssSourcePath = frameworkResourcesDir + ResourceHelper.toAbsolutePath("komet.css", Icon.class);
-            File kometCssSourceFile = new File(kometCssSourcePath);
-
-            // kView CSS file
-            String kViewResourcesDir = System.getProperty("user.dir").replace("/application", "/kview/src/main/resources");
-            String kViewCssSourcePath = kViewResourcesDir + ResourceHelper.toAbsolutePath("kview.css", BasicController.class);
-            File kviewCssSourceFile = new File(kViewCssSourcePath);
-
-            LOG.info("File exists? {}, komet css path = {}", kometCssSourceFile.exists(), kometCssSourceFile);
-            LOG.info("File exists? {}, kview css path = {}", kviewCssSourceFile.exists(), kviewCssSourceFile);
-
-            // ensure both exist on the development environment path
-            if (kometCssSourceFile.exists() && kviewCssSourceFile.exists()) {
-                Scene scene = root.getScene();
-
-                // Apply Komet css
-                scene.getStylesheets().clear();
-                scene.getStylesheets().add(kometCssSourceFile.toURI().toURL().toString());
-
-                // Recursively refresh any children using the kView css files.
-                refreshPanes(root, kviewCssSourceFile.toURI().toURL().toString());
-
-                LOG.info("Updated komet.css file: {}", kometCssSourceFile.getAbsolutePath());
-                LOG.info("Updated kview.css file: {}", kviewCssSourceFile.getAbsolutePath());
-            } else {
-                LOG.info("File not found for komet.css: {}", kometCssSourceFile.getAbsolutePath());
-            }
-        } catch (IOException e) {
-            // TODO: Raise an alert
-            LOG.error("Error refreshing CSS files", e);
-        }
-    }
-
     @Override
     public void stop() {
         LOG.info("Stopping application\n\n###############\n\n");
@@ -755,8 +670,7 @@ public class App extends Application {
 
         //Loading/setting the Komet screen
         Scene kometScene = new Scene(kometRoot, 1800, 1024);
-        kometScene.getStylesheets()
-                .add(graphicsModule.getClassLoader().getResource(CSS_LOCATION).toString());
+        addStylesheets(kometScene, KOMET_CSS);
 
         // if NOT on Mac OS
         if(System.getProperty("os.name")!=null && !System.getProperty("os.name").toLowerCase().startsWith(OS_NAME_MAC)) {

--- a/application/src/main/java/dev/ikm/komet/app/util/CssUtils.java
+++ b/application/src/main/java/dev/ikm/komet/app/util/CssUtils.java
@@ -1,0 +1,203 @@
+package dev.ikm.komet.app.util;
+
+import fr.brouillard.oss.cssfx.CSSFX;
+import fr.brouillard.oss.cssfx.api.URIToPathConverter;
+import javafx.scene.Scene;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.nio.file.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility interface for managing and applying CSS stylesheets.
+ * <p>
+ * This interface provides static methods to add CSS stylesheets to JavaFX scenes.
+ * It attempts to load CSS files from the local file system for development purposes
+ * and falls back to the JRT (Java Runtime) file system for production environments.
+ * Additionally, it integrates with CSSFX to enable live-reloading of CSS files during development.
+ * </p>
+ * <p>
+ * Supported CSS files are declared as constants within this interface. To add more CSS files,
+ * declare additional constants and update the relevant methods accordingly.
+ * </p>
+ *
+ * <p><strong>Usage Example:</strong></p>
+ * <pre>{@code
+ * import dev.ikm.komet.app.util.CssUtils;
+ * import javafx.scene.Scene;
+ * import javafx.scene.layout.BorderPane;
+ *
+ * // ...
+ *
+ * BorderPane root = new BorderPane();
+ * Scene scene = new Scene(root, 800, 600);
+ *
+ * // Apply CSS stylesheets
+ * CssUtils.addStylesheets(scene, CssUtils.KOMET_CSS, CssUtils.KVIEW_CSS);
+ *
+ * // Set up and show the stage
+ * primaryStage.setScene(scene);
+ * primaryStage.show();
+ * }</pre>
+ */
+public interface CssUtils {
+
+    Logger LOG = LoggerFactory.getLogger(CssUtils.class);
+
+    // Constants for CSS file names
+    String KOMET_CSS = "komet.css";
+    String KVIEW_CSS = "kview.css";
+
+    /**
+     * Adds the specified CSS files to the given JavaFX Scene. It attempts to load them from the local file system
+     * for development mode and falls back to the JRT file system for production mode. Also sets up CSSFX for live-reloading.
+     *
+     * @param scene    The JavaFX Scene to which the stylesheets will be added.
+     * @param cssFiles Variable number of CSS file names to be added.
+     */
+    static void addStylesheets(Scene scene, String... cssFiles) {
+        final String workingDir = System.getProperty("user.dir");
+        final Path workingDirPath = Paths.get(workingDir);
+
+        final Path frameworkResourcesDir = workingDirPath.resolveSibling("framework/src/main/resources");
+        final Path kviewResourcesDir = workingDirPath.resolveSibling("kview/src/main/resources");
+
+        List<String> cssUris = new ArrayList<>();
+        boolean loadedFromFileSystem = false;
+
+        for (String cssFile : cssFiles) {
+            Path cssPath = determineCssPath(cssFile, frameworkResourcesDir, kviewResourcesDir);
+
+            if (cssPath != null && Files.exists(cssPath)) {
+                String cssUri = cssPath.toUri().toString();
+                cssUris.add(cssUri);
+                loadedFromFileSystem = true;
+                LOG.info("Loaded CSS from local file system: {}", cssUri);
+            } else {
+                // Attempt to load from JRT (production mode)
+                String moduleName = getModuleNameForCss(cssFile);
+                String resourcePath = getResourcePathForCss(cssFile);
+
+                if (moduleName != null && resourcePath != null) {
+                    try {
+                        FileSystem jrtFileSystem = FileSystems.getFileSystem(URI.create("jrt:/"));
+                        Path cssResourcePathInJrt = jrtFileSystem.getPath("/modules", moduleName, resourcePath);
+                        if (Files.exists(cssResourcePathInJrt)) {
+                            String cssResourceUri = cssResourcePathInJrt.toUri().toString();
+                            cssUris.add(cssResourceUri);
+                            LOG.info("Loaded CSS from JRT file system: {}", cssResourceUri);
+                        } else {
+                            LOG.warn("CSS file '{}' not found in JRT file system at '{}'", cssFile, cssResourcePathInJrt);
+                        }
+                    } catch (FileSystemNotFoundException e) {
+                        LOG.warn("Error accessing JRT file system for CSS file '{}': {}", cssFile, e.getMessage());
+                    }
+                } else {
+                    LOG.warn("No module mapping found for CSS file '{}'", cssFile);
+                }
+            }
+        }
+
+        if (!cssUris.isEmpty()) {
+            scene.getStylesheets().addAll(cssUris);
+        }
+
+        if (loadedFromFileSystem) {
+            setupCssMonitor(cssFiles, frameworkResourcesDir, kviewResourcesDir);
+        }
+    }
+
+    /**
+     * Determines the file system path of the CSS file based on its name.
+     *
+     * @param cssFile               The name of the CSS file.
+     * @param frameworkResourcesDir The framework resources directory.
+     * @param kviewResourcesDir     The kview resources directory.
+     * @return The Path to the CSS file, or null if the file name is unrecognized.
+     */
+    private static Path determineCssPath(String cssFile, Path frameworkResourcesDir, Path kviewResourcesDir) {
+        return switch (cssFile) {
+            case KOMET_CSS -> frameworkResourcesDir.resolve(
+                    Paths.get("dev", "ikm", "komet", "framework", "graphics", KOMET_CSS));
+            case KVIEW_CSS -> kviewResourcesDir.resolve(
+                    Paths.get("dev", "ikm", "komet", "kview", "mvvm", "view", KVIEW_CSS));
+            // Add more cases here for additional CSS files
+            default -> {
+                LOG.warn("Unknown CSS file '{}', unable to determine path", cssFile);
+                yield null;
+            }
+        };
+    }
+
+    /**
+     * Returns the module name associated with the given CSS file.
+     *
+     * @param cssFile The name of the CSS file.
+     * @return The module name, or null if the file name is unrecognized.
+     */
+    private static String getModuleNameForCss(String cssFile) {
+        return switch (cssFile) {
+            case KOMET_CSS -> "dev.ikm.komet.framework";
+            case KVIEW_CSS -> "dev.ikm.komet.kview";
+            // Add more cases here for additional CSS files
+            default -> {
+                LOG.warn("Unknown CSS file '{}', no module mapping", cssFile);
+                yield null;
+            }
+        };
+    }
+
+    /**
+     * Returns the resource path within the module for the given CSS file.
+     *
+     * @param cssFile The name of the CSS file.
+     * @return The resource path, or null if the file name is unrecognized.
+     */
+    private static String getResourcePathForCss(String cssFile) {
+        return switch (cssFile) {
+            case KOMET_CSS -> "dev/ikm/komet/framework/graphics/" + KOMET_CSS;
+            case KVIEW_CSS -> "dev/ikm/komet/kview/mvvm/view/" + KVIEW_CSS;
+            // Add more cases here for additional CSS files
+            default -> {
+                LOG.warn("Unknown CSS file '{}', no resource path mapping", cssFile);
+                yield null;
+            }
+        };
+    }
+
+    /**
+     * Sets up CSSFX to monitor CSS changes in development mode.
+     *
+     * @param cssFiles              The list of CSS file names.
+     * @param frameworkResourcesDir The framework resources directory.
+     * @param kviewResourcesDir     The kview resources directory.
+     */
+    private static void setupCssMonitor(String[] cssFiles, Path frameworkResourcesDir, Path kviewResourcesDir) {
+        final URIToPathConverter myCssConverter = uri -> {
+            for (String cssFile : cssFiles) {
+                if (uri.contains(cssFile)) {
+                    Path cssPath = switch (cssFile) {
+                        case KOMET_CSS: yield frameworkResourcesDir.resolve(
+                                Paths.get("dev", "ikm", "komet", "framework", "graphics", KOMET_CSS));
+                        case KVIEW_CSS: yield kviewResourcesDir.resolve(
+                                Paths.get("dev", "ikm", "komet", "kview", "mvvm", "view", KVIEW_CSS));
+                        // Add more cases here for additional CSS files
+                        default:
+                            LOG.warn("Unknown CSS file '{}', unable to set up CSSFX converter", cssFile);
+                            yield null;
+                    };
+
+                    if (cssPath != null && Files.exists(cssPath)) {
+                        return cssPath;
+                    }
+                }
+            }
+            return null;
+        };
+
+        CSSFX.addConverter(myCssConverter).start();
+    }
+}

--- a/application/src/main/java/module-info.java
+++ b/application/src/main/java/module-info.java
@@ -26,6 +26,7 @@ import dev.ikm.tinkar.entity.StampService;
 module dev.ikm.komet.application {
 
     exports dev.ikm.komet.app;
+    exports dev.ikm.komet.app.util;
     opens dev.ikm.komet.app to javafx.fxml;
 
     // TODO Not happy that I have to specify these here... Can't dynamically add modules?
@@ -43,6 +44,7 @@ module dev.ikm.komet.application {
     requires javafx.controls;
     requires javafx.fxml;
     requires nsmenufx;
+    requires fr.brouillard.oss.cssfx;
     requires org.carlfx.cognitive;
     requires org.controlsfx.controls;
     requires dev.ikm.komet.classification;

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -4305,8 +4305,8 @@ Styling a context menu for kview ui/ux controls
     -fx-text-fill: black;
     -width: 348px;
     -fx-pref-width: -width;
-    -fx-min-width:width;
-    -fx-max-width:width;
+    -fx-min-width: -width;
+    -fx-max-width: -width;
     -fx-background-color: white;
     -fx-font-family: "Noto Sans";
     -fx-font-size: 12px;

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <axonic.version>1.1.4</axonic.version>
         <common-java5.version>3.0.0-M9</common-java5.version>
         <controlsfx.version>11.1.0</controlsfx.version>
+        <cssfx.version>11.5.1-jpms</cssfx.version>
         <ikonli.version>12.2.0</ikonli.version>
         <javafx-maven-plugin.version>0.0.8</javafx-maven-plugin.version>
         <jpackage.version>1.6.0</jpackage.version>
@@ -348,24 +349,25 @@
                 <artifactId>axonic</artifactId>
                 <version>${axonic.version}</version>
             </dependency>
-            <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-fxml -->
             <dependency>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-fxml</artifactId>
                 <version>${openjfx.version}</version>
             </dependency>
-            <!-- https://mvnrepository.com/artifact/com.dlsc.gemsfx/gemsfx -->
-            <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-web -->
             <dependency>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-web</artifactId>
                 <version>${openjfx.version}</version>
             </dependency>
-            <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-swing -->
             <dependency>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-swing</artifactId>
                 <version>${openjfx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>one.jpro.platform.jpms</groupId>
+                <artifactId>cssfx</artifactId>
+                <version>${cssfx.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.classgraph</groupId>


### PR DESCRIPTION
CSSFX enhances developer productivity by providing CSS reloading functionality in the running application.

During development, developers can run the application, modify CSS sources in their preferred editor, and upon saving (`CTRL+S` or `CMD+S`), the application updates in real time. **CSSFX monitoring is active exclusively in the development environment**, ensuring that live CSS reloading does not affect the performance or stability of the production/release build. This integration will streamline the UI development process by enabling instant visualization of CSS changes without restarting the application, thereby improving efficiency and accelerating design iterations.

The provided solution works on desktop and on the web when running with JPro.