### PR TITLE
Feature/finished/iia 1990 coordinate from start burst icon duplicates

### DIFF
--- a/framework/src/main/java/dev/ikm/komet/framework/view/ObservableCoordinate.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ObservableCoordinate.java
@@ -64,7 +64,6 @@ public interface ObservableCoordinate<T extends ImmutableCoordinate> extends Pro
                 coordinate.removeOverrides();
             }
         }
-        this.setValue(getOriginalValue());
     }
 
     void setExceptOverrides(T updatedCoordinate);


### PR DESCRIPTION
Selected a coordiante

<img width="671" alt="image" src="https://github.com/user-attachments/assets/cbfa8c59-6aab-444c-934e-e2a8a7a3e0cc" />

<img width="673" alt="image" src="https://github.com/user-attachments/assets/c091a498-f803-43fc-9555-5d24a14b3772" />

Selected "Remove overrides"
<img width="455" alt="image" src="https://github.com/user-attachments/assets/ed9d2a85-7900-4542-92b1-bc3364528fc5" />

![image](https://github.com/user-attachments/assets/37bc64fb-76a7-4988-bfd8-18556319324b)
