### PR TITLE
IIA-1822 round two of IIA-1640, where the text was a bug because…

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLFloatControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLFloatControlSkin.java
@@ -9,7 +9,6 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.TextFormatter;
 import javafx.util.Subscription;
 
-import java.text.MessageFormat;
 import java.util.ResourceBundle;
 import java.util.regex.Pattern;
 
@@ -76,12 +75,12 @@ public class KLFloatControlSkin extends SkinBase<KLFloatControl> {
                     double value = Double.parseDouble(newText);
                     // discard if we have a valid value, but it is infinite or NaN
                     if (Double.isInfinite(value) || Double.isNaN(value)) {
-                        errorLabel.setText(MessageFormat.format(resources.getString("error.float.text"), newText));
+                        errorLabel.setText(resources.getString("error.float.text"));
                         control.setShowError(true);
                         return null;
                     }
                 } catch (NumberFormatException nfe) {
-                    errorLabel.setText(MessageFormat.format(resources.getString("error.float.text"), newText));
+                    errorLabel.setText(resources.getString("error.float.text"));
                     control.setShowError(true);
                 }
                 return change;
@@ -110,7 +109,7 @@ public class KLFloatControlSkin extends SkinBase<KLFloatControl> {
                     return change;
                 }
             }
-            errorLabel.setText(MessageFormat.format(resources.getString("error.input.text"), addedText));
+            errorLabel.setText(resources.getString("error.float.text"));
             control.setShowError(true);
             return null;
         }));
@@ -133,6 +132,8 @@ public class KLFloatControlSkin extends SkinBase<KLFloatControl> {
                     control.setValue(value);
                 } catch (NumberFormatException e) {
                     // ignore, and keep control with its old value
+                    errorLabel.setText(resources.getString("error.float.text"));
+                    control.setShowError(true);
                 }
             }
             textChangedViaKeyEvent = false;

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/float-control.properties
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/float-control.properties
@@ -1,2 +1,2 @@
 error.input.text=Error: the typed character ''{0}'' was not a decimal number
-error.float.text=Error: the text ''{0}'' was not a valid floating point number
+error.float.text=Only numerical values can be \n added to the Float text box


### PR DESCRIPTION
…it wasn't consistent with the Integer error text

Jira bug:  https://ikmdev.atlassian.net/browse/IIA-1822

Summary of changes:

- Changed the error text per bug's description
- Removed the unnecessary formatter because the error text does not have a parameter
- Added another show error at the NumberFormatException, which was missed in the original defect

Before fix:

![image](https://github.com/user-attachments/assets/70650494-72ad-4fe0-90c0-a864f318443e)

After fix with consistent error message:

![image](https://github.com/user-attachments/assets/6e430292-ed0a-4f7b-aa27-f09b540a778c)

