### PR TITLE
IIA-1831 changed to match Integer where if the input string value is …

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLFloatControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLFloatControlSkin.java
@@ -66,22 +66,22 @@ public class KLFloatControlSkin extends SkinBase<KLFloatControl> {
             // - adding '-' or '+' if empty or ends in e/E
             // - back when text ends in [-/+, e, e-/+, E, E-/+]
             // - pattern
-            if (newText.isEmpty() ||
-                    (hasExponent(newText) && !hasExponent(oldText) && !oldText.isEmpty()) ||
-                    (("-".equals(addedText) || "+".equals(addedText)) && (oldText.isEmpty() || endsWithExponent(oldText))) ||
-                    (addedText.isEmpty() && ("+".equals(newText) || "-".equals(newText) || hasExponent(newText) || hasSignedExponent(newText))) ||
-                    NUMERICAL_PATTERN.matcher(newText).matches()) {
-                try {
-                    double value = Double.parseDouble(newText);
-                    // discard if we have a valid value, but it is infinite or NaN
-                    if (Double.isInfinite(value) || Double.isNaN(value)) {
+            if (newText.isEmpty() || NUMERICAL_PATTERN.matcher(newText).matches()) {
+                if (!newText.isEmpty() && ((hasExponent(newText) && !hasExponent(oldText) && !oldText.isEmpty()) ||
+                        (("-".equals(addedText) || "+".equals(addedText)) && (oldText.isEmpty() || endsWithExponent(oldText))) ||
+                        (addedText.isEmpty() && ("+".equals(newText) || "-".equals(newText) || hasExponent(newText) || hasSignedExponent(newText))))) {
+                    try {
+                        double value = Double.parseDouble(newText);
+                        // discard if we have a valid value, but it is infinite or NaN
+                        if (Double.isInfinite(value) || Double.isNaN(value)) {
+                            errorLabel.setText(resources.getString("error.float.text"));
+                            control.setShowError(true);
+                            return null;
+                        }
+                    } catch (NumberFormatException nfe) {
                         errorLabel.setText(resources.getString("error.float.text"));
                         control.setShowError(true);
-                        return null;
                     }
-                } catch (NumberFormatException nfe) {
-                    errorLabel.setText(resources.getString("error.float.text"));
-                    control.setShowError(true);
                 }
                 return change;
             } else if ("-".equals(addedText) || "+".equals(addedText)) { // typing '-'/'+' in any other position


### PR DESCRIPTION
…empty to not show the error label

Summary of changes:  re-arranged the first if statement to be coded like the KLIntegerControlSkin where newText.isEmpty() and !newText.isEmpty() is checked

Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-1831

Before fix:

![image](https://github.com/user-attachments/assets/b8d0adf9-0230-4ea8-ade5-18c287bab9a2)

After fix:

![image](https://github.com/user-attachments/assets/038bcebc-2691-4e80-b300-0633d142d0f1)
