### PR TITLE
Remove unexpected minus handling from KLIntegerControl

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLIntegerControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLIntegerControlSkin.java
@@ -72,16 +72,6 @@ public class KLIntegerControlSkin extends SkinBase<KLIntegerControl> {
                     }
                 }
                 return change;
-            } else if ("-".equals(change.getText()) ) {
-                if (change.getControlText().startsWith("-")) { // if text starts with '-', cancel it
-                    change.setText("");
-                    change.setRange(0, 1);
-                    change.setCaretPosition(change.getCaretPosition() - 2);
-                    change.setAnchor(change.getAnchor() - 2);
-                } else { // a '-', typed from any position, will be set at the beginning of the text
-                    change.setRange(0, 0);
-                }
-                return change;
             } else {
                 errorLabel.setText(MessageFormat.format(resources.getString("error.input.text"), change.getText()));
             }


### PR DESCRIPTION
This PR removes the handling of the minus sign `-` when typed in a different place other than the beginning of the integer number.