### PR TITLE
BugFix/IIA-1150: Selecting the "Patterns" pane on the left makes the scrollbars in the desktop area disappear

### DIFF
--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/navigation/navigation-concept-pattern.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/navigation/navigation-concept-pattern.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<StackPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane maxHeight="-Infinity" maxWidth="-Infinity" minWidth="-Infinity" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
       <VBox fx:id="scrollPaneContent" maxHeight="1.7976931348623157E308" prefWidth="372.0" styleClass="grey-vertical-scroll-area">
          <children>
             <HBox alignment="CENTER" minHeight="-Infinity" prefHeight="56.0">


### PR DESCRIPTION
Fixes https://ikmdev.atlassian.net/browse/IIA-1150

### Actual Behavior

Selecting the "Patterns" pane on the left makes the scrollbars in the desktop area disappear.

### Expected Behavior

Selecting the “Patterns” pane should have no effect on the desktop area

### Steps to Reproduce

1 - double click a Journal to open a Journal Window

2 - click to open the Navigator tray pane

3 - select the “Patterns” toggle

The scrollbars on the desktop area will disappear (pictures attached show the before and after)

![image](https://github.com/user-attachments/assets/7fc6dd24-86a9-4e05-86a0-7e811d458d3f)
![image](https://github.com/user-attachments/assets/c2b63442-8749-4fc0-b92b-158be651aac3)
