### PR TITLE
IIA-1139: Prompt Text values in the Pattern - Add Other name properties bump out are not being displayed

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/SortedComboBox.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/SortedComboBox.java
@@ -5,6 +5,7 @@ import javafx.beans.Observable;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.ListCell;
 
 /**
  * A ComboBox that always shows its items sorted when its popup is showing.
@@ -26,6 +27,20 @@ public class SortedComboBox<T> extends ComboBox<T> {
     private void init() {
         itemsProperty().addListener(this::onItemsChanged);
         addListenerToItems();
+
+        // Code below fixes IIA-1139. JavaFX Comboboxes have a weird behavior in that the prompt text can get cleared when interacting
+        // with them and never comes back again
+        setButtonCell(new ListCell<>() {
+            @Override
+            protected void updateItem(T item, boolean empty) {
+                super.updateItem(item, empty);
+                if (item == null || empty) {
+                    setText(getPromptText());
+                } else {
+                    setText(item.toString());
+                }
+            }
+        });
     }
 
     private void onItemsChanged(Observable observable) {


### PR DESCRIPTION
Fixes: https://ikmdev.atlassian.net/browse/IIA-1139

### Actual Behavior

Prompt Text values in the fields of Add Other name bump out are not being displayed.

![image](https://github.com/user-attachments/assets/23c6ee7c-4cc9-4335-b896-8bb48c2a952c)

### Expected Behavior

Default values(Enter name, Select case sensitivity , select status, select module, select language) should show up in the empty fields of Pattern - Add Other name properties bump out

### Steps to Reproduce

Launch KOMET

Click + for new journal 

Click + for new pattern

Fill status out the STAMP and pattern definition (meaning and purpose)

Click on the pencil icon of Descriptions - add FQN and then add other name