### PR TITLE
Feature/finished/iia 1892 submit other name causes exception in create mode

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
@@ -15,37 +15,6 @@
  */
 package dev.ikm.komet.kview.mvvm.view.details;
 
-import static dev.ikm.komet.framework.events.FrameworkTopics.RULES_TOPIC;
-import static dev.ikm.komet.kview.fxutils.IconsHelper.IconType.ATTACHMENT;
-import static dev.ikm.komet.kview.fxutils.IconsHelper.IconType.COMMENTS;
-import static dev.ikm.komet.kview.fxutils.MenuHelper.fireContextMenuEvent;
-import static dev.ikm.komet.kview.fxutils.SlideOutTrayHelper.slideIn;
-import static dev.ikm.komet.kview.fxutils.SlideOutTrayHelper.slideOut;
-import static dev.ikm.komet.kview.fxutils.ViewportHelper.clipChildren;
-import static dev.ikm.komet.kview.lidr.mvvm.viewmodel.DeviceViewModel.DEVICE_ENTITY;
-import static dev.ikm.komet.kview.mvvm.model.DataModelHelper.addToMembershipPattern;
-import static dev.ikm.komet.kview.mvvm.model.DataModelHelper.getMembershipPatterns;
-import static dev.ikm.komet.kview.mvvm.model.DataModelHelper.isInMembershipPattern;
-import static dev.ikm.komet.kview.mvvm.model.DataModelHelper.removeFromMembershipPattern;
-import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.AXIOM;
-import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.CONCEPT_STAMP_VIEW_MODEL;
-import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.CREATE;
-import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.CURRENT_ENTITY;
-import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.EDIT;
-import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.FULLY_QUALIFIED_NAME;
-import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.OTHER_NAMES;
-import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.MODE;
-import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.MODULES_PROPERTY;
-import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.PATHS_PROPERTY;
-import static dev.ikm.tinkar.coordinate.stamp.StampFields.MODULE;
-import static dev.ikm.tinkar.coordinate.stamp.StampFields.PATH;
-import static dev.ikm.tinkar.coordinate.stamp.StampFields.STATUS;
-import static dev.ikm.tinkar.coordinate.stamp.StampFields.TIME;
-import static dev.ikm.tinkar.terms.TinkarTerm.DEFINITION_DESCRIPTION_TYPE;
-import static dev.ikm.tinkar.terms.TinkarTerm.DESCRIPTION_CASE_SIGNIFICANCE;
-import static dev.ikm.tinkar.terms.TinkarTerm.FULLY_QUALIFIED_NAME_DESCRIPTION_TYPE;
-import static dev.ikm.tinkar.terms.TinkarTerm.LANGUAGE_CONCEPT_NID_FOR_DESCRIPTION;
-import static dev.ikm.tinkar.terms.TinkarTerm.REGULAR_NAME_DESCRIPTION_TYPE;
 import dev.ikm.komet.framework.Identicon;
 import dev.ikm.komet.framework.events.AxiomChangeEvent;
 import dev.ikm.komet.framework.events.EvtBus;
@@ -56,14 +25,7 @@ import dev.ikm.komet.framework.propsheet.KometPropertySheet;
 import dev.ikm.komet.framework.propsheet.SheetItem;
 import dev.ikm.komet.framework.view.ViewProperties;
 import dev.ikm.komet.kview.controls.KLExpandableNodeListControl;
-import dev.ikm.komet.kview.events.AddFullyQualifiedNameEvent;
-import dev.ikm.komet.kview.events.AddOtherNameToConceptEvent;
-import dev.ikm.komet.kview.events.ClosePropertiesPanelEvent;
-import dev.ikm.komet.kview.events.CreateConceptEvent;
-import dev.ikm.komet.kview.events.EditConceptEvent;
-import dev.ikm.komet.kview.events.EditConceptFullyQualifiedNameEvent;
-import dev.ikm.komet.kview.events.EditOtherNameConceptEvent;
-import dev.ikm.komet.kview.events.OpenPropertiesPanelEvent;
+import dev.ikm.komet.kview.events.*;
 import dev.ikm.komet.kview.fxutils.IconsHelper;
 import dev.ikm.komet.kview.fxutils.MenuHelper;
 import dev.ikm.komet.kview.mvvm.model.DataModelHelper;
@@ -76,21 +38,8 @@ import dev.ikm.komet.preferences.KometPreferences;
 import dev.ikm.tinkar.common.id.PublicId;
 import dev.ikm.tinkar.coordinate.stamp.calculator.Latest;
 import dev.ikm.tinkar.coordinate.view.calculator.ViewCalculator;
-import dev.ikm.tinkar.entity.ConceptEntity;
-import dev.ikm.tinkar.entity.EntityService;
-import dev.ikm.tinkar.entity.EntityVersion;
-import dev.ikm.tinkar.entity.FieldDefinitionForEntity;
-import dev.ikm.tinkar.entity.FieldDefinitionRecord;
-import dev.ikm.tinkar.entity.FieldRecord;
-import dev.ikm.tinkar.entity.PatternEntity;
-import dev.ikm.tinkar.entity.PatternEntityVersion;
-import dev.ikm.tinkar.entity.SemanticEntityVersion;
-import dev.ikm.tinkar.entity.StampEntity;
-import dev.ikm.tinkar.terms.ConceptFacade;
-import dev.ikm.tinkar.terms.EntityFacade;
-import dev.ikm.tinkar.terms.EntityProxy;
-import dev.ikm.tinkar.terms.State;
-import dev.ikm.tinkar.terms.TinkarTerm;
+import dev.ikm.tinkar.entity.*;
+import dev.ikm.tinkar.terms.*;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
@@ -100,17 +49,7 @@ import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.geometry.Side;
 import javafx.scene.Node;
-import javafx.scene.control.Button;
-import javafx.scene.control.ContextMenu;
-import javafx.scene.control.Hyperlink;
-import javafx.scene.control.Label;
-import javafx.scene.control.MenuItem;
-import javafx.scene.control.SeparatorMenuItem;
-import javafx.scene.control.TextField;
-import javafx.scene.control.TitledPane;
-import javafx.scene.control.ToggleButton;
-import javafx.scene.control.Tooltip;
-import javafx.scene.control.ScrollPane;
+import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.ScrollEvent;
@@ -118,11 +57,7 @@ import javafx.scene.layout.*;
 import javafx.scene.shape.SVGPath;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
-import org.carlfx.cognitive.loader.Config;
-import org.carlfx.cognitive.loader.FXMLMvvmLoader;
-import org.carlfx.cognitive.loader.InjectViewModel;
-import org.carlfx.cognitive.loader.JFXNode;
-import org.carlfx.cognitive.loader.NamedVm;
+import org.carlfx.cognitive.loader.*;
 import org.carlfx.cognitive.viewmodel.ValidationViewModel;
 import org.carlfx.cognitive.viewmodel.ViewModel;
 import org.controlsfx.control.PopOver;
@@ -138,6 +73,24 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+
+import static dev.ikm.komet.framework.events.FrameworkTopics.RULES_TOPIC;
+import static dev.ikm.komet.kview.fxutils.IconsHelper.IconType.ATTACHMENT;
+import static dev.ikm.komet.kview.fxutils.IconsHelper.IconType.COMMENTS;
+import static dev.ikm.komet.kview.fxutils.MenuHelper.fireContextMenuEvent;
+import static dev.ikm.komet.kview.fxutils.SlideOutTrayHelper.slideIn;
+import static dev.ikm.komet.kview.fxutils.SlideOutTrayHelper.slideOut;
+import static dev.ikm.komet.kview.fxutils.ViewportHelper.clipChildren;
+import static dev.ikm.komet.kview.lidr.mvvm.viewmodel.DeviceViewModel.DEVICE_ENTITY;
+import static dev.ikm.komet.kview.mvvm.model.DataModelHelper.*;
+import static dev.ikm.komet.kview.mvvm.viewmodel.ConceptViewModel.*;
+import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.MODE;
+import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.MODULES_PROPERTY;
+import static dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel.PATHS_PROPERTY;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.*;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.MODULE;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.PATH;
+import static dev.ikm.tinkar.terms.TinkarTerm.*;
 
 public class DetailsController  {
     private static final Logger LOG = LoggerFactory.getLogger(DetailsController.class);
@@ -1053,10 +1006,22 @@ public class DetailsController  {
         TextFlow row1 = new TextFlow();
 
         // TODO: need to retrieve the description Semantic's Text field (latest version text).
+
+        // during CREATE mode the semanticPublicId is null, which causes the
+        // NullPointerException when attempting to display the other name
+
         PublicId semanticPid = otherName.getSemanticPublicId();
-        int nid = EntityService.get().nidForPublicId(semanticPid);
-        Latest<SemanticEntityVersion> regularDescriptionTextversion = getViewProperties().calculator().latest(nid);
-        Text otherNameLabel = new Text(regularDescriptionTextversion.get().fieldValues().get(1).toString());
+        Text otherNameLabel;
+
+        // the semanticPid is null in CREATE mode, so use the nameText that was entered
+        // instead of the semanticPid field value
+        if (semanticPid != null) {
+            int nid = EntityService.get().nidForPublicId(semanticPid);
+            Latest<SemanticEntityVersion> regularDescriptionTextversion = getViewProperties().calculator().latest(nid);
+            otherNameLabel = new Text(regularDescriptionTextversion.get().fieldValues().get(1).toString());
+        } else {
+            otherNameLabel = new Text(otherName.getNameText());
+        }
         LOG.info("otherNameLabel : "+otherNameLabel);
 
         otherNameLabel.getStyleClass().add("descr-concept-name");

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/details/DetailsController.java
@@ -1007,14 +1007,11 @@ public class DetailsController  {
 
         // TODO: need to retrieve the description Semantic's Text field (latest version text).
 
-        // during CREATE mode the semanticPublicId is null, which causes the
-        // NullPointerException when attempting to display the other name
-
         PublicId semanticPid = otherName.getSemanticPublicId();
         Text otherNameLabel;
 
-        // the semanticPid is null in CREATE mode, so use the nameText that was entered
-        // instead of the semanticPid field value
+        // the semanticPublicId is null in CREATE mode, so use the nameText that was entered
+        // instead of the semanticPublicId field value
         if (semanticPid != null) {
             int nid = EntityService.get().nidForPublicId(semanticPid);
             Latest<SemanticEntityVersion> regularDescriptionTextversion = getViewProperties().calculator().latest(nid);


### PR DESCRIPTION
Jira ticket:

https://ikmdev.atlassian.net/browse/IIA-1892

The problem is actually in DetailsController.generateOtherNameRow(DescrName) and is caused by the MODE still being in CREATE.

During CREATE mode the otherName semanticId has not been set.

Only when the Concept goes into edit mode is the semanticId set, which is done within ConceptViewModel.createConcept().  But only if there is an Axiom defined in the Concept.

In CREATE mode the Fully Qualified Name and Other Names are stored in the ConceptViewModel, they have not yet been persisted.

When an Axiom exists and an Other Name is created, only then does the FQN and Other Name persist, and the other name’s sematicId is set.

Adding a conditional in generateOtherNameRow() for a null semanticId to use the other name as entered rather than using the semanticId to get the name fixes the problem.

![image](https://github.com/user-attachments/assets/ea94c89a-6435-430b-b272-5dd112e50df9)

After fix:

![image](https://github.com/user-attachments/assets/267418f8-37ca-44e1-9066-a631b49b137e)

Note that the Concept is still in CREATE mode.  An Axiom has not yet been created.
