### PR TITLE
Add enum with actions and change onAction API to allow different consumers

### DIFF
--- a/application/src/test/java/dev/ikm/komet/sampler/controllers/SamplerConceptNavigatorController.java
+++ b/application/src/test/java/dev/ikm/komet/sampler/controllers/SamplerConceptNavigatorController.java
@@ -34,6 +34,8 @@ import javafx.scene.control.TreeItem;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.VBox;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,6 +49,8 @@ import static dev.ikm.komet.kview.controls.KLConceptNavigatorTreeCell.CONCEPT_NA
 import static dev.ikm.komet.preferences.JournalWindowPreferences.MAIN_KOMET_WINDOW;
 
 public class SamplerConceptNavigatorController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SamplerConceptNavigatorController.class);
 
     @FXML
     private Label samplerDescription;
@@ -212,7 +216,7 @@ public class SamplerConceptNavigatorController {
                             .map(nid -> (ConceptFacade) Entity.getFast(nid)).toList();
                     ((ConceptNavigatorTreeItem) selectedItem).setRelatedConcepts(list);
                 }
-                yield i -> System.out.println("Click! on " + i.description());
+                yield i ->  LOG.info("Click on {}", i.description());
             }
             case SEND_TO_JOURNAL, SEND_TO_CHAPTER, COPY, SAVE_TO_FAVORITES -> _ -> {}; // TODO: Add implementation
         });

--- a/application/src/test/resources/dev/ikm/komet/sampler/Sampler_KLConceptNavigatorControl.fxml
+++ b/application/src/test/resources/dev/ikm/komet/sampler/Sampler_KLConceptNavigatorControl.fxml
@@ -11,6 +11,7 @@
 
 <?import javafx.scene.control.CheckBox?>
 <?import dev.ikm.komet.kview.controls.KLSearchControl?>
+<?import javafx.scene.control.Button?>
 <ScrollPane styleClass="sample-container" fitToWidth="true" hbarPolicy="NEVER" vbarPolicy="AS_NEEDED"
             xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.sampler.controllers.SamplerConceptNavigatorController">
     <VBox>
@@ -30,6 +31,7 @@
                 <Label text="Pick the dataset" styleClass="title"/>
                 <VBox fx:id="datasetBox" styleClass="dataset-box"/>
                 <CheckBox fx:id="showTagsCheckBox" text="Show Tags" styleClass="title"/>
+                <Button fx:id="cleanAreaButton" text="Clear workspace" onAction="#cleanArea" />
             </VBox>
         </SplitPane>
 

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptNavigatorTreeItem.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/ConceptNavigatorTreeItem.java
@@ -9,6 +9,7 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.TreeItem;
 
 import java.util.BitSet;
+import java.util.List;
 
 import static dev.ikm.komet.kview.controls.KLConceptNavigatorControl.MAX_LEVEL;
 
@@ -239,6 +240,21 @@ public class ConceptNavigatorTreeItem extends TreeItem<ConceptFacade> {
     }
     public final void setHighlighted(boolean value) {
         highlightedProperty.set(value);
+    }
+
+    /**
+     * Property that adds a list of related concepts to this concept TreeItem
+     * TODO
+     */
+    private final ObjectProperty<List<ConceptFacade>> relatedConceptsProperty = new SimpleObjectProperty<>(this, "relatedConcepts");
+    public final ObjectProperty<List<ConceptFacade>> relatedConceptsProperty() {
+       return relatedConceptsProperty;
+    }
+    public final List<ConceptFacade> getRelatedConcepts() {
+       return relatedConceptsProperty.get();
+    }
+    public final void setRelatedConcepts(List<ConceptFacade> value) {
+        relatedConceptsProperty.set(value);
     }
 
     /**

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorControl.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * <p>The KLConceptNavigatorControl control is a {@link TreeView} that provides a view on to a tree root
@@ -195,22 +196,23 @@ public class KLConceptNavigatorControl extends TreeView<ConceptFacade> {
     }
 
     /**
-     * <p>This property sets a consumer that accepts a list of {@link ConceptFacade}, so when one or more items are
-     * selected from the {@link KLConceptNavigatorControl}, the action defined for such consumer can be performed for
+     * <p>This property sets a {@link Function} that can be used to define an {@link Consumer<ConceptFacade>} after
+     * a given {@link CONTEXT_MENU_ACTION action}, so when one or more {@link ConceptFacade} items are
+     * selected from the {@link KLConceptNavigatorControl}, the operation defined for such function can be performed for
      * each of them.
      * </p>
      * <p>For instance, after selecting a number of items, a drag and drop gesture would drag those items from
      * the control and drop them in the {@link KLWorkspace}.
      * </p>
      */
-    private final ObjectProperty<Consumer<List<ConceptFacade>>> onActionProperty = new SimpleObjectProperty<>(this, "onAction");
-    public final ObjectProperty<Consumer<List<ConceptFacade>>> onActionProperty() {
+    private final ObjectProperty<Function<CONTEXT_MENU_ACTION, Consumer<ConceptFacade>>> onActionProperty = new SimpleObjectProperty<>(this, "onAction");
+    public final ObjectProperty<Function<CONTEXT_MENU_ACTION, Consumer<ConceptFacade>>> onActionProperty() {
        return onActionProperty;
     }
-    public final Consumer<List<ConceptFacade>> getOnAction() {
+    public final Function<CONTEXT_MENU_ACTION, Consumer<ConceptFacade>> getOnAction() {
        return onActionProperty.get();
     }
-    public final void setOnAction(Consumer<List<ConceptFacade>> value) {
+    public final void setOnAction(Function<CONTEXT_MENU_ACTION, Consumer<ConceptFacade>> value) {
         onActionProperty.set(value);
     }
 
@@ -277,6 +279,69 @@ public class KLConceptNavigatorControl extends TreeView<ConceptFacade> {
     }
     public final void setShowTags(boolean value) {
         showTagsProperty.set(value);
+    }
+
+    /**
+     * <p>This enum defines the possible actions that can be executed from the
+     * different context menus that are shown for this control.
+     * </p>
+     * @see #onActionProperty()
+     * @see SingleSelectionContextMenu
+     * @see MultipleSelectionContextMenu
+     */
+    public enum CONTEXT_MENU_ACTION {
+        /**
+         * <p>For a single ConceptNavigatorTreeItem, when this action is fired, show a submenu with a menuItem
+         * per related concept, with its own action.
+         * </p>
+         * @see ConceptNavigatorTreeItem#relatedConceptsProperty()
+         */
+        SHOW_RELATED_CONCEPTS,
+
+        /**
+         * <p>For a single ConceptNavigatorTreeItem, when this action is fired, open it in the
+         * workspace.
+         * </p>
+         * @see KLWorkspace
+         */
+        OPEN_IN_WORKSPACE,
+
+        /**
+         * <p>For a multiple selection of ConceptNavigatorTreeItem, when this action is fired, open them in the
+         * workspace.</p>
+         * @see KLWorkspace
+         */
+        POPULATE_SELECTION,
+
+        /**
+         * TODO
+         */
+        SEND_TO_JOURNAL,
+
+        /**
+         * TODO
+         */
+        SEND_TO_CHAPTER,
+
+        /**
+         * TODO
+         */
+        COPY,
+
+        /**
+         * TODO
+         */
+        SAVE_TO_FAVORITES;
+
+        public static List<CONTEXT_MENU_ACTION> getSingleActions() {
+            return List.of(SHOW_RELATED_CONCEPTS, OPEN_IN_WORKSPACE);
+        }
+
+        public static List<CONTEXT_MENU_ACTION> getMultipleActions() {
+            return List.of(POPULATE_SELECTION, SEND_TO_JOURNAL, SEND_TO_CHAPTER, COPY, SAVE_TO_FAVORITES);
+        }
+
+
     }
 
     /** {@inheritDoc} **/

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorTreeCell.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorTreeCell.java
@@ -19,7 +19,7 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.shape.Path;
 
 import java.util.BitSet;
-import java.util.List;
+import java.util.function.Consumer;
 
 import static dev.ikm.komet.kview.controls.ConceptNavigatorTreeItem.PS_STATE;
 import static dev.ikm.komet.kview.controls.KLConceptNavigatorControl.MAX_LEVEL;
@@ -146,7 +146,10 @@ public class KLConceptNavigatorTreeCell extends TreeCell<ConceptFacade> {
         addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
             if (e.getButton() == MouseButton.PRIMARY && e.getClickCount() == 2 && !isEmpty() && !isViewLineage()) {
                 if (treeView.getOnAction() != null) {
-                    treeView.getOnAction().accept(List.of(getItem()));
+                    Consumer<ConceptFacade> consumer = treeView.getOnAction().apply(KLConceptNavigatorControl.CONTEXT_MENU_ACTION.OPEN_IN_WORKSPACE);
+                    if (consumer != null) {
+                        consumer.accept(getItem());
+                    }
                 }
                 e.consume();
             }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/MultipleSelectionContextMenu.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/MultipleSelectionContextMenu.java
@@ -17,11 +17,11 @@ import java.util.ResourceBundle;
  */
 public class MultipleSelectionContextMenu extends ContextMenu {
 
-    private final MenuItem populateMessage;
-    private final MenuItem journalMessage;
-    private final MenuItem chapterMessage;
-    private final MenuItem copyMessage;
-    private final MenuItem saveMessage;
+    private final MenuItem populateMenuItem;
+    private final MenuItem journalMenuItem;
+    private final MenuItem chapterMenuItem;
+    private final MenuItem copyMenuItem;
+    private final MenuItem saveMenuItem;
 
     /**
      * Creates a new MultipleSelectionContextMenu
@@ -30,64 +30,64 @@ public class MultipleSelectionContextMenu extends ContextMenu {
         setAutoHide(true);
         ResourceBundle resources = ResourceBundle.getBundle("dev.ikm.komet.kview.controls.concept-navigator");
 
-        populateMessage = new MenuItem(resources.getString("multi.selection.context.menu.option.populate"), new IconRegion("icon", "populate"));
-        journalMessage = new MenuItem(resources.getString("multi.selection.context.menu.option.journal"), new IconRegion("icon", "send"));
-        chapterMessage = new MenuItem(resources.getString("multi.selection.context.menu.option.chapter"), new IconRegion("icon", "send"));
-        copyMessage = new MenuItem(resources.getString("multi.selection.context.menu.option.copy"), new IconRegion("icon", "duplicate"));
-        saveMessage = new MenuItem(resources.getString("multi.selection.context.menu.option.save"), new IconRegion("icon", "save"));
+        populateMenuItem = new MenuItem(resources.getString("multi.selection.context.menu.option.populate"), new IconRegion("icon", "populate"));
+        journalMenuItem = new MenuItem(resources.getString("multi.selection.context.menu.option.journal"), new IconRegion("icon", "send"));
+        chapterMenuItem = new MenuItem(resources.getString("multi.selection.context.menu.option.chapter"), new IconRegion("icon", "send"));
+        copyMenuItem = new MenuItem(resources.getString("multi.selection.context.menu.option.copy"), new IconRegion("icon", "duplicate"));
+        saveMenuItem = new MenuItem(resources.getString("multi.selection.context.menu.option.save"), new IconRegion("icon", "save"));
 
-        getItems().addAll(populateMessage, journalMessage, chapterMessage, copyMessage, saveMessage);
+        getItems().addAll(populateMenuItem, journalMenuItem, chapterMenuItem, copyMenuItem, saveMenuItem);
         setAnchorLocation(AnchorLocation.CONTENT_TOP_LEFT);
     }
 
     /**
-     * <p>Sets the {@link EventHandler<ActionEvent>} that will be handled when the {@link #populateMessage} menu
+     * <p>Sets the {@link EventHandler<ActionEvent>} that will be handled when the {@link #populateMenuItem} menu
      * item is fired.
      * </p>
      * @param eventHandler a {@link EventHandler<ActionEvent>}
      */
-    public void setPopulateMessageAction(EventHandler<ActionEvent> eventHandler) {
-        populateMessage.setOnAction(eventHandler);
+    public void setPopulateMenuItemAction(EventHandler<ActionEvent> eventHandler) {
+        populateMenuItem.setOnAction(eventHandler);
     }
 
     /**
-     * <p>Sets the {@link EventHandler<ActionEvent>} that will be handled when the {@link #journalMessage} menu
+     * <p>Sets the {@link EventHandler<ActionEvent>} that will be handled when the {@link #journalMenuItem} menu
      * item is fired.
      * </p>
      * @param eventHandler a {@link EventHandler<ActionEvent>}
      */
-    public void setJournalMessageAction(EventHandler<ActionEvent> eventHandler) {
-        journalMessage.setOnAction(eventHandler);
+    public void setJournalMenuItemAction(EventHandler<ActionEvent> eventHandler) {
+        journalMenuItem.setOnAction(eventHandler);
     }
 
     /**
-     * <p>Sets the {@link EventHandler<ActionEvent>} that will be handled when the {@link #chapterMessage} menu
+     * <p>Sets the {@link EventHandler<ActionEvent>} that will be handled when the {@link #chapterMenuItem} menu
      * item is fired.
      * </p>
      * @param eventHandler a {@link EventHandler<ActionEvent>}
      */
-    public void setChapterMessageAction(EventHandler<ActionEvent> eventHandler) {
-        chapterMessage.setOnAction(eventHandler);
+    public void setChapterMenuItemAction(EventHandler<ActionEvent> eventHandler) {
+        chapterMenuItem.setOnAction(eventHandler);
     }
 
     /**
-     * <p>Sets the {@link EventHandler<ActionEvent>} that will be handled when the {@link #copyMessage} menu
+     * <p>Sets the {@link EventHandler<ActionEvent>} that will be handled when the {@link #copyMenuItem} menu
      * item is fired.
      * </p>
      * @param eventHandler a {@link EventHandler<ActionEvent>}
      */
-    public void setCopyMessageAction(EventHandler<ActionEvent> eventHandler) {
-        copyMessage.setOnAction(eventHandler);
+    public void setCopyMenuItemAction(EventHandler<ActionEvent> eventHandler) {
+        copyMenuItem.setOnAction(eventHandler);
     }
 
     /**
-     * <p>Sets the {@link EventHandler<ActionEvent>} that will be handled when the {@link #saveMessage} menu
+     * <p>Sets the {@link EventHandler<ActionEvent>} that will be handled when the {@link #saveMenuItem} menu
      * item is fired.
      * </p>
      * @param eventHandler a {@link EventHandler<ActionEvent>}
      */
-    public void setSaveMessageAction(EventHandler<ActionEvent> eventHandler) {
-        saveMessage.setOnAction(eventHandler);
+    public void setSaveMenuItemAction(EventHandler<ActionEvent> eventHandler) {
+        saveMenuItem.setOnAction(eventHandler);
     }
 
     /**

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
@@ -71,6 +71,7 @@ import dev.ikm.komet.framework.tabs.DetachableTab;
 import dev.ikm.komet.framework.tabs.TabGroup;
 import dev.ikm.komet.framework.view.ObservableViewNoOverride;
 import dev.ikm.komet.framework.view.ViewProperties;
+import dev.ikm.komet.kview.controls.ConceptNavigatorTreeItem;
 import dev.ikm.komet.kview.controls.ConceptNavigatorUtils;
 import dev.ikm.komet.kview.controls.KLConceptNavigatorControl;
 import dev.ikm.komet.kview.controls.KLWorkspace;
@@ -174,6 +175,7 @@ import org.slf4j.LoggerFactory;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -492,8 +494,8 @@ public class JournalController {
             Dragboard dragboard = event.getDragboard();
             boolean success = false;
             if (event.getDragboard().hasContent(CONCEPT_NAVIGATOR_DRAG_FORMAT)) {
-                List<UUID[]> uuids = (List<UUID[]>) dragboard.getContent(CONCEPT_NAVIGATOR_DRAG_FORMAT);
-                populateWorkspaceWithSelection(uuids);
+                List<List<UUID[]>> uuids = (List<List<UUID[]>>) dragboard.getContent(CONCEPT_NAVIGATOR_DRAG_FORMAT);
+                uuids.forEach(this::populateWorkspaceWithSelection);
                 success = true;
             } else if (dragboard.hasString()) {
                 try {
@@ -959,10 +961,30 @@ public class JournalController {
         conceptNavigatorControl.setNavigator(navigator);
         conceptNavigatorControl.setHeader("Concept Header");
         conceptNavigatorControl.setShowTags(false);
-        conceptNavigatorControl.setOnAction(items ->
-                populateWorkspaceWithSelection(items.stream()
-                        .map(item -> item.publicId().asUuidArray())
-                        .toList()));
+        conceptNavigatorControl.setOnAction(action -> switch (action) {
+            // single selection
+            case OPEN_IN_WORKSPACE -> item -> {
+                List<UUID[]> uuids = List.<UUID[]>of(item.publicId().asUuidArray());
+                populateWorkspaceWithSelection(uuids);
+            };
+            case SHOW_RELATED_CONCEPTS -> {
+                // Dummy, for now just add the parents of the selected item as related content:
+                TreeItem<ConceptFacade> selectedItem = conceptNavigatorControl.getSelectionModel().getSelectedItem();
+                if (selectedItem != null) {
+                    conceptNavigatorControl.getNavigator().getParentNids(selectedItem.getValue().nid());
+                    List<ConceptFacade> list = Arrays.stream(conceptNavigatorControl.getNavigator().getParentNids(selectedItem.getValue().nid())).boxed()
+                            .map(nid -> (ConceptFacade) Entity.getFast(nid)).toList();
+                    ((ConceptNavigatorTreeItem) selectedItem).setRelatedConcepts(list);
+                }
+                yield i -> System.out.println("Click! on " + i.description());
+            }
+            // multiple selection
+            case POPULATE_SELECTION -> item -> {
+                List<UUID[]> uuids = List.<UUID[]>of(item.publicId().asUuidArray());
+                populateWorkspaceWithSelection(uuids);
+            };
+            case SEND_TO_JOURNAL, SEND_TO_CHAPTER, COPY, SAVE_TO_FAVORITES -> _ -> {}; // TODO: Add implementation
+        });
         searchControl.setOnLongHover(conceptNavigatorControl::expandAndHighlightConcept);
         searchControl.setOnSearchResultClick(_ -> conceptNavigatorControl.unhighlightConceptsWithDelay());
         searchControl.setOnClearSearch(_ -> ConceptNavigatorUtils.resetConceptNavigator(conceptNavigatorControl));

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/journal/JournalController.java
@@ -976,7 +976,7 @@ public class JournalController {
                             .map(nid -> (ConceptFacade) Entity.getFast(nid)).toList();
                     ((ConceptNavigatorTreeItem) selectedItem).setRelatedConcepts(list);
                 }
-                yield i -> System.out.println("Click! on " + i.description());
+                yield i -> LOG.info("Click on {}", i.description());
             }
             // multiple selection
             case POPULATE_SELECTION -> item -> {


### PR DESCRIPTION
This PR allows the user to open a concept Window by selecting the Open in Workspace action of the ContextMenu that shows up when a a single selection is done in the concept navigator control.

But it also redefines the `KLConceptNavigatorControl::onActionProperty` API, by adding an enum with the list of possible actions from the context menus that are shown when a single or multiple selection are done in the control.

For each action, the developer that uses this control has to provide a consumer of the item(s) affected by the selection, like opening it/them in the workspace.

For the related concepts action, a new API has been added to the ConceptNavigatorTreeItem, so each item can have a list of related concepts. This should be filled when the treeItem is created, for instance, or via Navigator (TODO).

