### PR TITLE
Feature/finished/iia 1920 float integer control skin exceptions

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLFloatControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLFloatControlSkin.java
@@ -86,12 +86,12 @@ public class KLFloatControlSkin extends SkinBase<KLFloatControl> {
                     double value = Double.parseDouble(newText);
                     // discard if we have a valid value, but it is infinite or NaN
                     if (Double.isInfinite(value) || Double.isNaN(value)) {
-                        errorLabel.setText("error1" /* resources.getString("error.float.text") */);
+                        errorLabel.setText(resources.getString("error.float.text"));
                         control.setShowError(true);
                         return null;
                     }
                 } catch (NumberFormatException nfe) {
-                    errorLabel.setText("error2" /* resources.getString("error.float.text") */);
+                    errorLabel.setText(resources.getString("error.float.text"));
                     control.setShowError(true);
                     return null;
                 }
@@ -121,7 +121,7 @@ public class KLFloatControlSkin extends SkinBase<KLFloatControl> {
                     return change;
                 }
             }
-            errorLabel.setText("error3" /* resources.getString("error.float.text") */);
+            errorLabel.setText(resources.getString("error.float.text"));
             control.setShowError(true);
             return null;
         }));

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLFloatControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLFloatControlSkin.java
@@ -79,7 +79,7 @@ public class KLFloatControlSkin extends SkinBase<KLFloatControl> {
                     NUMERICAL_PATTERN.matcher(newText).matches()) {
                 // checking for exponent at the end of the newText allows the exponent
                 // to be entered naturally
-                if (newText.isEmpty() || endsWithExponent(newText)) {
+                if (newText.isEmpty() || "-".equals(newText) || "+".equals(newText) || endsWithExponent(newText)) {
                     return change;
                 }
                 try {

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLFloatControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLFloatControlSkin.java
@@ -77,6 +77,8 @@ public class KLFloatControlSkin extends SkinBase<KLFloatControl> {
                     (("-".equals(addedText) || "+".equals(addedText)) && (oldText.isEmpty() || endsWithExponent(oldText))) ||
                     (addedText.isEmpty() && ("+".equals(newText) || "-".equals(newText) || hasExponent(newText) || hasSignedExponent(newText))) ||
                     NUMERICAL_PATTERN.matcher(newText).matches()) {
+                // checking for exponent at the end of the newText allows the exponent
+                // to be entered naturally
                 if (newText.isEmpty() || endsWithExponent(newText)) {
                     return change;
                 }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLIntegerControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLIntegerControlSkin.java
@@ -76,7 +76,7 @@ public class KLIntegerControlSkin extends SkinBase<KLIntegerControl> {
                             Integer.parseInt(text);
                         } catch (Exception e) {
                             // or else discard the change and warn
-                            errorLabel.setText("error1" /* resources.getString("error.integer.text") */);
+                            errorLabel.setText(resources.getString("error.integer.text"));
                             control.setShowError(true);
                             return null;
                         }
@@ -93,7 +93,7 @@ public class KLIntegerControlSkin extends SkinBase<KLIntegerControl> {
                     }
                     return change;
                 } else {
-                    errorLabel.setText("error2" /* resources.getString("error.integer.text") */);
+                    errorLabel.setText(resources.getString("error.integer.text"));
                     control.setShowError(true);
                 }
             }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLIntegerControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLIntegerControlSkin.java
@@ -12,7 +12,6 @@ import javafx.util.Duration;
 import javafx.util.Subscription;
 import javafx.util.converter.IntegerStringConverter;
 
-import java.text.MessageFormat;
 import java.util.ResourceBundle;
 import java.util.regex.Pattern;
 
@@ -21,7 +20,7 @@ import java.util.regex.Pattern;
  */
 public class KLIntegerControlSkin extends SkinBase<KLIntegerControl> {
 
-    private static final Pattern NUMERICAL_PATTERN = Pattern.compile("^(0|[1-9][0-9]*)$"); // allow '-', don't start with 0, but allow a zero by itself
+    private static final Pattern NUMERICAL_PATTERN = Pattern.compile("^-?(0|[1-9][0-9]*)$"); // allow '-', don't start with 0, but allow a zero by itself
     private static final ResourceBundle resources = ResourceBundle.getBundle("dev.ikm.komet.kview.controls.integer-control");
 
     // public to share with KLFloatControlSkin
@@ -63,34 +62,42 @@ public class KLIntegerControlSkin extends SkinBase<KLIntegerControl> {
         textField.setTextFormatter(new TextFormatter<>(new IntegerStringConverter(), null, change -> {
             errorLabel.setText(null);
             control.setShowError(false);
-            String text = change.getControlNewText();
-            if (text.isEmpty() || NUMERICAL_PATTERN.matcher(text).matches()) {
-                if (!text.isEmpty() && !"-".equals(text)) {
-                    // check that text is within [MIN_VALUE, MAX_VALUE]
-                    try {
-                        Integer.parseInt(text);
-                    } catch (Exception e) {
-                        // or else discard the change and warn
-                        errorLabel.setText(MessageFormat.format(resources.getString("error.integer.text"), text));
-                        control.setShowError(true);
-                        return null;
-                    }
-                }
-                return change;
-            } else if ("-".equals(change.getText()) ) {
-                if (change.getControlText().startsWith("-")) { // if text starts with '-', cancel it
-                    change.setText("");
-                    change.setRange(0, 1);
-                    change.setCaretPosition(change.getCaretPosition() - 2);
-                    change.setAnchor(change.getAnchor() - 2);
-                } else { // a '-', typed from any position, will be set at the beginning of the text
-                    change.setRange(0, 0);
-                }
+
+            if (!change.isContentChange()) {
+                // change can also be cursor location, so if no content change, then it is
+                // something else like cursor location change
                 return change;
             } else {
-                errorLabel.setText(MessageFormat.format(resources.getString("error.integer.text"), change.getText()));
-                control.setShowError(true);
+                String text = change.getControlNewText();
+                if (text.isEmpty() || NUMERICAL_PATTERN.matcher(text).matches()) {
+                    if (!text.isEmpty() && !"-".equals(text)) {
+                        // check that text is within [MIN_VALUE, MAX_VALUE]
+                        try {
+                            Integer.parseInt(text);
+                        } catch (Exception e) {
+                            // or else discard the change and warn
+                            errorLabel.setText("error1" /* resources.getString("error.integer.text") */);
+                            control.setShowError(true);
+                            return null;
+                        }
+                    }
+                    return change;
+                } else if ("-".equals(change.getText())) {
+                    if (change.getControlText().startsWith("-")) { // if text starts with '-', cancel it
+                        change.setText("");
+                        change.setRange(0, 1);
+                        change.setCaretPosition(change.getCaretPosition() - 2);
+                        change.setAnchor(change.getAnchor() - 2);
+                    } else { // a '-', typed from any position, will be set at the beginning of the text
+                        change.setRange(0, 0);
+                    }
+                    return change;
+                } else {
+                    errorLabel.setText("error2" /* resources.getString("error.integer.text") */);
+                    control.setShowError(true);
+                }
             }
+
             return null;
         }));
 


### PR DESCRIPTION
Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-1920

Summary of changes:

- added optional minus sign at beginning of KLIntegerControlSkin regex:  "^-?(0|[1-9][0-9]*)$"
- restructured conditionals to allow for additional checks of "-", "+", and exponent
- added checks for "-" (and "+" since float regex allows optional + at beginning) in KLFloatControlSkin

Before fix:

For Integer field, enter - followed by a decimal

![image](https://github.com/user-attachments/assets/2c5050e3-500a-47a2-98ff-167cd9a2e585)

For Float field, enter -

![image](https://github.com/user-attachments/assets/657d58ad-7274-4e1a-b48a-fcbe845eabac)

After fix:

Integer field now allows - and decimal without error

![image](https://github.com/user-attachments/assets/aa3b111b-62a0-477d-a68e-2eab50fb8916)

Float field now no exception:

![image](https://github.com/user-attachments/assets/d1cf3193-b719-43d2-93b2-bad0504d87f0)

![image](https://github.com/user-attachments/assets/817b4c4b-d451-42ed-8644-c779db0919ea)

![image](https://github.com/user-attachments/assets/1b85403a-973c-4f6d-867d-4d2ee6926f1f)

