### PR TITLE
Feature / JPRO-66 Push JPro Dependencies to Maven Central

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -90,7 +90,7 @@
         </dependency>
         <!-- Start JPro related dependencies -->
         <dependency>
-            <groupId>com.sandec.jpro</groupId>
+            <groupId>one.jpro</groupId>
             <artifactId>jpro-webapi</artifactId>
             <scope>compile</scope>
         </dependency>
@@ -481,6 +481,18 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>jpro-repository</id>
+                    <url>https://sandec.jfrog.io/artifactory/repo</url>
+                </pluginRepository>
+            </pluginRepositories>
+            <repositories>
+                <repository>
+                    <id>jpro-repository</id>
+                    <url>https://sandec.jfrog.io/artifactory/repo</url>
+                </repository>
+            </repositories>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -83,11 +83,10 @@
         <jsr305.version>3.0.2-r7</jsr305.version>
 
         <!-- JPRO Variables -->
-        <jpro.ikmdev.release>ikmdev</jpro.ikmdev.release>
-        <jpro.version>2024.3.4-${jpro.ikmdev.release}</jpro.version>
-        <jpro-platform.version>0.4.3</jpro-platform.version>
+        <jpro.version>2024.4.1</jpro.version>
+        <jpro-platform.version>0.4.4</jpro-platform.version>
         <!-- A special build for Komet using the ikmdev Guava module name -->
-        <jpro-auth-core.version>${jpro-platform.version}-${jpro.ikmdev.release}</jpro-auth-core.version>
+        <jpro-auth-core.version>${jpro-platform.version}-ikmdev</jpro-auth-core.version>
 
         <!-- TestFX Variables -->
         <testfx.version>4.0.18-jpms</testfx.version>
@@ -111,18 +110,6 @@
         <scenic-view.version>11.0.2</scenic-view.version>
     </properties>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>jpro-repository</id>
-            <url>https://sandec.jfrog.io/artifactory/repo</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <repositories>
-        <repository>
-            <id>jpro-repository</id>
-            <url>https://sandec.jfrog.io/artifactory/repo</url>
-        </repository>
-    </repositories>
     <dependencyManagement>
         <dependencies>
             <!--Module Dependencies -->
@@ -375,7 +362,7 @@
                 <version>${classgraph.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.sandec.jpro</groupId>
+                <groupId>one.jpro</groupId>
                 <artifactId>jpro-webapi</artifactId>
                 <version>${jpro.version}</version>
             </dependency>


### PR DESCRIPTION
Ensure that all necessary JPro-related libraries required for the Komet project are available on Maven Central.