### PR TITLE
Feature/iia 1273 semantic text overlap

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>application</artifactId>
     <dependencies>

--- a/artifact/pom.xml
+++ b/artifact/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>artifact</artifactId>
     <dependencies>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>builder</artifactId>
     <dependencies>

--- a/classification/pom.xml
+++ b/classification/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>classification</artifactId>
     <dependencies>

--- a/details/pom.xml
+++ b/details/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>details</artifactId>
     <dependencies>

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>executor</artifactId>
     <dependencies>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>framework</artifactId>
     <dependencies>

--- a/knowledge-layout/pom.xml
+++ b/knowledge-layout/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
 
     <artifactId>knowledge-layout</artifactId>

--- a/komet-terms/pom.xml
+++ b/komet-terms/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>komet-terms</artifactId>
     <dependencies>

--- a/kview/pom.xml
+++ b/kview/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>kview</artifactId>
     <dependencies>

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PatternDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PatternDetailsController.java
@@ -203,12 +203,6 @@ public class PatternDetailsController {
     private Button addDefinitionButton;
 
     @FXML
-    private Text semanticMeaningText;
-
-    @FXML
-    private Text semanticPurposeText;
-
-    @FXML
     private Button savePatternButton;
 
     // pattern definition fields
@@ -277,6 +271,8 @@ public class PatternDetailsController {
 
     @FXML
     private void initialize() {
+        purposeText.setText("");
+        meaningText.setText("");
         identifierText.setText("");
         fieldsTilePane.getChildren().clear();
         fieldsTilePane.setPrefColumns(2);

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/pattern/pattern-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/pattern/pattern-details.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import dev.ikm.komet.kview.mvvm.view.journal.VerticallyFilledPane?>
 <?import java.lang.String?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Cursor?>
@@ -35,8 +36,8 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
-<?import dev.ikm.komet.kview.mvvm.view.journal.VerticallyFilledPane?>
-<BorderPane fx:id="detailsOuterBorderPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="560.0" prefWidth="727.0" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.pattern.PatternDetailsController">
+
+<BorderPane fx:id="detailsOuterBorderPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="560.0" prefWidth="727.0" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.pattern.PatternDetailsController">
    <center>
       <BorderPane fx:id="detailsCenterBorderPane" prefWidth="762.0">
          <top>
@@ -166,7 +167,7 @@
             </HBox>
          </right>
          <center>
-            <BorderPane styleClass="main-center-container" prefWidth="762.0" BorderPane.alignment="CENTER">
+            <BorderPane prefWidth="762.0" styleClass="main-center-container" BorderPane.alignment="CENTER">
                <center>
                   <VBox focusTraversable="true" maxHeight="1.7976931348623157E308" opacity="0.92" prefWidth="762.0">
                      <children>
@@ -181,34 +182,36 @@
                                        </columnConstraints>
                                        <rowConstraints>
                                           <RowConstraints maxHeight="16.0" minHeight="16.0" prefHeight="16.0" vgrow="SOMETIMES" />
-                                          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                          <RowConstraints minHeight="30.0" prefHeight="30.0" vgrow="SOMETIMES" />
                                           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                                        </rowConstraints>
                                        <children>
-                                          <Text GridPane.columnIndex="1" strokeType="OUTSIDE" strokeWidth="0.0" style="-fx-font-family: Noto Sans; -fx-font-size: 12; -fx-font-weight: 600; -fx-fill: -Grey-12;" text="SEMANTIC MEANING:" wrappingWidth="121.474609375">
-                                             <font>
-                                                <Font name="Noto Sans Batak Regular" size="12.0" />
-                                             </font>
-                                          </Text>
-                                          <Label />
-                                          <Text GridPane.columnIndex="1" fx:id="semanticMeaningText" strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="227.6090087890625">
-                                             <font>
-                                                <Font name="Noto Sans Batak Regular" size="13.0" />
-                                             </font>
-                                          </Text>
-                                          <Text GridPane.columnIndex="0" fx:id="semanticPurposeText" strokeType="OUTSIDE" strokeWidth="0.0" style="-fx-font-family: Noto Sans; -fx-font-size: 12; -fx-font-weight: 500; -fx-fill: -Grey-12;" text="SEMANTIC PURPOSE" wrappingWidth="117.490234375" >
+                                          <Text fx:id="semanticPurposeText" strokeType="OUTSIDE" strokeWidth="0.0" style="-fx-font-family: Noto Sans; -fx-font-size: 12; -fx-font-weight: 500; -fx-fill: -Grey-12;" text="SEMANTIC PURPOSE" wrappingWidth="117.490234375" GridPane.columnIndex="0">
                                              <font>
                                                 <Font name="Open Sans Bold" size="14.0" />
                                              </font>
                                           </Text>
-                                          <Text GridPane.columnIndex="0" GridPane.rowIndex="2" fx:id="purposeDate" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-noto-sans-normal-grey-eight" >
+                                          <Text strokeType="OUTSIDE" strokeWidth="0.0" style="-fx-font-family: Noto Sans; -fx-font-size: 12; -fx-font-weight: 600; -fx-fill: -Grey-12;" text="SEMANTIC MEANING:" wrappingWidth="121.474609375" GridPane.columnIndex="1">
+                                             <font>
+                                                <Font name="Noto Sans Batak Regular" size="12.0" />
+                                             </font>
+                                          </Text>
+                                          <TextFlow GridPane.rowIndex="1">
+                                             <children>
+                                                <Text fx:id="purposeText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-noto-sans-bold-grey-twelve" text="Capsular pattern of joint movement limitation (finding)" />
+                                             </children>
+                                          </TextFlow>
+                                          <Text fx:id="purposeDate" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-noto-sans-normal-grey-eight" text="Date Added: Feb 02" GridPane.columnIndex="0" GridPane.rowIndex="2">
                                              <font>
                                                 <Font name="Noto Sans Batak Regular" size="13.0" />
                                              </font>
                                           </Text>
-                                          <Text GridPane.columnIndex="1" GridPane.rowIndex="1" fx:id="meaningText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-noto-sans-bold-grey-twelve"  />
-                                          <Text GridPane.columnIndex="1" GridPane.rowIndex="2" fx:id="meaningDate" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-noto-sans-normal-grey-eight"  />
-                                          <Text  GridPane.columnIndex="0" GridPane.rowIndex="1" fx:id="purposeText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-noto-sans-bold-grey-twelve" />
+                                          <TextFlow GridPane.columnIndex="1" GridPane.rowIndex="1">
+                                             <children>
+                                                <Text fx:id="meaningText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-noto-sans-bold-grey-twelve" text="Capsular pattern of joint movement limitation (finding)" />
+                                             </children>
+                                          </TextFlow>
+                                          <Text fx:id="meaningDate" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="text-noto-sans-normal-grey-eight" text="Date Added: Feb 02" GridPane.columnIndex="1" GridPane.rowIndex="2" />
                                        </children>
                                     </GridPane>
                                  </content>

--- a/list/pom.xml
+++ b/list/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>list</artifactId>
     <dependencies>

--- a/navigator/pom.xml
+++ b/navigator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>navigator</artifactId>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>dev.ikm.komet</groupId>
     <artifactId>komet-parent</artifactId>
     <name>KOMET</name>
-    <version>1.47.0-SNAPSHOT</version>
+    <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     <packaging>pom</packaging>
     <inceptionYear>2015</inceptionYear>
     <licenses>

--- a/preferences/pom.xml
+++ b/preferences/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>preferences</artifactId>
     <dependencies>

--- a/progress/pom.xml
+++ b/progress/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>progress</artifactId>
     <dependencies>

--- a/rules/pom.xml
+++ b/rules/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>rules</artifactId>
     <dependencies>

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.ikm.komet</groupId>
         <artifactId>komet-parent</artifactId>
-        <version>1.47.0-SNAPSHOT</version>
+        <version>1.47.0-IIA-1273-semantic-text-overlap-SNAPSHOT</version>
     </parent>
     <artifactId>search</artifactId>
     <dependencies>


### PR DESCRIPTION
Fixed the Semantic meaning and Semantic purpose text overlap issue.

https://ikmdev.atlassian.net/browse/IIA-1273

Validated the changes locally. Please help to review the PR. 

Before resizing the Pattern
<img width="960" alt="Before resizing Pattern" src="https://github.com/user-attachments/assets/f632356c-be15-4aa5-ac6c-31d89d87212e" />

After resizing the Pattern, the text doesn't overlap.
<img width="960" alt="After resizing Pattern - no text overlap" src="https://github.com/user-attachments/assets/4125afed-68bf-4a68-bcf4-600c165c61df" />


