### PR TITLE
bugfix/IIA-994-dnd-notworking-post-merge

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/navigation/ConceptPatternNavController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/navigation/ConceptPatternNavController.java
@@ -218,8 +218,7 @@ public class ConceptPatternNavController {
                             }
                         }
                     });
-                    PatternEntity patternEntity = EntityService.get().getEntityFast(patternItem.nid());
-                    setUpDraggable(patternHBox, patternEntity, PATTERN);
+                    setUpDraggable(patternHBox, patternItem, PATTERN);
 
                     patternsVBox.getChildren().addAll(new HBox(leftPadding, patternHBox));
                     // set the pattern's name
@@ -322,7 +321,7 @@ public class ConceptPatternNavController {
         });
     }
 
-    private void setUpDraggable(Node node, Entity<?> entity, DragAndDropType dropType) {
+    private void setUpDraggable(Node node, EntityFacade entity, DragAndDropType dropType) {
         Objects.requireNonNull(node, "The node must not be null.");
         Objects.requireNonNull(entity, "The entity must not be null.");
 

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/InstancesController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/InstancesController.java
@@ -44,7 +44,7 @@ public class InstancesController {
     private void loadInstances() {
         // load the pattern instances into an observable list
         ObservableList<Object> patternChildren = FXCollections.observableArrayList();
-        Entity patternItem = patternViewModel.getPropertyValue(PATTERN);
+        EntityFacade patternItem = patternViewModel.getPropertyValue(PATTERN);
         setMetaTitle(patternItem.description());
         int patternNid = patternItem.nid();
         AtomicInteger childCount = new AtomicInteger();


### PR DESCRIPTION
both double click and drag and drop pattern summoning are working

![image](https://github.com/user-attachments/assets/7d040a15-0517-4c2d-af72-bbf11cc7c031)

also check that existing concept drag and drop is working:
![image](https://github.com/user-attachments/assets/701f160c-d66d-4286-9e43-4c2e79ddef78)

next gen dnd still working:
![image](https://github.com/user-attachments/assets/51dc5d7a-129e-4e93-b8d5-dff99ebc7800)

right click populate on next gen search still working:
![image](https://github.com/user-attachments/assets/9288d0df-b05d-45c0-8cc0-7aacc8698985)


