### PR TITLE
feature/finished/IIA-1872-ClosePropertiesController-NullPointerException

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ClosePropertiesController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ClosePropertiesController.java
@@ -1,7 +1,5 @@
 package dev.ikm.komet.kview.mvvm.view.genediting;
 
-import static dev.ikm.komet.kview.events.genediting.PropertyPanelEvent.CLOSE_PANEL;
-import static dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel.WINDOW_TOPIC;
 import dev.ikm.komet.framework.events.EvtBusFactory;
 import dev.ikm.komet.kview.events.genediting.PropertyPanelEvent;
 import javafx.event.ActionEvent;
@@ -10,6 +8,9 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import org.carlfx.cognitive.loader.InjectViewModel;
 import org.carlfx.cognitive.viewmodel.SimpleViewModel;
+
+import static dev.ikm.komet.kview.events.genediting.PropertyPanelEvent.CLOSE_PANEL;
+import static dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel.WINDOW_TOPIC;
 
 /**
  * controller for the confirmation screen post save on the
@@ -21,7 +22,7 @@ public class ClosePropertiesController {
      * view model to store the event topic
      */
     @InjectViewModel
-    private SimpleViewModel propertiesViewModel;
+    private SimpleViewModel genEditingViewModel;
 
     /**
      * button to close the properties bump out
@@ -49,7 +50,7 @@ public class ClosePropertiesController {
      */
     @FXML
     private void closeProperties(ActionEvent event) {
-        EvtBusFactory.getDefaultEvtBus().publish(propertiesViewModel.getPropertyValue(WINDOW_TOPIC), new PropertyPanelEvent(event.getSource(), CLOSE_PANEL));
+        EvtBusFactory.getDefaultEvtBus().publish(genEditingViewModel.getPropertyValue(WINDOW_TOPIC), new PropertyPanelEvent(event.getSource(), CLOSE_PANEL));
     }
 
     /**


### PR DESCRIPTION
Jira ticket:

https://ikmdev.atlassian.net/browse/IIA-1872

Before, when pressing the CLOSE PROPERTIES PANEL button, a NullPointerException occurred:

Caused by: java.lang.NullPointerException: Cannot invoke "javafx.beans.property.Property.getValue()" because the return value of "org.carlfx.cognitive.viewmodel.ViewModel.getProperty(String)" is null
	at org.carlfx.cognitive@1.5.1/org.carlfx.cognitive.viewmodel.ViewModel.getPropertyValue(ViewModel.java:257)
	at dev.ikm.komet.kview/dev.ikm.komet.kview.mvvm.view.genediting.ClosePropertiesController.closeProperties(ClosePropertiesController.java:52)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	... 69 more

This was fixed by renaming propertiesViewModel to genEditingViewModel.
The injection didn't work because it couldn't find the name of genEditingViewModel.

After fix:

Submit button pressed, CLOSE PROPERTIES PANEL button displayed

![image](https://github.com/user-attachments/assets/44d8c715-e4f0-4eff-8458-a3606b2dd5d2)

Pressing CLOSE PROPERTIES PANEL now closes the panel without a NullPointerException

![image](https://github.com/user-attachments/assets/fcdc01d9-040a-4196-8450-b6b4449c8c28)
