### PR TITLE
Fixes where javafx controllers using the Factory's older create methods.

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingDetailsController.java
@@ -343,7 +343,7 @@ public class GenEditingDetailsController {
 
                 // need ObservableField<String>, ObservableView
                 StringFieldLabelFactory stringFieldLabelFactory = new StringFieldLabelFactory();
-                readOnlyNode = stringFieldLabelFactory.create(observableFields.get(fieldRecord.fieldIndex()), observableViewBase).klWidget();
+                readOnlyNode = stringFieldLabelFactory.create(observableFields.get(fieldRecord.fieldIndex()), observableViewBase, false).klWidget();
             } else if (dataTypeNid == TinkarTerm.COMPONENT_ID_SET_FIELD.nid()) {
                 readOnlyNode = rowf.createReadOnlyComponentSet(getViewProperties(), fieldRecord);
             } else if (dataTypeNid == TinkarTerm.DITREE_FIELD.nid()) {

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/SemanticFieldsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/SemanticFieldsController.java
@@ -120,7 +120,7 @@ public class SemanticFieldsController {
                 ObservableField<String> stringObservableField =observableFields.get(fieldRecord.fieldIndex());
 
                 //StringField klWidget returns the widget container which is an HBox with a hard coded label
-                node = stringFieldTextFactory.create(stringObservableField, observableViewBase).klWidget();
+                node = stringFieldTextFactory.create(stringObservableField, observableViewBase, true).klWidget();
 
                 node.setUserData(stringObservableField);
             } else if (dataTypeNid == TinkarTerm.COMPONENT_ID_SET_FIELD.nid()) {


### PR DESCRIPTION
@dholubek  This is a fix to the last PR. It failed to build. We missed methods using the `boolean editable` (3rd) parameter on the factory's `create()` method.