### PR TITLE
Restrict mouse right-click and increase font size

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptTile.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptTile.java
@@ -12,6 +12,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.Dragboard;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.HBox;
@@ -85,7 +86,7 @@ public class ConceptTile extends HBox {
         disclosurePane = new StackPane(disclosureIconRegion);
         disclosurePane.getStyleClass().add("region");
         disclosurePane.addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
-            if (cell.getTreeItem() != null) {
+            if (e.isPrimaryButtonDown() && cell.getTreeItem() != null) {
                 cell.getTreeItem().setExpanded(!cell.getTreeItem().isExpanded());
                 e.consume();
             }
@@ -93,7 +94,9 @@ public class ConceptTile extends HBox {
         IconRegion selectIconRegion = new IconRegion("icon", "select");
         StackPane selectPane = new StackPane(selectIconRegion);
         selectPane.addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
-            cell.pseudoClassStateChanged(DRAG_SELECTED_PSEUDO_CLASS, true);
+            if (e.getButton() == MouseButton.PRIMARY) {
+                cell.pseudoClassStateChanged(DRAG_SELECTED_PSEUDO_CLASS, true);
+            }
             e.consume();
         });
         selectPane.addEventFilter(MouseEvent.MOUSE_RELEASED, e -> {
@@ -120,7 +123,9 @@ public class ConceptTile extends HBox {
         };
         Tooltip.install(treePane, treeTooltip);
         treePane.addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
-            getConcept().setViewLineage(!getConcept().isViewLineage());
+            if (e.getButton() == MouseButton.PRIMARY) {
+                getConcept().setViewLineage(!getConcept().isViewLineage());
+            }
             e.consume();
         });
         treePane.managedProperty().bind(treePane.visibleProperty());
@@ -140,11 +145,13 @@ public class ConceptTile extends HBox {
 
         selectPane.addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
             e.consume();
-            treeViewSkin.setDraggingAllowed(false);
+            if (e.getButton() == MouseButton.PRIMARY) {
+                treeViewSkin.setDraggingAllowed(false);
+            }
         });
         selectPane.addEventFilter(MouseEvent.MOUSE_RELEASED, e -> treeViewSkin.setDraggingAllowed(true));
         selectPane.addEventFilter(MouseEvent.DRAG_DETECTED, e -> {
-            if (!cell.isEmpty()) {
+            if (e.getButton() == MouseButton.PRIMARY && !cell.isEmpty()) {
                 Dragboard dragboard = startDragAndDrop(TransferMode.COPY_OR_MOVE);
                 ClipboardContent clipboardContent = new ClipboardContent();
                 ConceptNavigatorTreeItem treeItem = (ConceptNavigatorTreeItem) cell.getTreeItem();

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorTreeCell.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorTreeCell.java
@@ -14,6 +14,7 @@ import javafx.scene.control.Cell;
 import javafx.scene.control.Skin;
 import javafx.scene.control.TreeCell;
 import javafx.scene.input.DataFormat;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.shape.Path;
 
@@ -137,7 +138,7 @@ public class KLConceptNavigatorTreeCell extends TreeCell<ConceptFacade> {
         setText(null);
 
         addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
-            if (e.getClickCount() == 2 && !isEmpty() && !isViewLineage()) {
+            if (e.getButton() == MouseButton.PRIMARY && e.getClickCount() == 2 && !isEmpty() && !isViewLineage()) {
                 if (treeView.getOnAction() != null) {
                     treeView.getOnAction().accept(List.of(getItem()));
                 }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/LineageBox.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/LineageBox.java
@@ -10,6 +10,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Skin;
 import javafx.scene.control.Tooltip;
+import javafx.scene.input.MouseButton;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
@@ -281,8 +282,8 @@ public class LineageBox extends ScrollPane {
          * <p>A tooltip is set in case the label text is too long and it gets truncated.
          * </p>
          * <p>A mouse click listener is added to mimic the tree expand/collapse gesture.
-         * When the item was collapsed, new {@link ParentHBox} are added, with the ancestors.
-         * When the item was expanded, the existing ancestors are removed.
+         * When the item is collapsed, new {@link ParentHBox} are added, with the ancestors.
+         * When the item is expanded, the existing ancestors are removed.
          * </p>
          * @param treeItem the {@link InvertedTree.ConceptItem}
          * @return a {@link Label}
@@ -300,6 +301,10 @@ public class LineageBox extends ScrollPane {
                 }
             };
             label.setOnMouseClicked(e -> {
+                e.consume();
+                if (e.getButton() != MouseButton.PRIMARY) {
+                    return;
+                }
                 ParentHBox currentHBox = (ParentHBox) label.getParent();
                 int currentIndex = lineageBoxRoot.getChildren().indexOf(currentHBox);
                 if (currentHBox.invertedTree.isLeaf()) {

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLConceptNavigatorTreeViewSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLConceptNavigatorTreeViewSkin.java
@@ -33,6 +33,7 @@ import javafx.scene.image.ImageView;
 import javafx.scene.image.WritableImage;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.Dragboard;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.VBox;
@@ -152,15 +153,17 @@ public class KLConceptNavigatorTreeViewSkin extends TreeViewSkin<ConceptFacade> 
             pseudoClassStateChanged(MULTIPLE_SELECTION_PSEUDO_CLASS, multiple);
         });
         treeView.addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
-            if (isMultipleSelectionByBoundingBox() &&
-                    !new Rectangle2D(xMin, yMin, xMax - xMin, yMax - yMin).contains(e.getSceneX(), e.getSceneY())) {
-                setMultipleSelectionByBoundingBox(false);
+            if (e.getButton() == MouseButton.PRIMARY) {
+                if (isMultipleSelectionByBoundingBox() &&
+                        !new Rectangle2D(xMin, yMin, xMax - xMin, yMax - yMin).contains(e.getSceneX(), e.getSceneY())) {
+                    setMultipleSelectionByBoundingBox(false);
+                }
+                x = e.getX();
+                y = e.getY();
             }
-            x = e.getX();
-            y = e.getY();
         });
         treeView.addEventFilter(MouseEvent.MOUSE_DRAGGED, e -> {
-            if (isDraggingAllowed() && draggedItems.isEmpty() && !isMultipleSelectionByClicking()) {
+            if (e.getButton() == MouseButton.PRIMARY && isDraggingAllowed() && draggedItems.isEmpty() && !isMultipleSelectionByClicking()) {
                 setMultipleSelectionByBoundingBox(true);
                 virtualFlow.setMouseTransparent(true);
                 double newX = e.getX();

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/LineageBoxSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/LineageBoxSkin.java
@@ -4,6 +4,7 @@ import dev.ikm.komet.kview.controls.ConceptNavigatorTreeItem;
 import dev.ikm.komet.kview.controls.IconRegion;
 import dev.ikm.komet.kview.controls.LineageBox;
 import javafx.scene.control.skin.ScrollPaneSkin;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 
@@ -27,11 +28,13 @@ public class LineageBoxSkin extends ScrollPaneSkin {
         closePane = new StackPane(closeIconRegion);
         closePane.getStyleClass().addAll("region", "close");
         closePane.addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
-            ConceptNavigatorTreeItem concept = lineageBox.getConcept();
-            if (concept != null) {
-                concept.setViewLineage(false);
-                concept.getInvertedTree().reset();
-                lineageBox.setConcept(null);
+            if (e.getButton() == MouseButton.PRIMARY) {
+                ConceptNavigatorTreeItem concept = lineageBox.getConcept();
+                if (concept != null) {
+                    concept.setViewLineage(false);
+                    concept.getInvertedTree().reset();
+                    lineageBox.setConcept(null);
+                }
             }
             e.consume();
         });

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/SearchControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/SearchControlSkin.java
@@ -19,6 +19,7 @@ import javafx.scene.control.Skin;
 import javafx.scene.control.SkinBase;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
+import javafx.scene.input.MouseButton;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.shape.Path;
@@ -100,16 +101,18 @@ public class SearchControlSkin extends SkinBase<SearchControl> {
 
         closePane = new StackPane(new IconRegion("icon", "close"));
         closePane.getStyleClass().add("region");
-        closePane.setOnMouseClicked(_ -> {
-            textField.clear();
-            resultsPane.getItems().clear();
-            resultsPane.setVisible(false);
+        closePane.setOnMouseClicked(e -> {
+            if (e.getButton() == MouseButton.PRIMARY) {
+                textField.clear();
+                resultsPane.getItems().clear();
+                resultsPane.setVisible(false);
+            }
         });
 
         filterPane = new StackPane(new IconRegion("icon", "filter"));
         filterPane.getStyleClass().add("filter-region");
-        filterPane.setOnMouseClicked(_ -> {
-            if (control.getOnFilterAction() != null) {
+        filterPane.setOnMouseClicked(e -> {
+            if (e.getButton() == MouseButton.PRIMARY && control.getOnFilterAction() != null) {
                 control.getOnFilterAction().handle(new ActionEvent());
             }
         });

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/concept-navigator.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/concept-navigator.css
@@ -229,7 +229,7 @@
 .navigator-tree-cell.tree-cell > .concept-tile > .concept-label {
     -fx-font-family: "Noto Sans";
     -fx-font-weight: normal;
-    -fx-font-size: 12;
+    -fx-font-size: 13;
     -fx-text-fill: -Grey-11;
     -fx-background-color: transparent;
     -fx-border-color: transparent;
@@ -635,7 +635,7 @@
 .lineage-box > .lineage-hbox > .lineage-label {
     -fx-font-family: "Noto Sans";
     -fx-font-weight: 500;
-    -fx-font-size: 10;
+    -fx-font-size: 12;
     -fx-text-fill: -Grey-11;
     -fx-alignment: center-left;
 }

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/search-control.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/search-control.css
@@ -184,14 +184,14 @@
 
 .search-result > .parent-description-label {
     -fx-font-family: "Noto Sans";
-    -fx-font-size: 10px;
+    -fx-font-size: 11px;
     -fx-text-fill: #545D72;
     -fx-font-weight: 500;
 }
 
 .search-result > .description-label {
     -fx-font-family: "Noto Sans";
-    -fx-font-size: 11px;
+    -fx-font-size: 12px;
     -fx-text-fill: #212430;
     -fx-font-weight: 500;
     -fx-graphic-text-gap: 0;


### PR DESCRIPTION
Fixes some issues in the concept navigator (treeView and search controls):
- restrict right-click events
- increase font size