### PR TITLE
Expand and highlight search results concepts in navigator

### DIFF
--- a/application/src/test/java/dev/ikm/komet/sampler/controllers/SamplerConceptNavigatorController.java
+++ b/application/src/test/java/dev/ikm/komet/sampler/controllers/SamplerConceptNavigatorController.java
@@ -2,6 +2,7 @@ package dev.ikm.komet.sampler.controllers;
 
 import dev.ikm.komet.app.AppState;
 import dev.ikm.komet.app.LoadDataSourceTask;
+import dev.ikm.komet.kview.controls.ConceptNavigatorUtils;
 import dev.ikm.komet.kview.controls.KLConceptNavigatorControl;
 import dev.ikm.komet.kview.controls.SearchControl;
 import dev.ikm.komet.framework.view.ObservableViewNoOverride;
@@ -192,6 +193,10 @@ public class SamplerConceptNavigatorController {
                 populateArea(items.stream()
                         .map(item -> item.publicId().asUuidArray())
                         .toList()));
+        searchControl.setOnLongHover(conceptNavigatorControl::expandAndHighlightConcept);
+        searchControl.setOnSearchResultClick(_ -> conceptNavigatorControl.unhighlightConceptsWithDelay());
+        searchControl.setOnClearSearch(_ -> ConceptNavigatorUtils.resetConceptNavigator(conceptNavigatorControl));
+
         showTagsCheckBox.selectedProperty().subscribe(s -> conceptNavigatorControl.setShowTags(s));
 
         conceptArea.setOnDragDropped(event -> {

--- a/application/src/test/java/dev/ikm/komet/sampler/controllers/SamplerConceptNavigatorController.java
+++ b/application/src/test/java/dev/ikm/komet/sampler/controllers/SamplerConceptNavigatorController.java
@@ -4,7 +4,7 @@ import dev.ikm.komet.app.AppState;
 import dev.ikm.komet.app.LoadDataSourceTask;
 import dev.ikm.komet.kview.controls.ConceptNavigatorUtils;
 import dev.ikm.komet.kview.controls.KLConceptNavigatorControl;
-import dev.ikm.komet.kview.controls.SearchControl;
+import dev.ikm.komet.kview.controls.KLSearchControl;
 import dev.ikm.komet.framework.view.ObservableViewNoOverride;
 import dev.ikm.komet.framework.view.ViewProperties;
 import dev.ikm.komet.framework.window.WindowSettings;
@@ -47,7 +47,7 @@ public class SamplerConceptNavigatorController {
     private Label samplerDescription;
 
     @FXML
-    private SearchControl searchControl;
+    private KLSearchControl searchControl;
 
     @FXML
     private KLConceptNavigatorControl conceptNavigatorControl;
@@ -152,7 +152,7 @@ public class SamplerConceptNavigatorController {
             TinkExecutor.threadPool().execute(() -> {
                 try {
                     List<LatestVersionSearchResult> results = calculator.search(searchControl.getText(), 1000).toList();
-                    List<SearchControl.SearchResult> searchResults = new ArrayList<>();
+                    List<KLSearchControl.SearchResult> searchResults = new ArrayList<>();
                     results.stream()
                             .filter(result -> result.latestVersion().isPresent())
                             .forEach(result -> {
@@ -160,20 +160,20 @@ public class SamplerConceptNavigatorController {
                                 searchResults.addAll(
                                         Entity.getConceptForSemantic(semantic.nid()).map(entity -> {
                                             int[] parentNids = navigator.getParentNids(entity.nid());
-                                            List<SearchControl.SearchResult> list = new ArrayList<>();
+                                            List<KLSearchControl.SearchResult> list = new ArrayList<>();
                                             if (parentNids != null) {
                                                 for (int parentNid : parentNids) {
                                                     ConceptFacade parent = Entity.getFast(parentNid);
-                                                    list.add(new SearchControl.SearchResult(parent, entity, searchControl.getText()));
+                                                    list.add(new KLSearchControl.SearchResult(parent, entity, searchControl.getText()));
                                                 }
                                             } else {
-                                                list.add(new SearchControl.SearchResult(null, entity, searchControl.getText()));
+                                                list.add(new KLSearchControl.SearchResult(null, entity, searchControl.getText()));
                                             }
                                             return list;
                                         }).orElse(List.of()));
                             });
                     // NOTE: different semanticIds give same entity
-                    List<SearchControl.SearchResult> distinctResults = searchResults.stream().distinct().toList();
+                    List<KLSearchControl.SearchResult> distinctResults = searchResults.stream().distinct().toList();
                     Platform.runLater(() -> {
                         searchControl.setResultsPlaceholder(null);
                         searchControl.resultsProperty().addAll(distinctResults);

--- a/application/src/test/resources/dev/ikm/komet/sampler/Sampler_KLConceptNavigatorControl.fxml
+++ b/application/src/test/resources/dev/ikm/komet/sampler/Sampler_KLConceptNavigatorControl.fxml
@@ -10,7 +10,7 @@
 <?import dev.ikm.komet.kview.controls.KLConceptNavigatorControl?>
 
 <?import javafx.scene.control.CheckBox?>
-<?import dev.ikm.komet.kview.controls.SearchControl?>
+<?import dev.ikm.komet.kview.controls.KLSearchControl?>
 <ScrollPane styleClass="sample-container" fitToWidth="true" hbarPolicy="NEVER" vbarPolicy="AS_NEEDED"
             xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.sampler.controllers.SamplerConceptNavigatorController">
     <VBox>
@@ -22,7 +22,7 @@
         </Label>
         <SplitPane fx:id="root" prefWidth="200.0" styleClass="sample-control-container">
             <VBox styleClass="inner-container">
-                <SearchControl fx:id="searchControl"/>
+                <KLSearchControl fx:id="searchControl"/>
                 <KLConceptNavigatorControl fx:id="conceptNavigatorControl"/>
             </VBox>
             <VBox fx:id="conceptArea" styleClass="center-container"/>

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptNavigatorTreeItem.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptNavigatorTreeItem.java
@@ -227,6 +227,26 @@ public class ConceptNavigatorTreeItem extends TreeItem<ConceptFacade> {
         tagProperty.set(value);
     }
 
+    /**
+     * Property that toggles the highlighted state of this concept TreeItem.
+     */
+    private final BooleanProperty highlightedProperty = new SimpleBooleanProperty(this, "highlighted");
+    public final BooleanProperty highlightedProperty() {
+       return highlightedProperty;
+    }
+    public final boolean isHighlighted() {
+       return highlightedProperty.get();
+    }
+    public final void setHighlighted(boolean value) {
+        highlightedProperty.set(value);
+    }
+
+    /**
+     * <p>Gets the {@link InvertedTree} instance of this concept TreeItem, which might by empty.
+     * </p>
+     * @return an {@link InvertedTree}
+     * @see ConceptNavigatorUtils#buildInvertedTree(int, Navigator)
+     */
     public final InvertedTree getInvertedTree() {
         return invertedTree;
     }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptNavigatorUtils.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptNavigatorUtils.java
@@ -12,6 +12,8 @@ import javafx.scene.transform.Scale;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
 
 import static dev.ikm.komet.kview.controls.KLConceptNavigatorControl.MAX_LEVEL;
 
@@ -155,7 +157,7 @@ public class ConceptNavigatorUtils {
      * @param navigator the {@link Navigator} that holds the dataset
      * @return an {@link InvertedTree}
      */
-    private static InvertedTree buildInvertedTree(int nid, Navigator navigator) {
+    static InvertedTree buildInvertedTree(int nid, Navigator navigator) {
         ConceptFacade facade = Entity.getFast(nid);
         InvertedTree.ConceptItem item = new InvertedTree.ConceptItem(facade.nid(), facade.nid(), facade.description());
         InvertedTree tree = new InvertedTree(item);
@@ -256,6 +258,85 @@ public class ConceptNavigatorUtils {
             }
             if (!model.isLeaf()) {
                 printTree(treeView, model, printAll);
+            }
+        }
+    }
+
+    /**
+     * <p>Builds the {@link InvertedTree} for a given {@link dev.ikm.komet.kview.controls.InvertedTree.ConceptItem},
+     * finds the sorted map of lineages, and takes the shorter lineage that matches the nid and child nid of
+     * such item.
+     * </p>
+     * @param conceptItem a given {@link dev.ikm.komet.kview.controls.InvertedTree.ConceptItem}
+     * @param navigator the {@link Navigator} that holds the dataset
+     * @return a {@link List<InvertedTree.ConceptItem>} with the shorter lineage that matches nid and child nid of
+     * such item.
+     */
+    public static List<InvertedTree.ConceptItem> findShorterLineage(InvertedTree.ConceptItem conceptItem, Navigator navigator) {
+        InvertedTree tree = buildInvertedTree(conceptItem.childNid(), navigator);
+        Map<Integer, List<InvertedTree.ConceptItem>> lineageMap = tree.getLineageMap();
+
+        return lineageMap.values().stream()
+                .filter(list -> conceptItem.equals(list.getLast()))
+                .findFirst()
+                .orElse(List.of());
+    }
+
+    /**
+     * <p>Resets selection, highlighted and expanded states of every concept TreeItem of the TreeView
+     * </p>
+     * @param treeView the {@link KLConceptNavigatorControl}
+     */
+    public static void resetConceptNavigator(KLConceptNavigatorControl treeView) {
+        treeView.getSelectionModel().clearSelection();
+        iterateTree((ConceptNavigatorTreeItem) treeView.getRoot(), item -> {
+            item.setHighlighted(false);
+            item.setExpanded(false);
+        });
+    }
+
+    /**
+     * <p>Expands and highlights the concept in the treeView, matching both its nid and parent nid.
+     * </p>
+     * @param treeView the {@link KLConceptNavigatorControl}
+     * @param conceptItem a {@link dev.ikm.komet.kview.controls.InvertedTree.ConceptItem}
+     */
+    public static void expandAndHighlightConcept(KLConceptNavigatorControl treeView, InvertedTree.ConceptItem conceptItem) {
+        resetConceptNavigator(treeView);
+
+        List<InvertedTree.ConceptItem> lineage = ConceptNavigatorUtils.findShorterLineage(conceptItem, treeView.getNavigator());
+        ConceptNavigatorTreeItem parent = (ConceptNavigatorTreeItem) treeView.getRoot();
+        for (int i = 0; i < lineage.size(); i++) {
+            int parentNid = lineage.get(i).nid();
+            int nid = lineage.get(i).childNid();
+            ConceptNavigatorTreeItem item = (ConceptNavigatorTreeItem) parent.getChildren().stream()
+                    .filter(c -> c.getValue().nid() == nid)
+                    .findFirst()
+                    .orElse(treeView.getConceptNavigatorTreeItem(nid, parentNid));
+            item.setExpanded(true);
+            parent = item;
+            if (i == lineage.size() - 1) {
+                treeView.getSelectionModel().select(item);
+                treeView.scrollTo(treeView.getSelectionModel().getSelectedIndex());
+                treeView.getSelectionModel().clearSelection();
+                item.setHighlighted(true);
+            }
+        }
+    }
+
+    /**
+     * <p>Recursive method that traverses the children of a {@link ConceptNavigatorTreeItem}, applying a certain
+     * function to each of them.
+     * </p>
+     * @param treeItem a {@link ConceptNavigatorTreeItem}
+     * @param consumer a {@link Consumer <ConceptNavigatorTreeItem>} to apply to each tree item
+     */
+    public static void iterateTree(ConceptNavigatorTreeItem treeItem, Consumer<ConceptNavigatorTreeItem> consumer) {
+        for (TreeItem<ConceptFacade> child : treeItem.getChildren()) {
+            ConceptNavigatorTreeItem model = (ConceptNavigatorTreeItem) child;
+            consumer.accept(model);
+            if (!child.isLeaf()) {
+                iterateTree(model, consumer);
             }
         }
     }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptNavigatorUtils.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptNavigatorUtils.java
@@ -296,35 +296,6 @@ public class ConceptNavigatorUtils {
     }
 
     /**
-     * <p>Expands and highlights the concept in the treeView, matching both its nid and parent nid.
-     * </p>
-     * @param treeView the {@link KLConceptNavigatorControl}
-     * @param conceptItem a {@link dev.ikm.komet.kview.controls.InvertedTree.ConceptItem}
-     */
-    public static void expandAndHighlightConcept(KLConceptNavigatorControl treeView, InvertedTree.ConceptItem conceptItem) {
-        resetConceptNavigator(treeView);
-
-        List<InvertedTree.ConceptItem> lineage = ConceptNavigatorUtils.findShorterLineage(conceptItem, treeView.getNavigator());
-        ConceptNavigatorTreeItem parent = (ConceptNavigatorTreeItem) treeView.getRoot();
-        for (int i = 0; i < lineage.size(); i++) {
-            int parentNid = lineage.get(i).nid();
-            int nid = lineage.get(i).childNid();
-            ConceptNavigatorTreeItem item = (ConceptNavigatorTreeItem) parent.getChildren().stream()
-                    .filter(c -> c.getValue().nid() == nid)
-                    .findFirst()
-                    .orElse(treeView.getConceptNavigatorTreeItem(nid, parentNid));
-            item.setExpanded(true);
-            parent = item;
-            if (i == lineage.size() - 1) {
-                treeView.getSelectionModel().select(item);
-                treeView.scrollTo(treeView.getSelectionModel().getSelectedIndex());
-                treeView.getSelectionModel().clearSelection();
-                item.setHighlighted(true);
-            }
-        }
-    }
-
-    /**
      * <p>Recursive method that traverses the children of a {@link ConceptNavigatorTreeItem}, applying a certain
      * function to each of them.
      * </p>

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptTile.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptTile.java
@@ -94,6 +94,7 @@ public class ConceptTile extends HBox {
         IconRegion selectIconRegion = new IconRegion("icon", "select");
         StackPane selectPane = new StackPane(selectIconRegion);
         selectPane.addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
+            getConcept().setHighlighted(false);
             if (e.getButton() == MouseButton.PRIMARY) {
                 cell.pseudoClassStateChanged(DRAG_SELECTED_PSEUDO_CLASS, true);
             }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptTile.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptTile.java
@@ -124,6 +124,7 @@ public class ConceptTile extends HBox {
         Tooltip.install(treePane, treeTooltip);
         treePane.addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
             if (e.getButton() == MouseButton.PRIMARY) {
+                getConcept().setHighlighted(false);
                 getConcept().setViewLineage(!getConcept().isViewLineage());
             }
             e.consume();

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptTile.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptTile.java
@@ -178,6 +178,8 @@ public class ConceptTile extends HBox {
             }
             cell.tagProperty().unbind();
             cell.setTag(ConceptNavigatorTreeItem.TAG.NONE);
+            cell.highlightedProperty().unbind();
+            cell.setHighlighted(false);
             cell.viewLineageProperty().unbind();
             cell.setViewLineage(false);
             treePane.setVisible(false);
@@ -204,6 +206,7 @@ public class ConceptTile extends HBox {
                 pseudoClassStateChanged(DEFINED_PSEUDO_CLASS, treeItem.isDefined());
                 cell.viewLineageProperty().bind(treeItem.viewLineageProperty());
                 cell.tagProperty().bind(treeItem.tagProperty());
+                cell.highlightedProperty().bind(treeItem.highlightedProperty());
                 treePane.setVisible(treeItem.isMultiParent());
             } else {
                 stopHoverTransition();

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorControl.java
@@ -4,6 +4,7 @@ import dev.ikm.komet.kview.controls.skin.KLConceptNavigatorTreeViewSkin;
 import dev.ikm.komet.navigator.graph.Navigator;
 import dev.ikm.tinkar.entity.Entity;
 import dev.ikm.tinkar.terms.ConceptFacade;
+import javafx.animation.PauseTransition;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
@@ -15,6 +16,7 @@ import javafx.beans.property.StringProperty;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.Skin;
 import javafx.scene.control.TreeView;
+import javafx.util.Duration;
 
 import java.util.Arrays;
 import java.util.List;
@@ -310,7 +312,7 @@ public class KLConceptNavigatorControl extends TreeView<ConceptFacade> {
      * @param parentNid the nid of the parent of the concept, or -1 if root.
      * @return a {@link ConceptNavigatorTreeItem} for that concept
      */
-    private ConceptNavigatorTreeItem getConceptNavigatorTreeItem(int nid, int parentNid) {
+    ConceptNavigatorTreeItem getConceptNavigatorTreeItem(int nid, int parentNid) {
         ConceptNavigatorTreeItem conceptNavigatorTreeItem = createSingleConceptNavigatorTreeItem(nid, parentNid);
         conceptNavigatorTreeItem.expandedProperty().subscribe((_, expanded) -> {
             if (expanded && conceptNavigatorTreeItem.getChildren().isEmpty()) {
@@ -356,4 +358,27 @@ public class KLConceptNavigatorControl extends TreeView<ConceptFacade> {
         return conceptNavigatorTreeItem;
     }
 
+    /**
+     * <p>Expands the treeView starting from its root node, so this concept gets visible, and
+     * then highlights it.
+     * </p>
+     * <p>From all the possible concept's lineages, the one that gets expanded is the shorter one
+     * that matches both its nid and parent nid.
+     * </p>
+     * @param conceptItem a {@link dev.ikm.komet.kview.controls.InvertedTree.ConceptItem}
+     * @see ConceptNavigatorUtils#findShorterLineage(InvertedTree.ConceptItem, Navigator)
+     */
+    public void expandAndHighlightConcept(InvertedTree.ConceptItem conceptItem) {
+        ConceptNavigatorUtils.expandAndHighlightConcept(this, conceptItem);
+    }
+
+    /**
+     * <p>Removes the highlight state of every concept in this treeView.
+     * </p>
+     */
+    public void unhighlightConceptsWithDelay() {
+        PauseTransition pause = new PauseTransition(Duration.millis(getActivation()));
+        pause.setOnFinished(_ -> ConceptNavigatorUtils.iterateTree((ConceptNavigatorTreeItem) getRoot(), item -> item.setHighlighted(false)));
+        pause.play();
+    }
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorControl.java
@@ -1,5 +1,6 @@
 package dev.ikm.komet.kview.controls;
 
+import dev.ikm.komet.kview.controls.skin.ConceptNavigatorHelper;
 import dev.ikm.komet.kview.controls.skin.KLConceptNavigatorTreeViewSkin;
 import dev.ikm.komet.navigator.graph.Navigator;
 import dev.ikm.tinkar.entity.Entity;
@@ -108,6 +109,26 @@ public class KLConceptNavigatorControl extends TreeView<ConceptFacade> {
      * @see ConceptNavigatorUtils#STYLE
      */
     public static final int MAX_LEVEL = 32;
+
+    /**
+     * Used to access internal methods of KLConceptNavigatorControl from
+     * {@link dev.ikm.komet.kview.controls.skin.KLConceptNavigatorTreeViewSkin}.
+     */
+    static {
+        ConceptNavigatorHelper.setConceptNavigatorAccessor(new ConceptNavigatorHelper.ConceptNavigatorAccessor() {
+
+            @Override
+            public void markCellDirty(KLConceptNavigatorTreeCell treeCell) {}
+
+            @Override
+            public void unselectItem(KLConceptNavigatorTreeCell treeCell) {}
+
+            @Override
+            public ConceptNavigatorTreeItem getConceptNavigatorTreeItem(KLConceptNavigatorControl treeView, int nid, int parentNid) {
+                return treeView.getConceptNavigatorTreeItem(nid, parentNid);
+            }
+        });
+    }
 
     private KLConceptNavigatorTreeViewSkin conceptNavigatorTreeViewSkin;
 
@@ -312,7 +333,7 @@ public class KLConceptNavigatorControl extends TreeView<ConceptFacade> {
      * @param parentNid the nid of the parent of the concept, or -1 if root.
      * @return a {@link ConceptNavigatorTreeItem} for that concept
      */
-    ConceptNavigatorTreeItem getConceptNavigatorTreeItem(int nid, int parentNid) {
+    private ConceptNavigatorTreeItem getConceptNavigatorTreeItem(int nid, int parentNid) {
         ConceptNavigatorTreeItem conceptNavigatorTreeItem = createSingleConceptNavigatorTreeItem(nid, parentNid);
         conceptNavigatorTreeItem.expandedProperty().subscribe((_, expanded) -> {
             if (expanded && conceptNavigatorTreeItem.getChildren().isEmpty()) {
@@ -369,11 +390,11 @@ public class KLConceptNavigatorControl extends TreeView<ConceptFacade> {
      * @see ConceptNavigatorUtils#findShorterLineage(InvertedTree.ConceptItem, Navigator)
      */
     public void expandAndHighlightConcept(InvertedTree.ConceptItem conceptItem) {
-        ConceptNavigatorUtils.expandAndHighlightConcept(this, conceptItem);
+        conceptNavigatorTreeViewSkin.expandAndHighlightConcept(conceptItem);
     }
 
     /**
-     * <p>Removes the highlight state of every concept in this treeView.
+     * <p>Toggles off the highlight state of every concept that might have it in this treeView.
      * </p>
      */
     public void unhighlightConceptsWithDelay() {

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorTreeCell.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorTreeCell.java
@@ -49,6 +49,11 @@ public class KLConceptNavigatorTreeCell extends TreeCell<ConceptFacade> {
             public void unselectItem(KLConceptNavigatorTreeCell treeCell) {
                 treeCell.unselectItem();
             }
+
+            @Override
+            public ConceptNavigatorTreeItem getConceptNavigatorTreeItem(KLConceptNavigatorControl treeView, int nid, int parentNid) {
+                return null;
+            }
         });
     }
 

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorTreeCell.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorTreeCell.java
@@ -90,6 +90,7 @@ public class KLConceptNavigatorTreeCell extends TreeCell<ConceptFacade> {
     private static final PseudoClass ADDED_TAG_PSEUDO_CLASS = PseudoClass.getPseudoClass("added-tag");
     private static final PseudoClass RETIRED_TAG_PSEUDO_CLASS = PseudoClass.getPseudoClass("retired-tag");
 
+    private static final PseudoClass HIGHLIGHTED_PSEUDO_CLASS = PseudoClass.getPseudoClass("highlighted");
     /**
      * <p>Custom data format identifier used as means of identifying the data stored on a dragboard
      * when one or more concept items are selected and dragged to a given target.
@@ -256,6 +257,27 @@ public class KLConceptNavigatorTreeCell extends TreeCell<ConceptFacade> {
     }
     public final void setTag(ConceptNavigatorTreeItem.TAG value) {
         tagProperty.set(value);
+    }
+
+    /**
+     * <p>Property that toggles the 'highlighted' pseudo class.
+     * </p>
+     * @see ConceptNavigatorTreeItem#highlightedProperty()
+     */
+    private final BooleanProperty highlightedProperty = new SimpleBooleanProperty(this, "highlighted") {
+        @Override
+        protected void invalidated() {
+            pseudoClassStateChanged(HIGHLIGHTED_PSEUDO_CLASS, get());
+        }
+    };
+    public final BooleanProperty highlightedProperty() {
+        return highlightedProperty;
+    }
+    public final boolean isHighlighted() {
+        return highlightedProperty.get();
+    }
+    public final void setHighlighted(boolean value) {
+        highlightedProperty.set(value);
     }
 
     private void unselectItem() {

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLSearchControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLSearchControl.java
@@ -19,15 +19,55 @@ import javafx.scene.control.Skin;
 
 import java.util.function.Consumer;
 
+/**
+ * <p>The Search control provides a search field for the user to type any term. It can be used for any purpose, like
+ * searching through a dataset of concepts (the actual search implementation should be done outside this control), and
+ * includes a filter button that can be used to open a menu with filter options.
+ * </p>
+ * <p>The {@link SearchResult search results} that are passed to the control via {@link #resultsProperty()}, if any,
+ * are shown below the search field in a {@link javafx.scene.control.ListView} with limited height. When there are no
+ * results, a placeholder text is shown instead.
+ * </p>
+ * <p>This control can interact with a {@link KLConceptNavigatorControl}, for instance, in order to show the results
+ * of a search through the dataset in the treeView.
+ * </p>
+ * <p>A simple implementation of this control, for a given {@link dev.ikm.komet.navigator.graph.Navigator} holding
+ * a valid dataset, can be as follows:
+ * <pre><code>
+ *     KLSearchControl searchControl = new KLSearchControl();
+ *     searchControl.setOnAction(_ -&gt; {
+ *          searchControl.setResultsPlaceholder("Searching...");
+ *          List&lt;ConceptFacade&gt; results = navigator.getViewCalculator().search(searchControl.getText(), 100);
+ *          List&lt;KLSearchControl.SearchResult&gt; searchResults = results.stream()
+ *              .map(entity -&gt;
+ *                  new KLSearchControl.SearchResult(Entity.getFast(navigator.getParentNids(entity.nid())[0]),
+ *                      entity, searchControl.getText())
+*               .toList());
+ *          searchControl.setResultsPlaceholder(null);
+ *          searchControl.resultsProperty().addAll(searchResults);
+ *     });
+ *     searchControl.setOnLongHover(result -&gt; System.out.println("Result " + result + " was hovered"));
+ *     searchControl.setOnSearchResultClick(result -&gt; System.out.println("Result " + result + " was selected"));
+ *     searchControl.setOnClearSearch(_ -&gt; System.out.println("Results have been cleared"));
+ * </code></pre>
+ * </p>
+ */
 public class KLSearchControl extends Control {
 
+    /**
+     * <p>Creates a {@link KLSearchControl} instance.
+     * </p>
+     */
     public KLSearchControl() {
 
         getStyleClass().add("search-control");
         getStylesheets().add(getUserAgentStylesheet());
     }
 
-    // promptTextProperty
+    /**
+     * The prompt text to display in the search field. If set to null (by default), the
+     * default prompt text is displayed. If set to an empty string, no prompt text is displayed.
+     */
     private final StringProperty promptTextProperty = new SimpleStringProperty(this, "promptText");
     public final StringProperty promptTextProperty() {
         return promptTextProperty;
@@ -39,7 +79,9 @@ public class KLSearchControl extends Control {
         promptTextProperty.set(value);
     }
 
-    // textProperty
+    /**
+     * The text displayed in the search field, typed by the user, or set programmatically.
+     */
     private final StringProperty textProperty = new SimpleStringProperty(this, "text");
     public final StringProperty textProperty() {
         return textProperty;
@@ -51,7 +93,16 @@ public class KLSearchControl extends Control {
         textProperty.set(value);
     }
 
-    // onActionProperty
+    /**
+     * <p>The action handler associated with this search field, or null if no action handler is assigned.
+     * Typically, this can be used to call the implementation that searches the dataset with the
+     * {@link #textProperty()}.
+     * </p>
+     * <p>When the search field is not empty, after the user presses the ENTER key, the event handler
+     * is called invoking the search action, and the results area becomes visible, waiting for
+     * {@link SearchResult search results} that are passed to the control via {@link #resultsProperty()}.
+     * </p>
+     */
     private final ObjectProperty<EventHandler<ActionEvent>> onActionProperty = new SimpleObjectProperty<>(this, "onAction");
     public final ObjectProperty<EventHandler<ActionEvent>> onActionProperty() {
         return onActionProperty;
@@ -63,7 +114,12 @@ public class KLSearchControl extends Control {
         onActionProperty.set(value);
     }
 
-    // onClearSearchProperty
+    /**
+     * <p>The search field includes a button that when pressed by the user clears the field and closes the results area.
+     * Therefore, {@link #textProperty()} and {@link #resultsProperty()} are cleared.
+     * This property can be used to include an external action to be invoked right before that happens.
+     * </p>
+     */
     private final ObjectProperty<EventHandler<ActionEvent>> onClearSearchProperty = new SimpleObjectProperty<>(this, "onClearSearch");
     public final ObjectProperty<EventHandler<ActionEvent>> onClearSearchProperty() {
        return onClearSearchProperty;
@@ -75,7 +131,9 @@ public class KLSearchControl extends Control {
         onClearSearchProperty.set(value);
     }
 
-    // onFilterActionProperty
+    /**
+     * Action to be invoked when the filter button is pressed.
+     */
     private final ObjectProperty<EventHandler<ActionEvent>> onFilterActionProperty = new SimpleObjectProperty<>(this, "onFilterAction");
     public final ObjectProperty<EventHandler<ActionEvent>> onFilterActionProperty() {
         return onFilterActionProperty;
@@ -87,7 +145,9 @@ public class KLSearchControl extends Control {
         onFilterActionProperty.set(value);
     }
 
-    // filterSetProperty
+    /**
+     * This boolean property tracks if the filter options are set or not.
+     */
     private final BooleanProperty filterSetProperty = new SimpleBooleanProperty(this, "filterSet");
     public final BooleanProperty filterSetProperty() {
         return filterSetProperty;
@@ -99,27 +159,14 @@ public class KLSearchControl extends Control {
         filterSetProperty.set(value);
     }
 
-    // activationProperty
-    private final DoubleProperty activationProperty = new SimpleDoubleProperty(this, "activation", 500);
-    public final DoubleProperty activationProperty() {
-        return activationProperty;
-    }
-    public final double getActivation() {
-        return activationProperty.get();
-    }
-    public final void setActivation(double value) {
-        activationProperty.set(value);
-    }
-
-    public record SearchResult(ConceptFacade parentConcept, ConceptFacade concept, String highlight) {}
-
-    // resultsProperty
-    private final ObservableList<SearchResult> resultsProperty = FXCollections.observableArrayList();
-    public final ObservableList<SearchResult> resultsProperty() {
-       return resultsProperty;
-    }
-
-    // resultsPlaceholderProperty
+    /**
+     * <p>The results area becomes visible when the search action defined by {@link #onActionProperty()} starts, and
+     * until the {@link SearchResult} are not available, or if {@link #resultsProperty()} is empty, this property can
+     * be used to set a message in the results area.
+     * </p>
+     * <p>When set to null (by default), the default placeholder text is displayed. When set to an empty string,
+     * no placeholder text is displayed.</p>
+     */
     private final StringProperty resultsPlaceholderProperty = new SimpleStringProperty(this, "resultsPlaceholder");
     public final StringProperty resultsPlaceholderProperty() {
         return resultsPlaceholderProperty;
@@ -131,7 +178,30 @@ public class KLSearchControl extends Control {
         resultsPlaceholderProperty.set(value);
     }
 
-    // onLongHoverProperty
+    /**
+     * <p>Double property that sets the milliseconds of activation or delay for performing an action, after
+     * a "long" hovering over a search result.</p>
+     * <p>The 'long-hover` event is defined as the sustained hovering over a search result that lasts at least the
+     * activation milliseconds.</p>
+     * <p>The default value is set to 500 ms.</p>
+     */
+    private final DoubleProperty activationProperty = new SimpleDoubleProperty(this, "activation", 500);
+    public final DoubleProperty activationProperty() {
+        return activationProperty;
+    }
+    public final double getActivation() {
+        return activationProperty.get();
+    }
+    public final void setActivation(double value) {
+        activationProperty.set(value);
+    }
+
+    /**
+     * <p>This property sets a consumer that accepts a {@link dev.ikm.komet.kview.controls.InvertedTree.ConceptItem},
+     * so when a long-hover event occurs over a {@link SearchResult}, the action defined for such consumer can be
+     * performed for it.
+     * </p>
+     */
     private final ObjectProperty<Consumer<InvertedTree.ConceptItem>> onLongHoverProperty = new SimpleObjectProperty<>(this, "onLongHover");
     public final ObjectProperty<Consumer<InvertedTree.ConceptItem>> onLongHoverProperty() {
        return onLongHoverProperty;
@@ -143,7 +213,12 @@ public class KLSearchControl extends Control {
         onLongHoverProperty.set(value);
     }
 
-    // onSearchResultClickProperty
+    /**
+     * <p>This property sets a consumer that accepts a {@link dev.ikm.komet.kview.controls.InvertedTree.ConceptItem},
+     * so when a click event occurs over a {@link SearchResult}, the action defined for such consumer can be
+     * performed for it.
+     * </p>
+     */
     private final ObjectProperty<Consumer<InvertedTree.ConceptItem>> onSearchResultClickProperty = new SimpleObjectProperty<>(this, "onSearchResultClick");
     public final ObjectProperty<Consumer<InvertedTree.ConceptItem>> onSearchResultClickProperty() {
        return onSearchResultClickProperty;
@@ -155,11 +230,36 @@ public class KLSearchControl extends Control {
         onSearchResultClickProperty.set(value);
     }
 
+    /**
+     * <p>The {@link SearchResult} record holds a result after searching a dataset with a given term. This
+     * result includes the {@link ConceptFacade} found, the {@link ConceptFacade} of one of its possible
+     * parents, and the string that was searched for.
+     * </p>
+     * @param parentConcept the {@link ConceptFacade} of one of the possible parents
+     * @param concept the {@link ConceptFacade} found as a result of a search in a dataset of {@link #textProperty()}
+     * @param highlight the term searched, typically defined by {@link #textProperty()}.
+     */
+    public record SearchResult(ConceptFacade parentConcept, ConceptFacade concept, String highlight) {}
+
+    /**
+     * <p>An {@link ObservableList<SearchResult>} that holds the {@link SearchResult} of a search performed
+     * through a dataset.
+     * </p>
+     * <p>This list of items defines the underlying data model a {@link javafx.scene.control.ListView} that
+     * is shown in the results area, with limited height.</p>
+     */
+    private final ObservableList<SearchResult> resultsProperty = FXCollections.observableArrayList();
+    public final ObservableList<SearchResult> resultsProperty() {
+        return resultsProperty;
+    }
+
+    /** {@inheritDoc} **/
     @Override
     protected Skin<?> createDefaultSkin() {
         return new KLSearchControlSkin(this);
     }
 
+    /** {@inheritDoc} **/
     @Override
     public String getUserAgentStylesheet() {
         return KLSearchControl.class.getResource("search-control.css").toExternalForm();

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLSearchControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLSearchControl.java
@@ -1,6 +1,6 @@
 package dev.ikm.komet.kview.controls;
 
-import dev.ikm.komet.kview.controls.skin.SearchControlSkin;
+import dev.ikm.komet.kview.controls.skin.KLSearchControlSkin;
 import dev.ikm.tinkar.terms.ConceptFacade;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -19,9 +19,9 @@ import javafx.scene.control.Skin;
 
 import java.util.function.Consumer;
 
-public class SearchControl extends Control {
+public class KLSearchControl extends Control {
 
-    public SearchControl() {
+    public KLSearchControl() {
 
         getStyleClass().add("search-control");
         getStylesheets().add(getUserAgentStylesheet());
@@ -157,11 +157,11 @@ public class SearchControl extends Control {
 
     @Override
     protected Skin<?> createDefaultSkin() {
-        return new SearchControlSkin(this);
+        return new KLSearchControlSkin(this);
     }
 
     @Override
     public String getUserAgentStylesheet() {
-        return SearchControl.class.getResource("search-control.css").toExternalForm();
+        return KLSearchControl.class.getResource("search-control.css").toExternalForm();
     }
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/SearchControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/SearchControl.java
@@ -17,6 +17,8 @@ import javafx.event.EventHandler;
 import javafx.scene.control.Control;
 import javafx.scene.control.Skin;
 
+import java.util.function.Consumer;
+
 public class SearchControl extends Control {
 
     public SearchControl() {
@@ -59,6 +61,18 @@ public class SearchControl extends Control {
     }
     public final void setOnAction(EventHandler<ActionEvent> value) {
         onActionProperty.set(value);
+    }
+
+    // onClearSearchProperty
+    private final ObjectProperty<EventHandler<ActionEvent>> onClearSearchProperty = new SimpleObjectProperty<>(this, "onClearSearch");
+    public final ObjectProperty<EventHandler<ActionEvent>> onClearSearchProperty() {
+       return onClearSearchProperty;
+    }
+    public final EventHandler<ActionEvent> getOnClearSearch() {
+       return onClearSearchProperty.get();
+    }
+    public final void setOnClearSearch(EventHandler<ActionEvent> value) {
+        onClearSearchProperty.set(value);
     }
 
     // onFilterActionProperty
@@ -115,6 +129,30 @@ public class SearchControl extends Control {
     }
     public final void setResultsPlaceholder(String value) {
         resultsPlaceholderProperty.set(value);
+    }
+
+    // onLongHoverProperty
+    private final ObjectProperty<Consumer<InvertedTree.ConceptItem>> onLongHoverProperty = new SimpleObjectProperty<>(this, "onLongHover");
+    public final ObjectProperty<Consumer<InvertedTree.ConceptItem>> onLongHoverProperty() {
+       return onLongHoverProperty;
+    }
+    public final Consumer<InvertedTree.ConceptItem> getOnLongHover() {
+       return onLongHoverProperty.get();
+    }
+    public final void setOnLongHover(Consumer<InvertedTree.ConceptItem> value) {
+        onLongHoverProperty.set(value);
+    }
+
+    // onSearchResultClickProperty
+    private final ObjectProperty<Consumer<InvertedTree.ConceptItem>> onSearchResultClickProperty = new SimpleObjectProperty<>(this, "onSearchResultClick");
+    public final ObjectProperty<Consumer<InvertedTree.ConceptItem>> onSearchResultClickProperty() {
+       return onSearchResultClickProperty;
+    }
+    public final Consumer<InvertedTree.ConceptItem> getOnSearchResultClick() {
+       return onSearchResultClickProperty.get();
+    }
+    public final void setOnSearchResultClick(Consumer<InvertedTree.ConceptItem> value) {
+        onSearchResultClickProperty.set(value);
     }
 
     @Override

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/ConceptNavigatorHelper.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/ConceptNavigatorHelper.java
@@ -1,5 +1,7 @@
 package dev.ikm.komet.kview.controls.skin;
 
+import dev.ikm.komet.kview.controls.ConceptNavigatorTreeItem;
+import dev.ikm.komet.kview.controls.KLConceptNavigatorControl;
 import dev.ikm.komet.kview.controls.KLConceptNavigatorTreeCell;
 
 /**
@@ -12,6 +14,8 @@ public class ConceptNavigatorHelper {
     public interface ConceptNavigatorAccessor {
         void markCellDirty(KLConceptNavigatorTreeCell treeCell);
         void unselectItem(KLConceptNavigatorTreeCell treeCell);
+
+        ConceptNavigatorTreeItem getConceptNavigatorTreeItem(KLConceptNavigatorControl treeView, int nid, int parentNid);
     }
 
     public static void markCellDirty(KLConceptNavigatorTreeCell treeCell) {
@@ -20,6 +24,10 @@ public class ConceptNavigatorHelper {
 
     public static void unselectItem(KLConceptNavigatorTreeCell treeCell) {
         accessor.unselectItem(treeCell);
+    }
+
+    public static ConceptNavigatorTreeItem getConceptNavigatorTreeItem(KLConceptNavigatorControl treeView, int nid, int parentNid) {
+        return accessor.getConceptNavigatorTreeItem(treeView, nid, parentNid);
     }
 
     public static void setConceptNavigatorAccessor(ConceptNavigatorAccessor accessor) {

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLConceptNavigatorTreeViewSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLConceptNavigatorTreeViewSkin.java
@@ -698,6 +698,7 @@ public class KLConceptNavigatorTreeViewSkin extends TreeViewSkin<ConceptFacade> 
                         }
                     }
                 });
+                item.setViewLineage(false);
                 item.setHighlighted(true);
                 highlighted.set(true);
             }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLConceptNavigatorTreeViewSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLConceptNavigatorTreeViewSkin.java
@@ -50,7 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static dev.ikm.komet.kview.controls.ConceptNavigatorTreeItem.STATE;
@@ -388,7 +387,7 @@ public class KLConceptNavigatorTreeViewSkin extends TreeViewSkin<ConceptFacade> 
      */
     private void unmarkAllItems(STATE state) {
         getConceptNavigatorTreeCellStream().forEach(ConceptNavigatorHelper::unselectItem);
-        iterateTree((ConceptNavigatorTreeItem) getSkinnable().getRoot(), model -> {
+        ConceptNavigatorUtils.iterateTree((ConceptNavigatorTreeItem) getSkinnable().getRoot(), model -> {
             PS_STATE.clearBitsRange(model.getBitSet(), state);
             markCellDirty(model);
         });
@@ -483,23 +482,6 @@ public class KLConceptNavigatorTreeViewSkin extends TreeViewSkin<ConceptFacade> 
         return getConceptNavigatorTreeCellStream()
                 .filter(cell -> treeItem.equals(cell.getTreeItem()))
                 .findFirst();
-    }
-
-    /**
-     * <p>Recursive method that traverses the children of a {@link ConceptNavigatorTreeItem}, applying a certain
-     * function to each of them.
-     * </p>
-     * @param treeItem a {@link ConceptNavigatorTreeItem}
-     * @param consumer a {@link Consumer<ConceptNavigatorTreeItem>} to apply to each tree item
-     */
-    private void iterateTree(ConceptNavigatorTreeItem treeItem, Consumer<ConceptNavigatorTreeItem> consumer) {
-        for (TreeItem<ConceptFacade> child : treeItem.getChildren()) {
-            ConceptNavigatorTreeItem model = (ConceptNavigatorTreeItem) child;
-            consumer.accept(model);
-            if (!child.isLeaf()) {
-                iterateTree(model, consumer);
-            }
-        }
     }
 
     /**

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLConceptNavigatorTreeViewSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLConceptNavigatorTreeViewSkin.java
@@ -13,8 +13,10 @@ import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanWrapper;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.css.PseudoClass;
@@ -25,6 +27,7 @@ import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Group;
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.SnapshotParameters;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
@@ -101,6 +104,7 @@ public class KLConceptNavigatorTreeViewSkin extends TreeViewSkin<ConceptFacade> 
     private MultipleSelectionContextMenu multipleSelectionContextMenu;
     private final SingleSelectionContextMenu singleSelectionContextMenu;
     private boolean isScrollBarDragging;
+    private final BooleanProperty highlighted = new SimpleBooleanProperty();
 
     /**
      * <p>Creates a {@link KLConceptNavigatorTreeViewSkin} instance.
@@ -677,7 +681,25 @@ public class KLConceptNavigatorTreeViewSkin extends TreeViewSkin<ConceptFacade> 
                     }
                 });
                 treeView.getSelectionModel().clearSelection();
+
+                // Clicking anywhere, unhighlights the item
+                EventHandler<MouseEvent> eventFilter = _ -> {
+                    treeView.unhighlightConceptsWithDelay();
+                    highlighted.set(false);
+                };
+                // install/uninstall event filter to the scene that holds the control
+                highlighted.subscribe((_, v) -> {
+                    Scene scene = treeView.getScene();
+                    if (scene != null) {
+                        if (v) {
+                            scene.addEventFilter(MouseEvent.MOUSE_PRESSED, eventFilter);
+                        } else {
+                            scene.removeEventFilter(MouseEvent.MOUSE_PRESSED, eventFilter);
+                        }
+                    }
+                });
                 item.setHighlighted(true);
+                highlighted.set(true);
             }
         }
     }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLSearchControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLSearchControlSkin.java
@@ -3,6 +3,7 @@ package dev.ikm.komet.kview.controls.skin;
 import dev.ikm.komet.kview.controls.IconRegion;
 import dev.ikm.komet.kview.controls.InvertedTree;
 import dev.ikm.komet.kview.controls.KLSearchControl;
+import dev.ikm.tinkar.terms.ConceptFacade;
 import javafx.animation.PauseTransition;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
@@ -35,6 +36,17 @@ import javafx.util.Subscription;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
+/**
+ * <p>Custom skin implementation for the {@link KLSearchControl}.
+ * </p>
+ * <p>This implementation takes care of adding a {@link TextField} as a search field for the user,
+ * with a clear button in it, a filter button and results area to display a
+ * {@link ListView<dev.ikm.komet.kview.controls.KLSearchControl.SearchResult>} with the
+ * search results, with a limited height. This area is only shown when the search field contains some text,
+ * the user has pressed ENTER and a search engine has performed a certain search, setting the results in
+ * the {@link KLSearchControl#resultsProperty()}.
+ * </p>
+ */
 public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
 
     private static final double SEARCH_RESULT_HEIGHT = 43; // 38 + 5
@@ -47,6 +59,19 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
 
     private final ListView<KLSearchControl.SearchResult> resultsPane;
 
+    /**
+     * <p>Creates a {@link KLSearchControlSkin} instance.
+     * </p>
+     * <p>Create the {@link ListView<dev.ikm.komet.kview.controls.KLSearchControl.SearchResult>} instance, and
+     * provide a custom cell factory that uses a {@link SearchResultBox} instance for the graphic node.
+     * </p>
+     * <p>The list height is limited, and up until 4 search results will be visible.
+     * </p>
+     * <p>Adds bindings and listeners to perform the necessary actions based on the {@link KLSearchControl}
+     * properties.
+     * </p>
+     * @param control The control that this skin should be installed onto
+     */
     public KLSearchControlSkin(KLSearchControl control) {
         super(control);
         ResourceBundle resources = ResourceBundle.getBundle("dev.ikm.komet.kview.controls.search-control");
@@ -180,6 +205,7 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
         });
     }
 
+    /** {@inheritDoc} **/
     @Override
     public void dispose() {
         if (subscription != null) {
@@ -193,11 +219,13 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
         super.dispose();
     }
 
+    /** {@inheritDoc} **/
     @Override
     protected double computeMinHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
         return computePrefHeight(width, topInset, rightInset, bottomInset, leftInset);
     }
 
+    /** {@inheritDoc} **/
     @Override
     protected double computePrefHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
         double prefHeight = textField.prefHeight(width) + snappedTopInset() + snappedBottomInset();
@@ -207,11 +235,13 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
         return prefHeight;
     }
 
+    /** {@inheritDoc} **/
     @Override
     protected double computeMaxHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
         return computePrefHeight(width, topInset, rightInset, bottomInset, leftInset);
     }
 
+    /** {@inheritDoc} **/
     @Override
     protected void layoutChildren(double contentX, double contentY, double contentWidth, double contentHeight) {
         double x = snapPositionX(contentX);
@@ -241,6 +271,13 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
         }
     }
 
+    /**
+     * <p>Custom implementation of a {@link Pane} layout, to render the content of a
+     * {@link dev.ikm.komet.kview.controls.KLSearchControl.SearchResult}.
+     * </p>
+     * <p>This can be used to render search results in a {@link ListView} control.
+     * </p>
+     */
     static class SearchResultBox extends Pane {
 
         private static final PseudoClass LONG_HOVER_PSEUDO_CLASS = PseudoClass.getPseudoClass("long-hover");
@@ -255,6 +292,17 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
         private KLSearchControl.SearchResult searchResult;
         private final StringProperty actualTextProperty;
 
+        /**
+         * <p>Creates an instance of a {@link SearchResultBox}.
+         * </p>
+         * <p>A {@link Label} node is used on top with the {@link ConceptFacade#description()} of the parent concept.
+         * </p>
+         * <p>A {@link Label} node is used below with the {@link ConceptFacade#description()} of the concept found in
+         * the search, highlighting the occurrences of the {@link KLSearchControl#textProperty()}.
+         * </p>
+         * @param searchControl the {@link KLSearchControl} with a {@link ListView} control, that
+         *                      will use this box as graphic node for its cells.
+         */
         public SearchResultBox(KLSearchControl searchControl) {
             this.searchControl = searchControl;
             subscription = Subscription.EMPTY;
@@ -289,6 +337,12 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
             getStylesheets().add(KLSearchControl.class.getResource("search-control.css").toExternalForm());
         }
 
+        /**
+         * <p>Update the content of this {@link SearchResultBox} with a new
+         * {@link dev.ikm.komet.kview.controls.KLSearchControl.SearchResult}
+         * </p>
+         * @param result a {@link dev.ikm.komet.kview.controls.KLSearchControl.SearchResult}
+         */
         void setSearchResult(KLSearchControl.SearchResult result) {
             cleanup();
             this.searchResult = result;
@@ -333,6 +387,11 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
             });
         }
 
+        /**
+         * Since this {@link SearchResultBox} is reused in the cells of a listView, before a new
+         * {@link dev.ikm.komet.kview.controls.KLSearchControl.SearchResult} is set, this method performs
+         * necessary clean up operations.
+         */
         void cleanup() {
             pseudoClassStateChanged(LONG_HOVER_PSEUDO_CLASS, false);
             if (subscription != null) {
@@ -342,12 +401,10 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
                 hoverTransition.stop();
                 hoverTransition = null;
             }
-            if (actualDescriptionText != null) {
-                actualDescriptionText.setText(null);
-            }
             descriptionLabel.setTooltip(null);
         }
 
+        /** {@inheritDoc} **/
         @Override
         protected void layoutChildren() {
             super.layoutChildren();
@@ -358,6 +415,11 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
             descriptionLabel.resizeRelocate(snappedLeftInset(), snappedTopInset() + parentDescriptionLabel.getHeight() + 1, conceptWidth, descriptionLabel.prefHeight(conceptWidth));
         }
 
+        /**
+         * Find and add the background {@link Path} nodes to this {@link SearchResultBox}, highlighting
+         * the occurrences of the {@link KLSearchControl#textProperty()} in the
+         * {@link ConceptFacade#description()}.
+         */
         private void addHighlightPaths() {
             getChildren().removeIf(Path.class::isInstance);
             String text = actualTextProperty.get();
@@ -378,6 +440,11 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
             }
         }
 
+        /**
+         * Uses the {@link Text#rangeShape(int, int)} API to get a {@link Path} that
+         * can be filled to define the background of a given segment of a {@link Label},
+         * simulating a highlighting effect.
+         */
         private void addBackgroundPath(int start, int end) {
             final Path path = new Path(actualDescriptionText.rangeShape(start, end));
             path.getStyleClass().add("highlight-path");

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLSearchControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLSearchControlSkin.java
@@ -2,7 +2,7 @@ package dev.ikm.komet.kview.controls.skin;
 
 import dev.ikm.komet.kview.controls.IconRegion;
 import dev.ikm.komet.kview.controls.InvertedTree;
-import dev.ikm.komet.kview.controls.SearchControl;
+import dev.ikm.komet.kview.controls.KLSearchControl;
 import javafx.animation.PauseTransition;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
@@ -35,7 +35,7 @@ import javafx.util.Subscription;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
-public class SearchControlSkin extends SkinBase<SearchControl> {
+public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
 
     private static final double SEARCH_RESULT_HEIGHT = 43; // 38 + 5
 
@@ -45,9 +45,9 @@ public class SearchControlSkin extends SkinBase<SearchControl> {
     private final StackPane filterPane;
     private Subscription subscription;
 
-    private final ListView<SearchControl.SearchResult> resultsPane;
+    private final ListView<KLSearchControl.SearchResult> resultsPane;
 
-    public SearchControlSkin(SearchControl control) {
+    public KLSearchControlSkin(KLSearchControl control) {
         super(control);
         ResourceBundle resources = ResourceBundle.getBundle("dev.ikm.komet.kview.controls.search-control");
 
@@ -81,7 +81,7 @@ public class SearchControlSkin extends SkinBase<SearchControl> {
             }
 
             @Override
-            protected void updateItem(SearchControl.SearchResult item, boolean empty) {
+            protected void updateItem(KLSearchControl.SearchResult item, boolean empty) {
                 super.updateItem(item, empty);
                 if (item != null && !empty) {
                     searchResult.setSearchResult(item);
@@ -94,7 +94,7 @@ public class SearchControlSkin extends SkinBase<SearchControl> {
         resultsPane.managedProperty().bind(resultsPane.visibleProperty());
         resultsPane.setVisible(false);
         resultsPane.setItems(control.resultsProperty());
-        control.resultsProperty().addListener((ListChangeListener<SearchControl.SearchResult>) _ -> {
+        control.resultsProperty().addListener((ListChangeListener<KLSearchControl.SearchResult>) _ -> {
             int itemCount = Math.max(1, Math.min(resultsPane.getItems().size(), 4));
             resultsPane.setPrefHeight(itemCount * SEARCH_RESULT_HEIGHT);
         });
@@ -247,15 +247,15 @@ public class SearchControlSkin extends SkinBase<SearchControl> {
 
         private final Label parentDescriptionLabel;
         private final Label descriptionLabel;
-        private final SearchControl searchControl;
+        private final KLSearchControl searchControl;
         private Text actualDescriptionText;
         private String highlight;
         private PauseTransition hoverTransition;
         private Subscription subscription;
-        private SearchControl.SearchResult searchResult;
+        private KLSearchControl.SearchResult searchResult;
         private final StringProperty actualTextProperty;
 
-        public SearchResultBox(SearchControl searchControl) {
+        public SearchResultBox(KLSearchControl searchControl) {
             this.searchControl = searchControl;
             subscription = Subscription.EMPTY;
 
@@ -286,10 +286,10 @@ public class SearchControlSkin extends SkinBase<SearchControl> {
             getChildren().addAll(parentDescriptionLabel, descriptionLabel);
 
             getStyleClass().add("search-result");
-            getStylesheets().add(SearchControl.class.getResource("search-control.css").toExternalForm());
+            getStylesheets().add(KLSearchControl.class.getResource("search-control.css").toExternalForm());
         }
 
-        void setSearchResult(SearchControl.SearchResult result) {
+        void setSearchResult(KLSearchControl.SearchResult result) {
             cleanup();
             this.searchResult = result;
             highlight = result.highlight().toLowerCase(Locale.ROOT);

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/SearchControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/SearchControlSkin.java
@@ -11,7 +11,10 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.ListChangeListener;
 import javafx.css.PseudoClass;
 import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
 import javafx.geometry.Bounds;
+import javafx.geometry.Point2D;
+import javafx.scene.Scene;
 import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
@@ -21,6 +24,7 @@ import javafx.scene.control.SkinBase;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.shape.Path;
@@ -150,10 +154,28 @@ public class SearchControlSkin extends SkinBase<SearchControl> {
             control.requestLayout();
         });
 
-        textField.focusedProperty().subscribe(f -> {
-            if (f && !resultsPane.getItems().isEmpty() && !resultsPane.isVisible()) {
+        // Clicking anywhere outside the control, hides the resultsPane
+        EventHandler<MouseEvent> eventFilter = e -> {
+            Point2D point2D = new Point2D(e.getSceneX(), e.getSceneY());
+            if (resultsPane.isVisible() && !control.contains(control.sceneToLocal(point2D))) {
+                resultsPane.setVisible(false);
+            }
+        };
+        // install/uninstall event filter to the scene that holds the control
+        subscription = resultsPane.visibleProperty().subscribe((_, b) -> {
+            Scene scene = control.getScene();
+            if (scene != null) {
+                if (b) {
+                    scene.addEventFilter(MouseEvent.MOUSE_CLICKED, eventFilter);
+                } else {
+                    scene.removeEventFilter(MouseEvent.MOUSE_CLICKED, eventFilter);
+                }
+            }
+        });
+        // when clicking inside the textField, show resultsPane
+        textField.addEventHandler(MouseEvent.MOUSE_CLICKED, _ -> {
+            if (!resultsPane.getItems().isEmpty() && !resultsPane.isVisible()) {
                 resultsPane.setVisible(true);
-                control.requestLayout();
             }
         });
     }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
@@ -72,6 +72,7 @@ import dev.ikm.komet.framework.tabs.TabGroup;
 import dev.ikm.komet.framework.view.ObservableViewNoOverride;
 import dev.ikm.komet.framework.view.ViewProperties;
 import dev.ikm.komet.framework.window.WindowSettings;
+import dev.ikm.komet.kview.controls.ConceptNavigatorUtils;
 import dev.ikm.komet.kview.controls.KLConceptNavigatorControl;
 import dev.ikm.komet.kview.controls.KLWorkspace;
 import dev.ikm.komet.kview.controls.NotificationPopup;
@@ -881,7 +882,6 @@ public class JournalController {
     public void loadConceptNavigatorPanel(ViewProperties viewProperties) {
         Navigator navigator = new ViewNavigator(viewProperties.nodeView());
         SearchControl searchControl = new SearchControl();
-
         searchControl.setOnAction(_ -> {
             ViewCalculator calculator = viewProperties.calculator();
             searchControl.setResultsPlaceholder("Searching..."); // DUMMY, resources?
@@ -937,6 +937,9 @@ public class JournalController {
                 populateWorkspaceWithSelection(items.stream()
                         .map(item -> item.publicId().asUuidArray())
                         .toList()));
+        searchControl.setOnLongHover(conceptNavigatorControl::expandAndHighlightConcept);
+        searchControl.setOnSearchResultClick(_ -> conceptNavigatorControl.unhighlightConceptsWithDelay());
+        searchControl.setOnClearSearch(_ -> ConceptNavigatorUtils.resetConceptNavigator(conceptNavigatorControl));
 
         VBox nodePanel = new VBox(searchControl, conceptNavigatorControl);
         nodePanel.getStyleClass().add("concept-navigator-container");

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
@@ -76,7 +76,7 @@ import dev.ikm.komet.kview.controls.ConceptNavigatorUtils;
 import dev.ikm.komet.kview.controls.KLConceptNavigatorControl;
 import dev.ikm.komet.kview.controls.KLWorkspace;
 import dev.ikm.komet.kview.controls.NotificationPopup;
-import dev.ikm.komet.kview.controls.SearchControl;
+import dev.ikm.komet.kview.controls.KLSearchControl;
 import dev.ikm.komet.kview.events.JournalTileEvent;
 import dev.ikm.komet.kview.events.MakeConceptWindowEvent;
 import dev.ikm.komet.kview.events.ShowNavigationalPanelEvent;
@@ -881,14 +881,14 @@ public class JournalController {
      */
     public void loadConceptNavigatorPanel(ViewProperties viewProperties) {
         Navigator navigator = new ViewNavigator(viewProperties.nodeView());
-        SearchControl searchControl = new SearchControl();
+        KLSearchControl searchControl = new KLSearchControl();
         searchControl.setOnAction(_ -> {
             ViewCalculator calculator = viewProperties.calculator();
             searchControl.setResultsPlaceholder("Searching..."); // DUMMY, resources?
             TinkExecutor.threadPool().execute(() -> {
                 try {
                     List<LatestVersionSearchResult> results = calculator.search(searchControl.getText(), 1000).toList();
-                    List<SearchControl.SearchResult> searchResults = new ArrayList<>();
+                    List<KLSearchControl.SearchResult> searchResults = new ArrayList<>();
                     results.stream()
                             .filter(result -> result.latestVersion().isPresent())
                             .forEach(result -> {
@@ -896,15 +896,15 @@ public class JournalController {
                                 searchResults.addAll(
                                         Entity.getConceptForSemantic(semantic.nid()).map(entity -> {
                                             int[] parentNids = navigator.getParentNids(entity.nid());
-                                            List<SearchControl.SearchResult> list = new ArrayList<>();
+                                            List<KLSearchControl.SearchResult> list = new ArrayList<>();
                                             if (parentNids != null) {
                                                 // Add one search result per parent
                                                 for (int parentNid : parentNids) {
                                                     ConceptFacade parent = Entity.getFast(parentNid);
-                                                    list.add(new SearchControl.SearchResult(parent, entity, searchControl.getText()));
+                                                    list.add(new KLSearchControl.SearchResult(parent, entity, searchControl.getText()));
                                                 }
                                             } else {
-                                                list.add(new SearchControl.SearchResult(null, entity, searchControl.getText()));
+                                                list.add(new KLSearchControl.SearchResult(null, entity, searchControl.getText()));
                                             }
                                             return list;
                                         })
@@ -912,7 +912,7 @@ public class JournalController {
                             });
 
                     // NOTE: different semanticIds can give the same entity, remove duplicates
-                    List<SearchControl.SearchResult> distinctResults = searchResults.stream().distinct().toList();
+                    List<KLSearchControl.SearchResult> distinctResults = searchResults.stream().distinct().toList();
                     Platform.runLater(() -> {
                         searchControl.setResultsPlaceholder(null);
                         searchControl.resultsProperty().addAll(distinctResults);

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/concept-navigator.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/concept-navigator.css
@@ -226,6 +226,12 @@
     -fx-padding: 4 4 2 2;
 }
 
+.navigator-tree-cell.tree-cell:highlighted > .concept-tile,
+.navigator-tree-cell.tree-cell:selected:highlighted > .concept-tile {
+    -fx-background-color: #00BD63, #F4FBF0;
+    -fx-background-insets: 0, 1;
+}
+
 .navigator-tree-cell.tree-cell > .concept-tile > .concept-label {
     -fx-font-family: "Noto Sans";
     -fx-font-weight: normal;

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/search-control.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/search-control.css
@@ -177,6 +177,10 @@
     -fx-pref-width: 1;
 }
 
+.search-result:long-hover {
+    -fx-background-color: #5896F6, #F4F9FF;
+}
+
 .search-result > .highlight-path {
     -fx-fill: #C0F5A0;
     -fx-stroke-width: 0;


### PR DESCRIPTION
This PR allows the interaction between SearchControl and KLConceptNavigatorControl, when a search is performed, and the user long-hovers over one of the search results. After some time, the treeView is expanded over the selected concept, and the concept is highlighted, while keeping its parent visible on top of the treeView.

<img width="564" alt="image" src="https://github.com/user-attachments/assets/4831e687-97c3-43fd-8aae-b8a2eca7f5cc" />

If the user clicks on the hovered search result, the search results are hidden, and the highlight effect goes away after some time.

If the user doesn't click on the hovered search result, but selects the concept in the treeView (or opens its lineage box), the highlight effect also goes away, but search results remain visible.

If the user clears the search field with the X button, the navigator is reset.

