### PR TITLE
Feature/finished/iia 1640 add error message to float editable field

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLIntegerControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLIntegerControlSkin.java
@@ -22,9 +22,11 @@ import java.util.regex.Pattern;
 public class KLIntegerControlSkin extends SkinBase<KLIntegerControl> {
 
     private static final Pattern NUMERICAL_PATTERN = Pattern.compile("^(0|[1-9][0-9]*)$"); // allow '-', don't start with 0, but allow a zero by itself
-    private static final PseudoClass ERROR_PSEUDO_CLASS = PseudoClass.getPseudoClass("error");
     private static final ResourceBundle resources = ResourceBundle.getBundle("dev.ikm.komet.kview.controls.integer-control");
-    private static final Duration ERROR_DURATION = Duration.seconds(5);
+
+    // public to share with KLFloatControlSkin
+    public static final PseudoClass ERROR_PSEUDO_CLASS = PseudoClass.getPseudoClass("error");
+    public static final Duration ERROR_DURATION = Duration.seconds(5);
 
     private final Label titleLabel;
     private final TextField textField;

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/float-control.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/float-control.css
@@ -34,4 +34,7 @@
     -fx-font-family: "Noto Sans";
     -fx-font-size: 12px;
     -fx-text-fill: -Accent-color-red;
+    -fx-text-alignment: center;
+    -fx-wrap-text: true;
+    -fx-alignment: center;
 }


### PR DESCRIPTION
Summary of changes:

- Added the calls to setShowError()
- Modified the layoutChildren() to set the width of the error label to match the width of the text field, which is what the Integer control skin does
- Modified KLIntegerControlSkin to make the ERROR_PSEUDO_CLASS and ERROR_DURATION to be public so the KLFloatControlSkin class can use
- Modified float css to match integer css

Jira ticket:

https://ikmdev.atlassian.net/browse/IIA-1640

Before fix:

![image](https://github.com/user-attachments/assets/1dc71fa6-ac06-43da-bf52-2554e15ba822)

With fix:

![image](https://github.com/user-attachments/assets/b4a8e7f0-185c-4209-a232-d0cd44c3bf68)


