### PR TITLE
BugFix/IIA-1140: Shrinking Window makes toggle buttons disappear

### DIFF
--- a/kview/src/main/resources/dev/ikm/komet/kview/lidr/mvvm/view/properties/lidr-properties.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/lidr/mvvm/view/properties/lidr-properties.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.shape.SVGPath?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="300.0" prefWidth="518.0" styleClass="properties-tab-outer-container" stylesheets="@../../../../mvvm/view/kview.css" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.lidr.mvvm.view.properties.PropertiesController">
+<BorderPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefWidth="518.0" styleClass="properties-tab-outer-container" stylesheets="@../../../../mvvm/view/kview.css" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.lidr.mvvm.view.properties.PropertiesController">
    <center>
       <BorderPane prefWidth="518.0" styleClass="properties-tab-container">
          <top>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/pattern/pattern-properties.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/pattern/pattern-properties.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.shape.SVGPath?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="300.0" prefWidth="518.0" styleClass="properties-tab-outer-container" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.pattern.PropertiesController">
+<BorderPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefWidth="518.0" styleClass="properties-tab-outer-container" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.pattern.PropertiesController">
    <center>
       <BorderPane prefWidth="518.0" styleClass="properties-tab-container">
          <top>


### PR DESCRIPTION
Fixes https://ikmdev.atlassian.net/browse/IIA-1140

### Actual Behavior 

When shrinking a Window (Concept window, Pattern or Lidr) the toggle buttons on the right can disappear. The video in the Jira ticket shows this problem happening.

### Expected Behavior

Toggle buttons on the right pane should stay in place, not move and not disappear when shrinking the Window

### Steps to Reproduce

1 - create Pattern Window

2 - expand the right pane of the Window

3 - select “comments” toggle

4 - Shrink window

5 - Toggles on the upper part of the right pane will disappear