### PR TITLE
BugFix/IIA-1165: Toggle Buttons on the left when starting Komet are misaligned, have inconsistent sizes, etc

### DIFF
--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -563,7 +563,7 @@
     -default-button-height: 56px;
     -default-button-width: -1;
 
-    -fx-alignment: top-center;
+    -fx-alignment: center-left;
     -fx-background-insets: 0;
     /*-fx-background-color: #F3F5F8FF;*/
     -fx-background-color: -Grey-11;
@@ -586,7 +586,7 @@
     -fx-background-color: transparent;
     -fx-background-insets: 0;
     -fx-background-radius: 0px, 0px, 0px, 0px;
-    -fx-padding: 16 12;
+    -fx-padding: 16 19 16 12;
     -fx-font-family: "Noto Sans";
     -fx-font-size: 14px;
     -fx-font-style: normal;
@@ -607,15 +607,43 @@
     -fx-content-display: left;
     -fx-graphic-text-gap: 8;
     -fx-min-width: -default-button-width;
-    -fx-pref-width: 144;
-    -fx-max-width: 144;
+    width: 152;
+    -fx-pref-width: width;
+    -fx-max-width: width;
 }
 
-/* all sidebar button regions are transparent */
+.side-bar .toggle-button .icon-container {
+    -fx-alignment: center-left;
+    -fx-spacing: 7px;
+}
+
+.side-bar .toggle-button .icon-container .icon-image-container {
+    -fx-min-width: 26px;
+    -fx-pref-width: 26px;
+}
+
+.side-bar .toggle-button .icon-container .label {
+    -fx-text-fill: white;
+}
+
+.side-bar .toggle-button:selected .icon-container .label {
+    -fx-text-fill: #111;
+}
+
 .side-bar .button .icon,
-.side-bar .toggle-button .icon
-{
+.side-bar .toggle-button .icon {
     -fx-background-color: -icon-paint;
+}
+
+.side-bar .toggle-button .icon,
+.side-bar .toggle-button .container-icon {
+    width: 20;
+    -fx-min-width: width;
+    -fx-pref-width: width;
+    -fx-max-width: width;
+
+    -fx-alignment: center;
+    -fx-position-shape: true;
 }
 
 
@@ -629,13 +657,23 @@ selected(active) - dark black
 /* Hover over tab button */
 .side-bar.show-text .toggle-button:selected,
 .side-bar.show-text .button:selected,
+.side-bar .toggle-button:selected,
+.side-bar .button:selected {
+    -fx-background-color: -Primary-05;
+}
+
+.side-bar.show-text .toggle-button:selected:hover,
+.side-bar.show-text .button:selected:hover,
+.side-bar .toggle-button:selected:hover,
+.side-bar .button:selected:hover{
+    -fx-background-color: derive(-Primary-05, 20%);
+}
+
 .side-bar.show-text .toggle-button:hover,
 .side-bar.show-text .button:hover,
-.side-bar .toggle-button:selected,
-.side-bar .button:selected,
 .side-bar .toggle-button:hover,
 .side-bar .button:hover {
-    -fx-background-color: -Primary-05;
+    -fx-background-color: rgba(100, 100, 100, 0.25);
 }
 
 /* Default */
@@ -667,12 +705,15 @@ selected(active) - dark black
 /* An Home svg (region) */
 .home {
     -width-size: 20;
-    -height-size: 17;
+    -height-size: 18;
     -fx-min-height: -height-size;
     -fx-min-width: -width-size;
     -fx-max-height: -height-size;
     -fx-max-width: -width-size;
     -fx-shape: "M10 3.19L15 7.69V15.5H13V9.5H7V15.5H5V7.69L10 3.19ZM10 0.5L0 9.5H3V17.5H9V11.5H11V17.5H17V9.5H20L10 0.5Z";
+
+    /* This icon shape is not correcly positioned so we need to correct that below */
+    -fx-translate-y: -1;
 }
 
 /* An Search svg (region) */
@@ -3283,16 +3324,24 @@ Landing page elements.
 
 /* label */
 .counter {
+    size: 16;
+    -fx-pref-width: size;
+    -fx-pref-height: size;
+
+    -fx-background-radius: 2em;
+    -fx-background-insets: 0;
+    -fx-background-color: -Accent-color-red;
+
+    -fx-translate-y: -2px;
+    -fx-translate-x: 4px;
+}
+
+.counter > .label {
     -fx-text-fill: -Grey-White;
-    -fx-label-padding: 2;
-    -fx-padding: 0 4 1 4;
     -fx-font-family: "Noto Sans";
     -fx-font-size: 11px;
     -fx-font-style: normal;
     -fx-font-weight: 700;
-    -fx-background-radius: 12;
-    -fx-background-color: -Accent-color-red;
-
 }
 
 .split-pane.flat-split-divider:horizontal > .split-pane-divider {

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/landingpage/landing-page.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/landingpage/landing-page.fxml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import java.lang.String?>
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
@@ -16,7 +17,6 @@
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
@@ -25,81 +25,112 @@
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
 
-<BorderPane fx:id="landingPageBorderPane" minHeight="0.0" minWidth="0.0" prefHeight="682.0" prefWidth="1035.0" styleClass="landing-container" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.landingpage.LandingPageController">
+<BorderPane fx:id="landingPageBorderPane" minHeight="0.0" minWidth="0.0" prefHeight="682.0" prefWidth="1035.0" styleClass="landing-container" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.landingpage.LandingPageController">
    <left>
       <VBox fillWidth="false" maxWidth="201.0" nodeOrientation="LEFT_TO_RIGHT" prefHeight="400.0" prefWidth="144.0" BorderPane.alignment="CENTER">
          <children>
-            <ToggleButton graphicTextGap="8.0" mnemonicParsing="false" selected="true" text="Home" textFill="#d3b5b5">
+            <ToggleButton mnemonicParsing="false" selected="true">
                <graphic>
-                  <Region>
-                     <styleClass>
-                        <String fx:value="icon" />
-                        <String fx:value="home" />
-                     </styleClass>
-                  </Region>
+                  <HBox styleClass="icon-container">
+                     <StackPane styleClass="icon-image-container">
+                        <Region>
+                           <styleClass>
+                              <String fx:value="icon" />
+                              <String fx:value="home" />
+                           </styleClass>
+                        </Region>
+                     </StackPane>
+                     <Label text="Home" />
+                  </HBox>
                </graphic>
                <toggleGroup>
                   <ToggleGroup fx:id="sidebarToggleGroup" />
                </toggleGroup>
             </ToggleButton>
-            <ToggleButton graphicTextGap="8.0" mnemonicParsing="false" text="Favorites" textFill="#d3b5b5" toggleGroup="$sidebarToggleGroup">
+            <ToggleButton mnemonicParsing="false" toggleGroup="$sidebarToggleGroup">
                <graphic>
-                  <Region>
-                     <styleClass>
-                        <String fx:value="icon" />
-                        <String fx:value="heart" />
-                     </styleClass>
-                  </Region>
+                  <HBox styleClass="icon-container">
+                     <StackPane styleClass="icon-image-container">
+                        <Region>
+                           <styleClass>
+                              <String fx:value="icon" />
+                              <String fx:value="heart" />
+                           </styleClass>
+                        </Region>
+                     </StackPane>
+                     <Label text="Favorites" />
+                  </HBox>
                </graphic>
             </ToggleButton>
-            <ToggleButton graphicTextGap="8.0" mnemonicParsing="false" text="Comments" textFill="#d3b5b5" toggleGroup="$sidebarToggleGroup">
+            <ToggleButton mnemonicParsing="false" toggleGroup="$sidebarToggleGroup">
                <graphic>
-                  <Region>
-                     <styleClass>
-                        <String fx:value="icon" />
-                        <String fx:value="comment" />
-                     </styleClass>
-                  </Region>
+                  <HBox styleClass="icon-container">
+                     <StackPane styleClass="icon-image-container">
+                        <Region>
+                           <styleClass>
+                              <String fx:value="icon" />
+                              <String fx:value="comment" />
+                           </styleClass>
+                        </Region>
+                     </StackPane>
+                     <Label text="Comments" />
+                  </HBox>
                </graphic>
             </ToggleButton>
-            <ToggleButton graphicTextGap="8.0" mnemonicParsing="false" text="Notifications" textFill="#d3b5b5" toggleGroup="$sidebarToggleGroup">
+            <ToggleButton mnemonicParsing="false" toggleGroup="$sidebarToggleGroup">
                <graphic>
-                  <Pane>
-                     <children>
+                  <HBox styleClass="icon-container">
+                     <StackPane styleClass="icon-image-container">
                         <Region>
                            <styleClass>
                               <String fx:value="icon" />
                               <String fx:value="notification" />
                            </styleClass>
                         </Region>
-                        <Label fx:id="notificationCounter" layoutX="6.0" layoutY="-9.0" styleClass="counter" text="4" textFill="#c39292" />
-                     </children>
-                  </Pane>
+                        <StackPane alignment="TOP_RIGHT" maxHeight="-Infinity" maxWidth="-Infinity" styleClass="counter" StackPane.alignment="TOP_RIGHT">
+                           <Label fx:id="notificationCounter" text="4" StackPane.alignment="CENTER" />
+                           <StackPane.margin>
+                              <Insets top="-8.0" />
+                           </StackPane.margin>
+                        </StackPane>
+                     </StackPane>
+                     <Label text="Notifications" />
+                  </HBox>
                </graphic>
             </ToggleButton>
             <VBox prefHeight="200.0" prefWidth="100.0" />
             <Region styleClass="flex-space" VBox.vgrow="ALWAYS" />
-            <ToggleButton fx:id="settingsToggleButton" mnemonicParsing="false" text="Settings" toggleGroup="$sidebarToggleGroup">
+            <ToggleButton fx:id="settingsToggleButton" mnemonicParsing="false" toggleGroup="$sidebarToggleGroup">
                <graphic>
-                  <Region prefHeight="200.0" prefWidth="200.0">
-                     <styleClass>
-                        <String fx:value="icon" />
-                        <String fx:value="settings" />
-                     </styleClass>
-                  </Region>
+                  <HBox styleClass="icon-container">
+                     <StackPane styleClass="icon-image-container">
+                        <Region>
+                           <styleClass>
+                              <String fx:value="icon" />
+                              <String fx:value="settings" />
+                           </styleClass>
+                        </Region>
+                     </StackPane>
+                     <Label text="Settings" />
+                  </HBox>
                </graphic>
             </ToggleButton>
-            <ToggleButton mnemonicParsing="false" text="Profile">
+            <ToggleButton mnemonicParsing="false">
                <toggleGroup>
                   <ToggleGroup fx:id="sidebarToggleGroup1" />
                </toggleGroup>
                <graphic>
-                  <Region prefHeight="200.0" prefWidth="200.0">
-                     <styleClass>
-                        <String fx:value="icon" />
-                        <String fx:value="avatar" />
-                     </styleClass>
-                  </Region>
+                  <HBox styleClass="icon-container">
+                     <StackPane styleClass="icon-image-container">
+                        <Region>
+                           <styleClass>
+                              <String fx:value="icon" />
+                              <String fx:value="avatar" />
+                           </styleClass>
+                        </Region>
+                     </StackPane>
+                     <Label text="Profile" />
+                  </HBox>
                </graphic>
             </ToggleButton>
          </children>


### PR DESCRIPTION
Fixes https://ikmdev.atlassian.net/browse/IIA-1165

### Actual Behavior

Toggle Buttons on the left when starting Komet are misaligned, have inconsistent sizes, text color and icon color don't match, etc

![image](https://github.com/user-attachments/assets/dcc48373-f4a0-418e-86ed-eddef37c21ad)

### Expected Behavior

Icons should all have the texts aligned horizontally, icon sizes should be consistent, icons color and text color should match and other minor tweaks for a more pleasing UI

### Steps to Reproduce

1 - Start Komet

Look at the left pane that contains the Toggle Buttons

### How it looks after this PR
![image](https://github.com/user-attachments/assets/4bc80184-53dc-4304-be76-31580b6810b6)
![image](https://github.com/user-attachments/assets/e4840aee-5fce-4b8d-ade2-0f87d4572b2d)

