### PR TITLE
Feature/IIA-1294: Improve read only controls

### DIFF
--- a/application/src/test/java/dev/ikm/komet/sampler/controllers/SamplerReadOnlyStringController.java
+++ b/application/src/test/java/dev/ikm/komet/sampler/controllers/SamplerReadOnlyStringController.java
@@ -1,7 +1,7 @@
 package dev.ikm.komet.sampler.controllers;
 
-import dev.ikm.komet.kview.controls.KLReadOnlyStringControl;
-import dev.ikm.komet.kview.controls.KLReadOnlyStringControl.StringDataType;
+import dev.ikm.komet.kview.controls.KLReadOnlyDataTypeControl;
+import dev.ikm.komet.kview.controls.KLReadOnlyDataTypeControl.DataType;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
@@ -11,10 +11,10 @@ import javafx.scene.control.TextField;
 
 public class SamplerReadOnlyStringController {
     @FXML
-    private ComboBox<StringDataType> dataTypeComboBox;
+    private ComboBox<DataType> dataTypeComboBox;
 
     @FXML
-    private KLReadOnlyStringControl readOnlyStringControl;
+    private KLReadOnlyDataTypeControl<String> readOnlyStringControl;
 
     @FXML
     private CheckBox editModeCheckBox;
@@ -34,16 +34,16 @@ public class SamplerReadOnlyStringController {
                 "KlIntegerField, KlFloatField, KlUuidField, KlInstantField");
 
         titleTextField.setText(readOnlyStringControl.getTitle());
-        textTextField.setText(readOnlyStringControl.getText());
+        textTextField.setText(readOnlyStringControl.getValue());
         editModeCheckBox.setSelected(readOnlyStringControl.isEditMode());
 
         // Data Type Combobox
-        for (StringDataType stringDataType : StringDataType.values()) {
-            dataTypeComboBox.getItems().add(stringDataType);
+        for (DataType dataType : DataType.values()) {
+            dataTypeComboBox.getItems().add(dataType);
         }
-        dataTypeComboBox.setValue(readOnlyStringControl.getDataType());
+        dataTypeComboBox.setValue(readOnlyStringControl.getType());
         dataTypeComboBox.valueProperty().addListener(observable -> {
-            readOnlyStringControl.setDataType(dataTypeComboBox.getValue());
+            readOnlyStringControl.setType(dataTypeComboBox.getValue());
         });
     }
 
@@ -54,7 +54,7 @@ public class SamplerReadOnlyStringController {
 
     @FXML
     private void onTextChanged(ActionEvent actionEvent) {
-        readOnlyStringControl.setText(textTextField.getText());
+        readOnlyStringControl.setValue(textTextField.getText());
     }
 
     @FXML

--- a/application/src/test/resources/dev/ikm/komet/sampler/Sampler_KLReadOnlyComponent.fxml
+++ b/application/src/test/resources/dev/ikm/komet/sampler/Sampler_KLReadOnlyComponent.fxml
@@ -24,7 +24,7 @@
         <BorderPane styleClass="sample-control-container">
             <left>
                 <VBox prefWidth="500" styleClass="inner-container" fillWidth="true">
-                    <KLReadOnlyComponentControl fx:id="readOnlyComponentControl" title="A TITLE:" text="[Placehoder]">
+                    <KLReadOnlyComponentControl fx:id="readOnlyComponentControl" title="A TITLE:" promptText="[Placeholder]">
                         <icon>
                             <Image url="@icon-example.png" />
                         </icon>

--- a/application/src/test/resources/dev/ikm/komet/sampler/Sampler_KLReadOnlyString.fxml
+++ b/application/src/test/resources/dev/ikm/komet/sampler/Sampler_KLReadOnlyString.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.Button?>
-<?import dev.ikm.komet.kview.controls.KLReadOnlyStringControl?>
+<?import dev.ikm.komet.kview.controls.KLReadOnlyDataTypeControl?>
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.ComboBox?>
 
@@ -24,7 +24,7 @@
         <BorderPane styleClass="sample-control-container">
             <left>
                 <VBox prefWidth="500" styleClass="inner-container" fillWidth="true">
-                    <KLReadOnlyStringControl fx:id="readOnlyStringControl" title="A TITLE:" promptText="[Placeholder]" />
+                    <KLReadOnlyDataTypeControl fx:id="readOnlyStringControl" title="A TITLE:" promptText="[Placeholder]" />
                 </VBox>
             </left>
             <right>

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLReadOnlyBaseControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLReadOnlyBaseControl.java
@@ -16,7 +16,7 @@ public abstract class KLReadOnlyBaseControl extends Control {
     public void setTitle(String title) { this.title.set(title); }
 
     // -- prompt text
-    private StringProperty promptText = new SimpleStringProperty();
+    private StringProperty promptText = new SimpleStringProperty("[Placeholder]");
     public String getPromptText() { return promptText.get(); }
     public StringProperty promptTextProperty() { return promptText; }
     public void setPromptText(String text) { this.promptText.set(text); }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLReadOnlyComponentControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLReadOnlyComponentControl.java
@@ -7,21 +7,14 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
-import javafx.scene.control.Control;
 import javafx.scene.control.Skin;
 import javafx.scene.image.Image;
 
-public class KLReadOnlyComponentControl extends Control {
+public class KLReadOnlyComponentControl extends KLReadOnlyBaseControl {
 
     public KLReadOnlyComponentControl() {
         getStyleClass().add("read-only-component-control");
     }
-
-    // -- title
-    private StringProperty title = new SimpleStringProperty();
-    public String getTitle() { return title.get(); }
-    public StringProperty titleProperty() { return title; }
-    public void setTitle(String title) { this.title.set(title); }
 
     // -- text
     private StringProperty text = new SimpleStringProperty();
@@ -34,12 +27,6 @@ public class KLReadOnlyComponentControl extends Control {
     public Image getIcon() { return icon.get(); }
     public ObjectProperty<Image> iconProperty() { return icon; }
     public void setIcon(Image icon) { this.icon.set(icon); }
-
-    // -- edit mode
-    private BooleanProperty editMode = new SimpleBooleanProperty();
-    public boolean isEditMode() { return editMode.get(); }
-    public BooleanProperty editModeProperty() { return editMode; }
-    public void setEditMode(boolean editMode) { this.editMode.set(editMode); }
 
     @Override
     protected Skin<?> createDefaultSkin() {

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLReadOnlyDataTypeControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLReadOnlyDataTypeControl.java
@@ -3,13 +3,11 @@ package dev.ikm.komet.kview.controls;
 import dev.ikm.komet.kview.controls.skin.KLReadOnlyStringControlSkin;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
 import javafx.scene.control.Skin;
 
-public class KLReadOnlyStringControl extends KLReadOnlyBaseControl {
+public class KLReadOnlyDataTypeControl<T> extends KLReadOnlyBaseControl {
 
-    public enum StringDataType {
+    public enum DataType {
         INTEGER,
         FLOAT,
         STRING,
@@ -19,21 +17,21 @@ public class KLReadOnlyStringControl extends KLReadOnlyBaseControl {
         BYTE_ARRAY
     }
 
-    public KLReadOnlyStringControl() {
+    public KLReadOnlyDataTypeControl() {
         getStyleClass().add("read-only-string-control");
     }
 
     // -- data type
-    private ObjectProperty<StringDataType> dataType = new SimpleObjectProperty<>(StringDataType.STRING);
-    public StringDataType getDataType() { return dataType.get(); }
-    public ObjectProperty<StringDataType> dataTypeProperty() { return dataType; }
-    public void setDataType(StringDataType stringDataType) { this.dataType.set(stringDataType); }
+    private ObjectProperty<DataType> type = new SimpleObjectProperty<>(DataType.STRING);
+    public DataType getType() { return type.get(); }
+    public ObjectProperty<DataType> typeProperty() { return type; }
+    public void setType(DataType type) { this.type.set(type); }
 
-    // -- text
-    private StringProperty text = new SimpleStringProperty();
-    public String getText() { return text.get(); }
-    public StringProperty textProperty() { return text; }
-    public void setText(String text) { this.text.set(text); }
+    // -- value
+    private ObjectProperty<T> value = new SimpleObjectProperty<>();
+    public T getValue() { return value.get(); }
+    public ObjectProperty<T> valueProperty() { return value; }
+    public void setValue(T value) { this.value.set(value); }
 
     // -- on add units of measure action
     private ObjectProperty<Runnable> onAddUnitsOfMeasureAction = new SimpleObjectProperty<>();

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLReadOnlyDataTypeControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLReadOnlyDataTypeControl.java
@@ -1,6 +1,6 @@
 package dev.ikm.komet.kview.controls;
 
-import dev.ikm.komet.kview.controls.skin.KLReadOnlyStringControlSkin;
+import dev.ikm.komet.kview.controls.skin.KLReadOnlyDataTypeControlSkin;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.Skin;
@@ -41,7 +41,7 @@ public class KLReadOnlyDataTypeControl<T> extends KLReadOnlyBaseControl {
 
     @Override
     protected Skin<?> createDefaultSkin() {
-        return new KLReadOnlyStringControlSkin(this);
+        return new KLReadOnlyDataTypeControlSkin<T>(this);
     }
 
     @Override

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyBaseControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyBaseControlSkin.java
@@ -12,9 +12,13 @@ import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SkinBase;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 
 public abstract class KLReadOnlyBaseControlSkin<T extends KLReadOnlyBaseControl> extends SkinBase<T> {
     protected static final PseudoClass EDIT_MODE_PSEUDO_CLASS = PseudoClass.getPseudoClass("edit-mode");
+
+    protected final VBox mainContainer = new VBox();
 
     protected final Label titleLabel = new Label();
     protected final Label promptTextLabel = new Label();
@@ -47,9 +51,19 @@ public abstract class KLReadOnlyBaseControlSkin<T extends KLReadOnlyBaseControl>
 
         control.editModeProperty().addListener(editModeChanged);
 
+
+        mainContainer.getChildren().addAll(titleLabel);
+        mainContainer.setFillWidth(true);
+        getChildren().add(mainContainer);
+
+        titleLabel.setPrefWidth(Double.MAX_VALUE);
+        titleLabel.setMaxWidth(Region.USE_PREF_SIZE);
+
+
         initContextMenu(control);
 
         // CSS
+        mainContainer.getStyleClass().add("main-container");
         titleLabel.getStyleClass().add("title");
         promptTextLabel.getStyleClass().add("prompt-text");
         contextMenu.getStyleClass().add("klcontext-menu");

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyBaseControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyBaseControlSkin.java
@@ -4,6 +4,7 @@ import dev.ikm.komet.kview.controls.KLReadOnlyBaseControl;
 import dev.ikm.komet.kview.controls.KometIcon;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
+import javafx.beans.binding.StringBinding;
 import javafx.css.PseudoClass;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -28,7 +29,20 @@ public abstract class KLReadOnlyBaseControlSkin<T extends KLReadOnlyBaseControl>
     public KLReadOnlyBaseControlSkin(T control) {
         super(control);
 
-        titleLabel.textProperty().bind(control.titleProperty());
+        titleLabel.textProperty().bind(new StringBinding() {
+            {
+                super.bind(control.titleProperty());
+            }
+            @Override
+            protected String computeValue() {
+                String title = control.getTitle();
+                if (title != null) {
+                    return control.getTitle().toUpperCase();
+                } else {
+                    return "";
+                }
+            }
+        });
         promptTextLabel.textProperty().bind(control.promptTextProperty());
 
         control.editModeProperty().addListener(editModeChanged);

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyComponentControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyComponentControlSkin.java
@@ -7,10 +7,8 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
-import javafx.scene.layout.VBox;
 
 public class KLReadOnlyComponentControlSkin extends KLReadOnlyBaseControlSkin<KLReadOnlyComponentControl> {
-    private final VBox mainContainer = new VBox();
 
     private final HBox textContainer = new HBox();
     private final ImageView iconImageView = new ImageView();
@@ -22,16 +20,13 @@ public class KLReadOnlyComponentControlSkin extends KLReadOnlyBaseControlSkin<KL
     public KLReadOnlyComponentControlSkin(KLReadOnlyComponentControl control) {
         super(control);
 
-        mainContainer.getChildren().addAll(titleLabel, textContainer);
+        mainContainer.getChildren().addAll(textContainer);
+
         textContainer.getChildren().addAll(iconImageView, promptTextLabel, textLabel);
-        getChildren().add(mainContainer);
 
         textLabel.textProperty().bind(control.textProperty());
         iconImageView.imageProperty().bind(control.iconProperty());
 
-        mainContainer.setFillWidth(true);
-        titleLabel.setPrefWidth(Double.MAX_VALUE);
-        titleLabel.setMaxWidth(Region.USE_PREF_SIZE);
         textLabel.setMaxWidth(Region.USE_PREF_SIZE);
         HBox.setHgrow(textLabel, Priority.ALWAYS);
 
@@ -41,7 +36,6 @@ public class KLReadOnlyComponentControlSkin extends KLReadOnlyBaseControlSkin<KL
         setupContextMenu(control);
 
         // CSS
-        mainContainer.getStyleClass().add("main-container");
         textContainer.getStyleClass().add("text-container");
         textLabel.getStyleClass().add("text");
     }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyComponentControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyComponentControlSkin.java
@@ -1,29 +1,20 @@
 package dev.ikm.komet.kview.controls.skin;
 
-import dev.ikm.komet.kview.controls.KLReadOnlyComponentControl;
-import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
-import javafx.css.PseudoClass;
+import dev.ikm.komet.kview.controls.*;
 import javafx.scene.control.Label;
-import javafx.scene.control.SkinBase;
+import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
-public class KLReadOnlyComponentControlSkin extends SkinBase<KLReadOnlyComponentControl> {
-    private static final PseudoClass EDIT_MODE_PSEUDO_CLASS = PseudoClass.getPseudoClass("edit-mode");
-
+public class KLReadOnlyComponentControlSkin extends KLReadOnlyBaseControlSkin<KLReadOnlyComponentControl> {
     private final VBox mainContainer = new VBox();
-
-    private final Label titleLabel = new Label();
 
     private final HBox textContainer = new HBox();
     private final ImageView iconImageView = new ImageView();
     private final Label textLabel = new Label();
-
-    private InvalidationListener editModeChanged = this::onEditModeChanged;
 
     /**
      * @param control The control for which this Skin should attach to.
@@ -32,13 +23,11 @@ public class KLReadOnlyComponentControlSkin extends SkinBase<KLReadOnlyComponent
         super(control);
 
         mainContainer.getChildren().addAll(titleLabel, textContainer);
-        textContainer.getChildren().addAll(iconImageView, textLabel);
+        textContainer.getChildren().addAll(iconImageView, promptTextLabel, textLabel);
         getChildren().add(mainContainer);
 
-        titleLabel.textProperty().bind(control.titleProperty());
         textLabel.textProperty().bind(control.textProperty());
         iconImageView.imageProperty().bind(control.iconProperty());
-        control.editModeProperty().addListener(editModeChanged);
 
         mainContainer.setFillWidth(true);
         titleLabel.setPrefWidth(Double.MAX_VALUE);
@@ -49,14 +38,22 @@ public class KLReadOnlyComponentControlSkin extends SkinBase<KLReadOnlyComponent
         iconImageView.setFitWidth(20);
         iconImageView.setFitHeight(20);
 
+        setupContextMenu(control);
+
         // CSS
         mainContainer.getStyleClass().add("main-container");
-        titleLabel.getStyleClass().add("title");
         textContainer.getStyleClass().add("text-container");
         textLabel.getStyleClass().add("text");
     }
 
-    private void onEditModeChanged(Observable observable) {
-        pseudoClassStateChanged(EDIT_MODE_PSEUDO_CLASS, getSkinnable().isEditMode());
+    private void setupContextMenu(KLReadOnlyComponentControl control) {
+        contextMenu.getItems().add(
+                createMenuItem("Edit Component", KometIcon.IconValue.PENCIL, this::fireOnEditAction)
+        );
+
+        contextMenu.getItems().addAll(
+                new SeparatorMenuItem(),
+                createMenuItem("Remove", KometIcon.IconValue.TRASH, this::fireOnRmoveAction)
+        );
     }
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyDataTypeControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyDataTypeControlSkin.java
@@ -10,7 +10,7 @@ import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
-public class KLReadOnlyStringControlSkin extends KLReadOnlyBaseControlSkin<KLReadOnlyDataTypeControl> {
+public class KLReadOnlyDataTypeControlSkin<T> extends KLReadOnlyBaseControlSkin<KLReadOnlyDataTypeControl<T>> {
 
     private final VBox textContainer = new VBox();
     private final Label textLabel = new Label();
@@ -18,7 +18,7 @@ public class KLReadOnlyStringControlSkin extends KLReadOnlyBaseControlSkin<KLRea
     /**
      * @param control The control for which this Skin should attach to.
      */
-    public KLReadOnlyStringControlSkin(KLReadOnlyDataTypeControl control) {
+    public KLReadOnlyDataTypeControlSkin(KLReadOnlyDataTypeControl control) {
         super(control);
 
         mainContainer.getChildren().addAll(textContainer);

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyImageControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyImageControlSkin.java
@@ -17,7 +17,6 @@ import java.io.File;
 public class KLReadOnlyImageControlSkin extends KLReadOnlyBaseControlSkin<KLReadOnlyImageControl> {
     private static final PseudoClass IMAGE_SELECTED_PSEUDO_CLASS = PseudoClass.getPseudoClass("image-selected");
 
-    private final VBox mainContainer = new VBox();
     private final VBox textContainer = new VBox();
     private final Label textLabel = new Label();
 
@@ -32,14 +31,11 @@ public class KLReadOnlyImageControlSkin extends KLReadOnlyBaseControlSkin<KLRead
     public KLReadOnlyImageControlSkin(KLReadOnlyImageControl control) {
         super(control);
 
+        mainContainer.getChildren().addAll(imageContainer, textContainer);
+
         imageContainer.getChildren().addAll(imageView, promptTextLabel);
         textContainer.getChildren().add(textLabel);
-        mainContainer.getChildren().addAll(titleLabel, imageContainer, textContainer);
-        getChildren().add(mainContainer);
 
-        mainContainer.setFillWidth(true);
-        titleLabel.setPrefWidth(Double.MAX_VALUE);
-        titleLabel.setMaxWidth(Region.USE_PREF_SIZE);
         textLabel.setPrefWidth(Double.MAX_VALUE);
         textLabel.setMaxWidth(Region.USE_PREF_SIZE);
 
@@ -52,7 +48,6 @@ public class KLReadOnlyImageControlSkin extends KLReadOnlyBaseControlSkin<KLRead
         setupContextMenu(control);
 
         // CSS
-        mainContainer.getStyleClass().add("main-container");
         textContainer.getStyleClass().add("text-container");
         textLabel.getStyleClass().add("text");
         imageContainer.getStyleClass().add("image-container");

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyStringControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyStringControlSkin.java
@@ -1,34 +1,44 @@
 package dev.ikm.komet.kview.controls.skin;
 
 import dev.ikm.komet.kview.NodeUtils;
-import dev.ikm.komet.kview.controls.KLReadOnlyStringControl;
+import dev.ikm.komet.kview.controls.KLReadOnlyDataTypeControl;
 import dev.ikm.komet.kview.controls.KometIcon.IconValue;
+import javafx.beans.binding.ObjectBinding;
 import javafx.event.ActionEvent;
 import javafx.scene.control.Label;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
-public class KLReadOnlyStringControlSkin extends KLReadOnlyBaseControlSkin<KLReadOnlyStringControl> {
-    private final VBox mainContainer = new VBox();
+public class KLReadOnlyStringControlSkin extends KLReadOnlyBaseControlSkin<KLReadOnlyDataTypeControl> {
+
     private final VBox textContainer = new VBox();
     private final Label textLabel = new Label();
 
     /**
      * @param control The control for which this Skin should attach to.
      */
-    public KLReadOnlyStringControlSkin(KLReadOnlyStringControl control) {
+    public KLReadOnlyStringControlSkin(KLReadOnlyDataTypeControl control) {
         super(control);
 
-        mainContainer.getChildren().addAll(titleLabel, textContainer);
+        mainContainer.getChildren().addAll(textContainer);
+
         textContainer.getChildren().addAll(promptTextLabel, textLabel);
-        getChildren().add(mainContainer);
 
-        textLabel.textProperty().bind(control.textProperty());
+        textLabel.textProperty().bind(new ObjectBinding<>() {
+            {
+                super.bind(control.valueProperty());
+            }
+            @Override
+            protected String computeValue() {
+                if (control.getValue() == null) {
+                    return "";
+                } else {
+                    return String.valueOf(control.getValue());
+                }
+            }
+        });
 
-        mainContainer.setFillWidth(true);
-        titleLabel.setPrefWidth(Double.MAX_VALUE);
-        titleLabel.setMaxWidth(Region.USE_PREF_SIZE);
         textLabel.setPrefWidth(Double.MAX_VALUE);
         textLabel.setMaxWidth(Region.USE_PREF_SIZE);
 
@@ -37,34 +47,33 @@ public class KLReadOnlyStringControlSkin extends KLReadOnlyBaseControlSkin<KLRea
         setupContextMenu(control);
 
         // CSS
-        mainContainer.getStyleClass().add("main-container");
         textContainer.getStyleClass().add("text-container");
         textLabel.getStyleClass().add("text");
     }
 
-    private void initTexts(KLReadOnlyStringControl control) {
+    private void initTexts(KLReadOnlyDataTypeControl control) {
         updatePromptTextAndTextLabelVisibility(control);
-        control.textProperty().addListener(observable -> updatePromptTextAndTextLabelVisibility(control));
+        control.valueProperty().addListener(observable -> updatePromptTextAndTextLabelVisibility(control));
     }
 
-    private void updatePromptTextAndTextLabelVisibility(KLReadOnlyStringControl control) {
-        boolean showPromptText = control.getText() == null || control.getText().isEmpty();
+    private void updatePromptTextAndTextLabelVisibility(KLReadOnlyDataTypeControl control) {
+        boolean showPromptText = control.getValue() == null;
 
         NodeUtils.setShowing(promptTextLabel, showPromptText);
         NodeUtils.setShowing(textLabel, !showPromptText);
     }
 
-    private void setupContextMenu(KLReadOnlyStringControl control) {
+    private void setupContextMenu(KLReadOnlyDataTypeControl control) {
         addMenuItemsToContextMenu(control);
 
-        control.dataTypeProperty().addListener(observable -> {
+        control.typeProperty().addListener(observable -> {
             contextMenu.getItems().clear();
             addMenuItemsToContextMenu(control);
         });
     }
 
-    private void addMenuItemsToContextMenu(KLReadOnlyStringControl control) {
-        switch (control.getDataType()) {
+    private void addMenuItemsToContextMenu(KLReadOnlyDataTypeControl control) {
+        switch (control.getType()) {
             case STRING -> addMenuItemsForStringType(control);
             case INTEGER -> addMenuItemsForIntegerType(control);
             case FLOAT -> addMenuItemsForFloatType(control);
@@ -80,44 +89,44 @@ public class KLReadOnlyStringControlSkin extends KLReadOnlyBaseControlSkin<KLRea
         );
     }
 
-    private void addMenuItemsForStringType(KLReadOnlyStringControl control) {
+    private void addMenuItemsForStringType(KLReadOnlyDataTypeControl control) {
         contextMenu.getItems().add(
                 createMenuItem("Edit Text", IconValue.PENCIL, this::fireOnEditAction)
         );
     }
 
-    private void addMenuItemsForIntegerType(KLReadOnlyStringControl control) {
+    private void addMenuItemsForIntegerType(KLReadOnlyDataTypeControl control) {
         contextMenu.getItems().add(
                 createMenuItem("Edit Integer", IconValue.PENCIL, this::fireOnEditAction)
         );
     }
 
-    private void addMenuItemsForFloatType(KLReadOnlyStringControl control) {
+    private void addMenuItemsForFloatType(KLReadOnlyDataTypeControl control) {
         contextMenu.getItems().addAll(
                 createMenuItem("Edit Float", IconValue.PENCIL, this::fireOnEditAction),
                 createMenuItem("Add Unit of Measure", IconValue.PLUS, this::fireOnAddUnitsOfMeasureAction)
         );
     }
 
-    private void addMenuItemsForBooleanType(KLReadOnlyStringControl control) {
+    private void addMenuItemsForBooleanType(KLReadOnlyDataTypeControl control) {
         contextMenu.getItems().add(
                 createMenuItem("Edit Selection", IconValue.PENCIL, this::fireOnEditAction)
         );
     }
 
-    private void addMenuItemsForUUIDType(KLReadOnlyStringControl control) {
+    private void addMenuItemsForUUIDType(KLReadOnlyDataTypeControl control) {
         contextMenu.getItems().add(
                 createMenuItem("Edit Identifier", IconValue.PENCIL, this::fireOnEditAction)
         );
     }
 
-    private void addMenuItemsForInstantType(KLReadOnlyStringControl control) {
+    private void addMenuItemsForInstantType(KLReadOnlyDataTypeControl control) {
         contextMenu.getItems().add(
                 createMenuItem("Edit Identifier", IconValue.PENCIL, this::fireOnEditAction)
         );
     }
 
-    private void addMenuItemsForByteArrayType(KLReadOnlyStringControl control) {
+    private void addMenuItemsForByteArrayType(KLReadOnlyDataTypeControl control) {
         contextMenu.getItems().add(
                 createMenuItem("Edit Selection", IconValue.PENCIL, this::fireOnEditAction)
         );

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyStringListControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyStringListControlSkin.java
@@ -40,8 +40,6 @@ public class KLReadOnlyStringListControlSkin extends KLReadOnlyBaseControlSkin<K
         // CSS
         mainContainer.getStyleClass().add("main-container");
         textsContainer.getStyleClass().add("text-container");
-
-        contextMenu.getStyleClass().add("klcontext-menu");
     }
 
     private void initTexts(KLReadOnlyStringListControl control){

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyStringListControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyStringListControlSkin.java
@@ -11,7 +11,6 @@ import javafx.scene.layout.VBox;
 import java.util.HashMap;
 
 public class KLReadOnlyStringListControlSkin extends KLReadOnlyBaseControlSkin<KLReadOnlyStringListControl> {
-    private final VBox mainContainer = new VBox();
     private final VBox textsContainer = new VBox();
 
     private final ListChangeListener<String> textsChanged = this::onTextChanged;
@@ -23,12 +22,8 @@ public class KLReadOnlyStringListControlSkin extends KLReadOnlyBaseControlSkin<K
     public KLReadOnlyStringListControlSkin(KLReadOnlyStringListControl control) {
         super(control);
 
-        mainContainer.getChildren().addAll(titleLabel, textsContainer);
-        getChildren().add(mainContainer);
+        mainContainer.getChildren().addAll(textsContainer);
 
-        mainContainer.setFillWidth(true);
-        titleLabel.setPrefWidth(Double.MAX_VALUE);
-        titleLabel.setMaxWidth(Region.USE_PREF_SIZE);
         textsContainer.setFillWidth(true);
         textsContainer.setPrefWidth(Double.MAX_VALUE);
         textsContainer.setMaxWidth(Region.USE_PREF_SIZE);
@@ -38,7 +33,6 @@ public class KLReadOnlyStringListControlSkin extends KLReadOnlyBaseControlSkin<K
         setupContextMenu(control);
 
         // CSS
-        mainContainer.getStyleClass().add("main-container");
         textsContainer.getStyleClass().add("text-container");
     }
 

--- a/kview/src/main/java/dev/ikm/komet/kview/klfields/floatfield/DefaultKlFloatField.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/klfields/floatfield/DefaultKlFloatField.java
@@ -3,11 +3,12 @@ package dev.ikm.komet.kview.klfields.floatfield;
 import dev.ikm.komet.framework.observable.ObservableField;
 import dev.ikm.komet.framework.view.ObservableView;
 import dev.ikm.komet.kview.controls.KLFloatControl;
-import dev.ikm.komet.kview.controls.KLReadOnlyStringControl;
+import dev.ikm.komet.kview.controls.KLReadOnlyDataTypeControl;
 import dev.ikm.komet.kview.klfields.BaseDefaultKlField;
 import dev.ikm.komet.layout.component.version.field.KlFloatField;
-import javafx.beans.binding.ObjectBinding;
 import javafx.scene.Node;
+
+import static dev.ikm.komet.kview.controls.KLReadOnlyDataTypeControl.DataType.FLOAT;
 
 public class DefaultKlFloatField extends BaseDefaultKlField<Float> implements KlFloatField {
 
@@ -17,20 +18,19 @@ public class DefaultKlFloatField extends BaseDefaultKlField<Float> implements Kl
         Node node;
         if (isEditable) {
             KLFloatControl floatControl = new KLFloatControl();
+
             floatControl.valueProperty().bindBidirectional(observableFloatField.valueProperty());
             floatControl.setTitle(getTitle());
+
             node = floatControl;
         } else {
-            KLReadOnlyStringControl readOnlyStringControl = new KLReadOnlyStringControl();
+            KLReadOnlyDataTypeControl<Float> readOnlyStringControl = new KLReadOnlyDataTypeControl<>();
 
-            readOnlyStringControl.textProperty().bind(new ObjectBinding<>() {
-                {super.bind(observableFloatField.valueProperty());}
-                @Override
-                protected String computeValue() {
-                    return String.valueOf(observableFloatField.value());
-                }
-            });
+            readOnlyStringControl.valueProperty().bindBidirectional(observableFloatField.valueProperty());
             readOnlyStringControl.setTitle(getTitle());
+
+            readOnlyStringControl.setType(FLOAT);
+
             node = readOnlyStringControl;
         }
         setKlWidget(node);

--- a/kview/src/main/java/dev/ikm/komet/kview/klfields/integerField/DefaultKlIntegerField.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/klfields/integerField/DefaultKlIntegerField.java
@@ -3,11 +3,12 @@ package dev.ikm.komet.kview.klfields.integerField;
 import dev.ikm.komet.framework.observable.ObservableField;
 import dev.ikm.komet.framework.view.ObservableView;
 import dev.ikm.komet.kview.controls.KLIntegerControl;
-import dev.ikm.komet.kview.controls.KLReadOnlyStringControl;
+import dev.ikm.komet.kview.controls.KLReadOnlyDataTypeControl;
 import dev.ikm.komet.kview.klfields.BaseDefaultKlField;
 import dev.ikm.komet.layout.component.version.field.KlIntegerField;
-import javafx.beans.binding.ObjectBinding;
 import javafx.scene.Node;
+
+import static dev.ikm.komet.kview.controls.KLReadOnlyDataTypeControl.DataType.INTEGER;
 
 public class DefaultKlIntegerField extends BaseDefaultKlField<Integer> implements KlIntegerField {
 
@@ -17,19 +18,19 @@ public class DefaultKlIntegerField extends BaseDefaultKlField<Integer> implement
         Node node;
         if (isEditable) {
             KLIntegerControl integerControl = new KLIntegerControl();
+
             integerControl.valueProperty().bindBidirectional(observableIntegerField.valueProperty());
             integerControl.setTitle(getTitle());
+
             node = integerControl;
         } else {
-            KLReadOnlyStringControl readOnlyStringControl = new KLReadOnlyStringControl();
-            readOnlyStringControl.textProperty().bind(new ObjectBinding<>() {
-                {super.bind(observableIntegerField.valueProperty());}
-                @Override
-                protected String computeValue() {
-                    return String.valueOf(observableIntegerField.value());
-                }
-            });
+            KLReadOnlyDataTypeControl<Integer> readOnlyStringControl = new KLReadOnlyDataTypeControl<>();
+
+            readOnlyStringControl.valueProperty().bindBidirectional(observableIntegerField.valueProperty());
             readOnlyStringControl.setTitle(getTitle());
+
+            readOnlyStringControl.setType(INTEGER);
+
             node = readOnlyStringControl;
         }
         setKlWidget(node);

--- a/kview/src/main/java/dev/ikm/komet/kview/klfields/stringfield/DefaultKlStringField.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/klfields/stringfield/DefaultKlStringField.java
@@ -2,7 +2,7 @@ package dev.ikm.komet.kview.klfields.stringfield;
 
 import dev.ikm.komet.framework.observable.ObservableField;
 import dev.ikm.komet.framework.view.ObservableView;
-import dev.ikm.komet.kview.controls.KLReadOnlyStringControl;
+import dev.ikm.komet.kview.controls.KLReadOnlyDataTypeControl;
 import dev.ikm.komet.kview.controls.KLStringControl;
 import dev.ikm.komet.kview.klfields.BaseDefaultKlField;
 import dev.ikm.komet.layout.component.version.field.KlStringField;
@@ -16,13 +16,17 @@ public class DefaultKlStringField extends BaseDefaultKlField<String> implements 
         Node node;
         if (isEditable) {
             KLStringControl stringControl = new KLStringControl();
+
             stringControl.textProperty().bindBidirectional(observableStringField.valueProperty());
             stringControl.setTitle(getTitle());
+
             node = stringControl;
         } else {
-            KLReadOnlyStringControl readOnlyStringControl = new KLReadOnlyStringControl();
-            readOnlyStringControl.textProperty().bindBidirectional(observableStringField.valueProperty());
+            KLReadOnlyDataTypeControl<String> readOnlyStringControl = new KLReadOnlyDataTypeControl<>();
+
+            readOnlyStringControl.valueProperty().bindBidirectional(observableStringField.valueProperty());
             readOnlyStringControl.setTitle(getTitle());
+
             node = readOnlyStringControl;
         }
 

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/read-only-component-control.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/read-only-component-control.css
@@ -1,15 +1,20 @@
-.read-only-component-control .main-container .text-container {
-    -fx-border-width: 1px;
-    -fx-border-color: transparent;
-
-    -fx-spacing: 8px;
-}
-
+.read-only-component-control .main-container .text-container,
 .read-only-component-control .main-container .title {
     -fx-border-width: 1px;
     -fx-border-color: transparent;
+}
 
+.read-only-component-control .main-container .title {
     -fx-text-fill: #5d5d5d;
+}
+
+.read-only-component-control .main-container .text-container .text {
+    -fx-text-fill: #111;
+    -fx-font-size: 1.166667em;
+}
+
+.read-only-component-control .main-container .text-container {
+    -fx-spacing: 8px;
 }
 
 .read-only-component-control:hover .main-container .text-container {

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/read-only-image-control.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/read-only-image-control.css
@@ -7,7 +7,7 @@
 }
 
 .read-only-image-control .main-container .title {
-    -fx-text-fill: #111;
+    -fx-text-fill: #5d5d5d;
 }
 
 .read-only-image-control .main-container .text-container {
@@ -16,6 +16,7 @@
 
 .read-only-image-control .main-container .text-container .text {
     -fx-text-fill: #111;
+    -fx-font-size: 1.166667em;
 }
 
 .read-only-image-control:hover .main-container .text-container .text {

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/read-only-string-control.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/read-only-string-control.css
@@ -10,11 +10,15 @@
     -fx-text-fill: #5d5d5d;
 }
 
+.read-only-string-control .main-container .text-container .text {
+    -fx-text-fill: #111;
+    -fx-font-size: 1.166667em;
+}
+
 .read-only-string-control:hover .main-container .text-container {
     -fx-background-color: #f4f4f4;
     -fx-border-color: #dfdfdf;
 }
-
 
 .read-only-string-control:edit-mode .main-container .text-container {
     -fx-background-color: #f4f9ff;

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/read-only-string-list-control.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/read-only-string-list-control.css
@@ -10,11 +10,15 @@
     -fx-text-fill: #5d5d5d;
 }
 
+.read-only-string-list-control .main-container .text-container .text {
+    -fx-text-fill: #111;
+    -fx-font-size: 1.166667em;
+}
+
 .read-only-string-list-control:hover .main-container .text-container {
     -fx-background-color: #f4f4f4;
     -fx-border-color: #dfdfdf;
 }
-
 
 .read-only-string-list-control:edit-mode .main-container .text-container {
     -fx-background-color: #f4f9ff;

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
@@ -217,19 +217,10 @@
                                  </font>
                                  <content>
                                     <VBox fx:id="semanticDetailsVBox" maxWidth="1.7976931348623157E308" prefWidth="610.0" styleClass="titled-content-background">
-                                       <children>
-                                          <VBox maxWidth="1.7976931348623157E308" styleClass="semantic-field-container">
-                                             <children>
-                                                <Label styleClass="semantic-field-type-label" text="TEST PERFORMED ANALYTE OBSERVABLE (LOINC):" />
-                                                <HBox alignment="CENTER_LEFT" maxWidth="1.7976931348623157E308" nodeOrientation="LEFT_TO_RIGHT" prefHeight="32.0" prefWidth="673.0" spacing="3.0">
-                                                   <children>
-                                                      <ImageView fitHeight="20.0" fitWidth="20.0" pickOnBounds="true" preserveRatio="true" styleClass="identicon-image-view" />
-                                                      <Label maxWidth="1.7976931348623157E308" styleClass="semantic-field-value" text="Concept FQN / Semantic Name D" HBox.hgrow="ALWAYS" />
-                                                   </children>
-                                                </HBox>
-                                             </children>
-                                          </VBox>
-                                       </children>
+                                       <styleClass>
+                                          <String fx:value="titled-content-background" />
+                                          <String fx:value="semantic-field-container" />
+                                       </styleClass>
                                     </VBox>
                                  </content>
                               </TitledPane>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -4966,7 +4966,7 @@ Styling a context menu for kview ui/ux controls
     -fx-spacing: 12px;
 
     -fx-fill-width: true;
-    -fx-padding: 16px 8px 12px 8px;
+    -fx-padding: 16px 8px 20px 8px;
     -fx-background-color: -Grey-1;
 }
 .semantic-field-set-container,

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -4756,8 +4756,8 @@ Styling a context menu for kview ui/ux controls
     -fx-border-insets: 0;
 }
 
-.pattern-window.concept-detail-pane .main-center-container .titled-pane .title,
-.lidr-window.concept-detail-pane .main-center-container .titled-pane .title {
+.pattern-window.concept-detail-pane .main-center-container .titled-pane >  .title,
+.lidr-window.concept-detail-pane .main-center-container .titled-pane > .title {
     -fx-padding: 8 4 4 6;
 }
 
@@ -4961,11 +4961,12 @@ Styling a context menu for kview ui/ux controls
 
 /* Semantic Details section - VBox */
 .semantic-field-container {
-    -height: 58;
-    -fx-min-height: -height;
-    -fx-pref-height: -height;
+    -fx-min-height: 58px;
+
+    -fx-spacing: 12px;
+
     -fx-fill-width: true;
-    -fx-padding: 8px 12px;
+    -fx-padding: 16px 8px 12px 8px;
     -fx-background-color: -Grey-1;
 }
 .semantic-field-set-container,


### PR DESCRIPTION
Fixes https://ikmdev.atlassian.net/browse/IIA-1294

--------------------------

List of improvements:
- remove unnecessary old code
- improvements to style of read-only controls
- improvements to style of left pane (that contains read-only controls)
- add missing context menu to read-only component control
- add missing prompt text to read-only component control
- make read-only component control and skin extend from base component and base skin control
- remove code redundancy between read-only controls
- set correct data type for read-only control in data type field implementation
- improve readOnlyStringControl API by having a valueProperty