### PR TITLE
Feature/IIA-1228: Implement ready only and edit interfaces on an Integer field.

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/klfields/integerField/DefaultKlIntegerField.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/klfields/integerField/DefaultKlIntegerField.java
@@ -1,0 +1,29 @@
+package dev.ikm.komet.kview.klfields.integerField;
+
+import dev.ikm.komet.framework.observable.ObservableField;
+import dev.ikm.komet.framework.view.ObservableView;
+import dev.ikm.komet.kview.controls.KLIntegerControl;
+import dev.ikm.komet.kview.controls.KLReadOnlyStringControl;
+import dev.ikm.komet.kview.klfields.BaseDefaultKlField;
+import dev.ikm.komet.layout.component.version.field.KlIntegerField;
+import javafx.scene.Node;
+
+public class DefaultKlIntegerField extends BaseDefaultKlField<Integer> implements KlIntegerField {
+
+    public DefaultKlIntegerField(ObservableField<Integer> observableIntegerField, ObservableView observableView, boolean isEditable) {
+        super(observableIntegerField, observableView, isEditable);
+
+        Node node;
+        if (isEditable) {
+            KLIntegerControl integerControl = new KLIntegerControl();
+            integerControl.valueProperty().bindBidirectional(observableIntegerField.valueProperty());
+            integerControl.setTitle(getTitle());
+            node = integerControl;
+        } else {
+            KLReadOnlyStringControl readOnlyStringControl = new KLReadOnlyStringControl();
+            readOnlyStringControl.setText(String.valueOf(observableIntegerField.value())); readOnlyStringControl.setTitle(getTitle());
+            node = readOnlyStringControl;
+        }
+        setKlWidget(node);
+    }
+}

--- a/kview/src/main/java/dev/ikm/komet/kview/klfields/integerField/KlIntegerFieldFactory.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/klfields/integerField/KlIntegerFieldFactory.java
@@ -1,0 +1,35 @@
+package dev.ikm.komet.kview.klfields.integerField;
+
+import dev.ikm.komet.framework.observable.ObservableField;
+import dev.ikm.komet.framework.view.ObservableView;
+import dev.ikm.komet.layout.component.version.field.KlField;
+import dev.ikm.komet.layout.component.version.field.KlFieldFactory;
+import dev.ikm.komet.layout.component.version.field.KlIntegerField;
+
+public class KlIntegerFieldFactory  implements KlFieldFactory<Integer> {
+
+    @Override
+    public KlField<Integer> create(ObservableField<Integer> observableField, ObservableView observableView, boolean editable) {
+        return new DefaultKlIntegerField(observableField, observableView, editable);
+    }
+
+    @Override
+    public Class<? extends KlField<Integer>> getFieldInterface() {
+        return KlIntegerField.class;
+    }
+
+    @Override
+    public Class<? extends KlField<Integer>> getFieldImplementation() {
+        return DefaultKlIntegerField.class;
+    }
+
+    @Override
+    public String getName() {
+        return "Integer Field Factory";
+    }
+
+    @Override
+    public String getDescription() {
+        return "An Integer field";
+    }
+}

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingHelper.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingHelper.java
@@ -1,0 +1,34 @@
+package dev.ikm.komet.kview.mvvm.view.genediting;
+
+import dev.ikm.komet.framework.observable.ObservableEntity;
+import dev.ikm.komet.framework.observable.ObservableField;
+import dev.ikm.komet.framework.observable.ObservableSemantic;
+import dev.ikm.komet.framework.observable.ObservableSemanticSnapshot;
+import dev.ikm.komet.framework.view.ViewProperties;
+import dev.ikm.tinkar.coordinate.stamp.calculator.Latest;
+import dev.ikm.tinkar.entity.FieldRecord;
+import dev.ikm.tinkar.entity.SemanticEntityVersion;
+import org.eclipse.collections.api.list.ImmutableList;
+
+/**
+ * Helper class to have common methods to avoid code redundancy.
+ */
+
+public class GenEditingHelper {
+
+    /**
+     *
+     * @param viewProperties viewProperties cannot be null. Required to get the calculator.
+     * @param semanticEntityVersionLatest
+     * @param fieldRecord
+     * @return the observable field
+     * @param <T>
+     */
+
+    public static <T> ObservableField<T> getObservableFields(ViewProperties viewProperties, Latest<SemanticEntityVersion> semanticEntityVersionLatest, FieldRecord<Object> fieldRecord){
+        ObservableSemantic observableSemantic = ObservableEntity.get(semanticEntityVersionLatest.get().nid());
+        ObservableSemanticSnapshot observableSemanticSnapshot = observableSemantic.getSnapshot(viewProperties.calculator());
+        ImmutableList<ObservableField> observableFields = observableSemanticSnapshot.getLatestFields().get();
+        return observableFields.get(fieldRecord.fieldIndex());
+    }
+}

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/SemanticFieldsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/SemanticFieldsController.java
@@ -25,6 +25,7 @@ import dev.ikm.komet.framework.observable.ObservableSemanticSnapshot;
 import dev.ikm.komet.framework.view.ObservableViewBase;
 import dev.ikm.komet.framework.view.ViewProperties;
 import dev.ikm.komet.kview.klfields.editable.EditableKLFieldFactory;
+import dev.ikm.komet.kview.klfields.integerField.KlIntegerFieldFactory;
 import dev.ikm.komet.kview.klfields.readonly.ReadOnlyKLFieldFactory;
 import dev.ikm.komet.kview.klfields.stringfield.KlStringFieldFactory;
 import dev.ikm.komet.layout.component.version.field.KlField;
@@ -102,7 +103,6 @@ public class SemanticFieldsController {
         Consumer<FieldRecord<Object>> updateUIConsumer = (fieldRecord) -> {
 
             Node node = null;
-            System.out.println("---> dataType() " + fieldRecord.dataType().description());
             int dataTypeNid = fieldRecord.dataType().nid();
             if (dataTypeNid == TinkarTerm.COMPONENT_FIELD.nid()) {
                 // load a read-only component
@@ -110,23 +110,19 @@ public class SemanticFieldsController {
                 node = klField.klWidget();
                 node.setUserData(klField.field());
             } else if (dataTypeNid == TinkarTerm.STRING_FIELD.nid() || fieldRecord.dataType().nid() == TinkarTerm.STRING.nid()) {
-
                 KlStringFieldFactory stringFieldTextFactory = new KlStringFieldFactory();
-                ObservableSemantic observableSemantic = ObservableEntity.get(semanticEntityVersionLatest.get().nid());
-                ObservableSemanticSnapshot observableSemanticSnapshot = observableSemantic.getSnapshot(getViewProperties().calculator());
-                ImmutableList<ObservableField> observableFields = observableSemanticSnapshot.getLatestFields().get();
-                ObservableViewBase observableViewBase = getViewProperties().nodeView();
-
-                ObservableField<String> stringObservableField =observableFields.get(fieldRecord.fieldIndex());
-
-                //StringField klWidget returns the widget container which is an HBox with a hard coded label
-                node = stringFieldTextFactory.create(stringObservableField, observableViewBase, true).klWidget();
-
+                ObservableField<String> stringObservableField = GenEditingHelper.getObservableFields(getViewProperties(), semanticEntityVersionLatest, fieldRecord);
+                node = stringFieldTextFactory.create(stringObservableField, getViewProperties().nodeView(), true).klWidget();
                 node.setUserData(stringObservableField);
             } else if (dataTypeNid == TinkarTerm.COMPONENT_ID_SET_FIELD.nid()) {
                 node = rowf.createReadOnlyComponentSet(getViewProperties(), fieldRecord);
             } else if (dataTypeNid == TinkarTerm.DITREE_FIELD.nid()) {
                 node = rowf.createReadOnlyDiTree(getViewProperties(), fieldRecord);
+            }else if (dataTypeNid == TinkarTerm.INTEGER_FIELD.nid() || fieldRecord.dataType().nid() == TinkarTerm.INTEGER_FIELD.nid()) {
+                ObservableField<Integer> integerObservableField = GenEditingHelper.getObservableFields(getViewProperties(), semanticEntityVersionLatest, fieldRecord);
+                KlIntegerFieldFactory klIntegerFieldFactory = new KlIntegerFieldFactory();
+                node = klIntegerFieldFactory.create(integerObservableField, getViewProperties().nodeView(), true).klWidget();
+                node.setUserData(integerObservableField);
             }
 
             // Add to VBox
@@ -135,7 +131,6 @@ public class SemanticFieldsController {
                 // Add separator
                 editFieldsVBox.getChildren().add(createSeparator());
             }
-            System.out.println("field record: " + fieldRecord);
         };
         rowf.setupSemanticDetailsUI(getViewProperties(), semanticEntityVersionLatest, updateUIConsumer);
     }


### PR DESCRIPTION
Implement ready only and edit interfaces on an Integer field. 

https://ikmdev.atlassian.net/browse/IIA-1228

Please find the attached screenshots of the changes validated on local. 
<img width="829" alt="existing Integer Value" src="https://github.com/user-attachments/assets/5ff35711-d8d1-47f6-b532-03336ab70c30" />
Clicking on edit to update the integer value to 10 and clicking on Submit button.
<img width="960" alt="updating to new Integer value" src="https://github.com/user-attachments/assets/fefb578e-02d1-4a8e-a26a-0b689053a294" />

Close the Pattern and re-open the Semantic Pattern window reflecting the updated Integer value.
<img width="960" alt="updated the Integer Field values" src="https://github.com/user-attachments/assets/1cfd697b-014e-439b-a744-84cca88cf2d3" />
