### PR TITLE
BugFix/IIA-1136: Shrinking a window can make its contents get cut out

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/lidr/mvvm/view/details/LidrDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/lidr/mvvm/view/details/LidrDetailsController.java
@@ -33,6 +33,7 @@ import dev.ikm.komet.kview.lidr.mvvm.view.properties.PropertiesController;
 import dev.ikm.komet.kview.lidr.mvvm.viewmodel.AnalyteGroupViewModel;
 import dev.ikm.komet.kview.lidr.mvvm.viewmodel.LidrViewModel;
 import dev.ikm.komet.kview.mvvm.model.DescrName;
+import dev.ikm.komet.kview.mvvm.view.journal.VerticallyFilledPane;
 import dev.ikm.komet.kview.mvvm.view.stamp.StampEditController;
 import dev.ikm.komet.kview.mvvm.view.timeline.TimelineController;
 import dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel;
@@ -193,10 +194,10 @@ public class LidrDetailsController {
      * Used slide out the properties view
      */
     @FXML
-    private Pane propertiesSlideoutTrayPane;
+    private VerticallyFilledPane propertiesSlideoutTrayPane;
 
     @FXML
-    private Pane timelineSlideoutTrayPane;
+    private VerticallyFilledPane timelineSlideoutTrayPane;
 
     /**
      * A function from the caller. This class passes a boolean true if classifier button is pressed invoke caller's function to be returned a view.
@@ -430,13 +431,8 @@ public class LidrDetailsController {
         clipChildren(slideoutTrayPane, 0);
         contentViewPane.setLayoutX(-width);
         slideoutTrayPane.setMaxWidth(0);
-
-        Region contentRegion = contentViewPane;
-        // binding the child's height to the preferred height of hte parent
-        // so that when we resize the window the content in the slide out pane
-        // aligns with the details view
-        contentRegion.prefHeightProperty().bind(slideoutTrayPane.heightProperty());
     }
+
     private Consumer<LidrDetailsController> onCloseConceptWindow;
     public void setOnCloseConceptWindow(Consumer<LidrDetailsController> onClose) {
         this.onCloseConceptWindow = onClose;

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
@@ -28,6 +28,7 @@ import dev.ikm.komet.kview.events.*;
 import dev.ikm.komet.kview.fxutils.MenuHelper;
 import dev.ikm.komet.kview.mvvm.model.DataModelHelper;
 import dev.ikm.komet.kview.mvvm.model.DescrName;
+import dev.ikm.komet.kview.mvvm.view.journal.VerticallyFilledPane;
 import dev.ikm.komet.kview.mvvm.view.stamp.StampEditController;
 import dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel;
 import dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel;
@@ -206,10 +207,10 @@ public class DetailsController  {
      * Used slide out the properties view
      */
     @FXML
-    private Pane propertiesSlideoutTrayPane;
+    private VerticallyFilledPane propertiesSlideoutTrayPane;
 
     @FXML
-    private Pane timelineSlideoutTrayPane;
+    private VerticallyFilledPane timelineSlideoutTrayPane;
 
     @FXML
     private ContextMenu reasonerContextMenu;
@@ -595,13 +596,8 @@ public class DetailsController  {
         clipChildren(slideoutTrayPane, 0);
         contentViewPane.setLayoutX(-width);
         slideoutTrayPane.setMaxWidth(0);
-
-        Region contentRegion = contentViewPane;
-        // binding the child's height to the preferred height of hte parent
-        // so that when we resize the window the content in the slide out pane
-        // aligns with the details view
-        contentRegion.prefHeightProperty().bind(slideoutTrayPane.heightProperty());
     }
+
     private Consumer<DetailsController> onCloseConceptWindow;
     public void setOnCloseConceptWindow(Consumer<DetailsController> onClose) {
         this.onCloseConceptWindow = onClose;

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/VerticallyFilledPane.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/VerticallyFilledPane.java
@@ -6,9 +6,14 @@ import javafx.scene.layout.Pane;
 
 /**
  * VerticallyFilledPane works like Pane, it doesn't do any positioning of its children, only resizing.
+ * Use case: The algorithm for the Tray Panes of Komet relies on the use of a layout container like Pane and its characteristic
+ * of allowing children to be positioned outside its bounds (because it doesn't do any positioning). This class goes a step
+ * further and provides other useful features for the Tray Pane that JavaFX Pane does not have.
+ *
  * The difference from Pane is that when resizing its children it sets their height so that they occupy the whole height of the
  * VerticallyFilledPane. The width of each child is set to their preferred width.
- * Use case: this "Layout container" was created to be used in Tray Panes so that he content fills the Tray Pane.
+ * Another thing VerticallyFilledPane does differently from Pane is to compute its min height and set it to be the maximum
+ * min height of all of its children.
  */
 public class VerticallyFilledPane extends Pane {
 
@@ -24,5 +29,18 @@ public class VerticallyFilledPane extends Pane {
                 node.resize(width, paneHeight);
             }
         }
+    }
+
+    @Override
+    protected double computeMinHeight(double width) {
+        if (getChildren().isEmpty()) {
+            return 0;
+        }
+
+        double minHeight = 0;
+        for (Node child : getChildren()) {
+            minHeight = Math.max(child.minHeight(width), minHeight);
+        }
+        return minHeight;
     }
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PatternDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PatternDetailsController.java
@@ -77,6 +77,7 @@ import dev.ikm.komet.kview.fxutils.MenuHelper;
 import dev.ikm.komet.kview.mvvm.model.DescrName;
 import dev.ikm.komet.kview.mvvm.model.PatternDefinition;
 import dev.ikm.komet.kview.mvvm.model.PatternField;
+import dev.ikm.komet.kview.mvvm.view.journal.VerticallyFilledPane;
 import dev.ikm.komet.kview.mvvm.view.stamp.StampEditController;
 import dev.ikm.komet.kview.mvvm.viewmodel.PatternViewModel;
 import dev.ikm.tinkar.coordinate.view.calculator.ViewCalculator;
@@ -155,10 +156,10 @@ public class PatternDetailsController {
      * Used slide out the properties view
      */
     @FXML
-    private Pane propertiesSlideoutTrayPane;
+    private VerticallyFilledPane propertiesSlideoutTrayPane;
 
     @FXML
-    private Pane timelineSlideoutTrayPane;
+    private VerticallyFilledPane timelineSlideoutTrayPane;
 
     @FXML
     private Label patternTitleText;
@@ -859,14 +860,7 @@ public class PatternDetailsController {
         clipChildren(slideoutTrayPane, 0);
         contentViewPane.setLayoutX(-width);
         slideoutTrayPane.setMaxWidth(0);
-
-        Region contentRegion = contentViewPane;
-        // binding the child's height to the preferred height of hte parent
-        // so that when we resize the window the content in the slide out pane
-        // aligns with the details view
-        contentRegion.prefHeightProperty().bind(slideoutTrayPane.heightProperty());
     }
-
 
     public void putTitlePanesArrowOnRight() {
         putArrowOnRight(this.patternDefinitionTitledPane);

--- a/kview/src/main/resources/dev/ikm/komet/kview/lidr/mvvm/view/details/lidr-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/lidr/mvvm/view/details/lidr-details.fxml
@@ -33,6 +33,7 @@
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
 
+<?import dev.ikm.komet.kview.mvvm.view.journal.VerticallyFilledPane?>
 <BorderPane fx:id="detailsOuterBorderPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="560.0" prefWidth="727.0" stylesheets="@../../../../mvvm/view/kview.css" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.lidr.mvvm.view.details.LidrDetailsController">
    <center>
       <BorderPane fx:id="detailsCenterBorderPane" prefWidth="762.0">
@@ -152,8 +153,8 @@
          <right>
             <HBox styleClass="main-right-container" BorderPane.alignment="CENTER">
                <children>
-                  <Pane fx:id="propertiesSlideoutTrayPane" styleClass="slideout-tray-pane" />
-                  <Pane fx:id="timelineSlideoutTrayPane" styleClass="slideout-tray-pane" />
+                  <VerticallyFilledPane fx:id="propertiesSlideoutTrayPane" styleClass="slideout-tray-pane" />
+                  <VerticallyFilledPane fx:id="timelineSlideoutTrayPane" styleClass="slideout-tray-pane" />
                </children>
             </HBox>
          </right>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/details/concept-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/details/concept-details.fxml
@@ -37,6 +37,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
+<?import dev.ikm.komet.kview.mvvm.view.journal.VerticallyFilledPane?>
 
 <BorderPane fx:id="detailsOuterBorderPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="650.0" prefWidth="727.0" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
    <center>
@@ -140,8 +141,8 @@
          <right>
             <HBox styleClass="main-right-container" BorderPane.alignment="CENTER">
                <children>
-                  <Pane fx:id="propertiesSlideoutTrayPane" styleClass="slideout-tray-pane" />
-                  <Pane fx:id="timelineSlideoutTrayPane" styleClass="slideout-tray-pane" />
+                  <VerticallyFilledPane fx:id="propertiesSlideoutTrayPane" styleClass="slideout-tray-pane" />
+                  <VerticallyFilledPane fx:id="timelineSlideoutTrayPane" styleClass="slideout-tray-pane" />
                </children>
             </HBox>
          </right>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/pattern/pattern-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/pattern/pattern-details.fxml
@@ -36,6 +36,7 @@
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
 
+<?import dev.ikm.komet.kview.mvvm.view.journal.VerticallyFilledPane?>
 <BorderPane fx:id="detailsOuterBorderPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="560.0" prefWidth="727.0" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.pattern.PatternDetailsController">
    <center>
       <BorderPane fx:id="detailsCenterBorderPane" prefWidth="762.0">
@@ -160,8 +161,8 @@
          <right>
             <HBox styleClass="main-right-container" BorderPane.alignment="CENTER">
                <children>
-                  <Pane fx:id="propertiesSlideoutTrayPane" styleClass="slideout-tray-pane" />
-                  <Pane fx:id="timelineSlideoutTrayPane" styleClass="slideout-tray-pane" />
+                  <VerticallyFilledPane fx:id="propertiesSlideoutTrayPane" styleClass="slideout-tray-pane" />
+                  <VerticallyFilledPane fx:id="timelineSlideoutTrayPane" styleClass="slideout-tray-pane" />
                </children>
             </HBox>
          </right>


### PR DESCRIPTION
Fixes https://ikmdev.atlassian.net/browse/IIA-1136

## Some Remarks
There's a bunch of code duplication between Lidr, Pattern and Concept Window. This particular bug happens on all 3 windows and because of the code duplication had to be fixed using the same fix (same code) on 3 different places.

@carldea @dholubek @swaroopsalvi 
Perhaps it would be interesting to create a ticket to refactor these classes and remove the code duplication?

## Bug Description
### Actual Behavior

When shrinking a Window its contents can get cut out.

For example, when shrinking the Concept Window the buttons on the bottom of “Add Description: Fully Qualified Name” disappear (video bellow shows this issue happening). 

https://github.com/user-attachments/assets/f3881c41-f6b9-4ff5-b91c-53ea5996a9e0

This also happens for example in the “Add other name” pane and on Lidr Window when “Add/Edit” tab is selected.

This bug can happen on any type of Window (Concept or Lidr or Pattern) depending on the contents of the pane on its right. 


### Expected Behavior

Content of Window shouldn’t get cut out.

### Steps to Reproduce

1 - Click the plus bottom at the top and click to create new Concept Window
2- Click the Toggle Switch button so that “Add Description: Fully Qualified Name” is showing
3- Resize Window and shrink it vertically 
4 - There will be a point where the button at the bottom disappear.