### PR TITLE
Feature/finished/iia 1992 1967 change language coord starburst

### DIFF
--- a/framework/src/main/java/dev/ikm/komet/framework/view/ObservableCoordinateAbstract.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ObservableCoordinateAbstract.java
@@ -16,7 +16,6 @@
 package dev.ikm.komet.framework.view;
 
 import dev.ikm.tinkar.coordinate.ImmutableCoordinate;
-import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleObjectProperty;
@@ -26,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.Objects;
 
@@ -58,6 +56,8 @@ public abstract class ObservableCoordinateAbstract<T extends ImmutableCoordinate
     protected abstract void addListeners();
 
     protected void changeBaseCoordinate(ObservableValue<? extends T> observable, T oldValue, T newValue) {
+        // TODO look into another way to not have to physically remove then add the listeners
+        // the protected instance variable listening
         removeListeners();
         this.immutableCoordinate.setValue(baseCoordinateChangedListenersRemoved(observable, oldValue, newValue));
         addListeners();
@@ -76,26 +76,13 @@ public abstract class ObservableCoordinateAbstract<T extends ImmutableCoordinate
     public void setValue(T value) {
         T oldValue = getValue();
         if (!Objects.equals(oldValue, value)) {
-            // this method is being recursively called.  when listeners are notified, they in turn
-            // call this method setValue().  Within changeBaseCoordinate() listeners are removed then
-            // added back.  An ArrayList cannot be modified when the items are being iterated.
-            Platform.runLater(() -> {
-                try {
-                    // Copy change listener list to avoid ConcurrentModificationException
-                    // This was added because addListener() was being called recursively within the listener.changed
-                    // loop below.
-                    List<ChangeListener<? super T>> copiedChangeListenerList = new ArrayList<>(changeListenerList);
+            changeBaseCoordinate(this.immutableCoordinate, oldValue, value);
 
-                    changeBaseCoordinate(this.immutableCoordinate, oldValue, value);
-                    for (ChangeListener<? super T> listener : copiedChangeListenerList) {
-                        listener.changed(this.immutableCoordinate, oldValue, value);
-                    }
-                } catch (ConcurrentModificationException e) {
-                    LOG.error("ConcurrentModificationException", e);
-                    
-                    throw e;
-                }
-            });
+            // iterate through the listener ArrayList without concurrency issues using the iterator
+            var iterator = changeListenerList.iterator();
+            while (iterator.hasNext()) {
+                iterator.next().changed(immutableCoordinate, oldValue, value);
+            }
         }
     }
 

--- a/framework/src/main/java/dev/ikm/komet/framework/view/ObservableCoordinateAbstract.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ObservableCoordinateAbstract.java
@@ -81,8 +81,13 @@ public abstract class ObservableCoordinateAbstract<T extends ImmutableCoordinate
             // added back.  An ArrayList cannot be modified when the items are being iterated.
             Platform.runLater(() -> {
                 try {
+                    // Copy change listener list to avoid ConcurrentModificationException
+                    // This was added because addListener() was being called recursively within the listener.changed
+                    // loop below.
+                    List<ChangeListener<? super T>> copiedChangeListenerList = new ArrayList<>(changeListenerList);
+
                     changeBaseCoordinate(this.immutableCoordinate, oldValue, value);
-                    for (ChangeListener<? super T> listener : changeListenerList) {
+                    for (ChangeListener<? super T> listener : copiedChangeListenerList) {
                         listener.changed(this.immutableCoordinate, oldValue, value);
                     }
                 } catch (ConcurrentModificationException e) {

--- a/framework/src/main/java/dev/ikm/komet/framework/view/ObservableViewWithOverride.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ObservableViewWithOverride.java
@@ -106,9 +106,11 @@ public class ObservableViewWithOverride extends ObservableViewBase {
 
         ObservableList<ObservableLanguageCoordinateBase> languageCoordinateList = FXCollections.observableArrayList();
 
-        observableView.languageCoordinates().forEach(languageCoord -> {
-            languageCoordinateList.add(new ObservableLanguageCoordinateWithOverride(languageCoord));
-        });
+        if (observableView.languageCoordinates() != null) {
+            observableView.languageCoordinates().forEach(languageCoord -> {
+                languageCoordinateList.add(new ObservableLanguageCoordinateWithOverride(languageCoord));
+            });
+        }
 
         ListProperty<ObservableLanguageCoordinateBase> languageListProperty = new SimpleEqualityBasedListProperty<>(this,
                 "", languageCoordinateList);

--- a/framework/src/main/java/dev/ikm/komet/framework/view/ObservableViewWithOverride.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ObservableViewWithOverride.java
@@ -15,9 +15,12 @@
  */
 package dev.ikm.komet.framework.view;
 
-import javafx.beans.value.ObservableValue;
 import dev.ikm.tinkar.coordinate.view.ViewCoordinate;
 import dev.ikm.tinkar.coordinate.view.ViewCoordinateRecord;
+import javafx.beans.property.ListProperty;
+import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 
 public class ObservableViewWithOverride extends ObservableViewBase {
 
@@ -97,7 +100,20 @@ public class ObservableViewWithOverride extends ObservableViewBase {
     @Override
     protected ListPropertyWithOverride<ObservableLanguageCoordinateBase> makeLanguageCoordinateListProperty(ViewCoordinate viewRecord) {
         ObservableView observableView = (ObservableView) viewRecord;
-        return new ListPropertyWithOverride(observableView.languageCoordinates(), this);
+
+        // convert the ObservableLanguageCoordinateNoOverride to ObservableLanguageCoordinateWithOverride
+        // before putting into the ListPropertyWithOverride
+
+        ObservableList<ObservableLanguageCoordinateBase> languageCoordinateList = FXCollections.observableArrayList();
+
+        observableView.languageCoordinates().forEach(languageCoord -> {
+            languageCoordinateList.add(new ObservableLanguageCoordinateWithOverride(languageCoord));
+        });
+
+        ListProperty<ObservableLanguageCoordinateBase> languageListProperty = new SimpleEqualityBasedListProperty<>(this,
+                "", languageCoordinateList);
+
+        return new ListPropertyWithOverride<>(languageListProperty, this);
     }
 
     @Override

--- a/framework/src/main/java/dev/ikm/komet/framework/view/ViewMenuTask.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ViewMenuTask.java
@@ -127,9 +127,7 @@ public class ViewMenuTask extends TrackingCallable<List<MenuItem>> {
         for (StateSet stateSet : new StateSet[]{StateSet.ACTIVE, StateSet.ACTIVE_AND_INACTIVE, StateSet.ACTIVE_INACTIVE_AND_WITHDRAWN,
                 StateSet.INACTIVE, StateSet.WITHDRAWN}) {
             CheckMenuItem item = new CheckMenuItem(stateSet.toUserString());
-            if (observableView.navigationCoordinate().getOriginalValue().vertexStates() == observableView.stampCoordinate().allowedStates()) {
-                item.setSelected(stateSet.equals(observableView.navigationCoordinate().getOriginalValue().vertexStates()));
-            }
+            item.setSelected(stateSet.equals(observableView.stampCoordinate().allowedStates()));
             item.setOnAction(event -> {
                 Platform.runLater(() -> {
                     observableView.setAllowedStates(stateSet);


### PR DESCRIPTION
Jira tickets:

https://ikmdev.atlassian.net/browse/IIA-1992
https://ikmdev.atlassian.net/browse/IIA-1967

These defects are related, both with the Change description preference menu item.

Summary of changes:

- ObservableViewWithOverride.makeLanguageCoordinateListProperty() - this method was directly using the ObservableLanguageCoordinateNoOverride, rather than converting to ObservableLanguageCoordinateWithOverride.  The starburst icon only changes to the orange color when overrides have been set, and the WithOverride class was not being used (at all, anywhere in the code).  Added conversion to the WithOverride class just like all of the other make* methods do.
- ViewMenuTask.addChangeItemsForView() - modified to check if there are multiple languages, and if not, now doesn't append the index number of the language for the Menu text.
- ViewMenuTask refactored to have a common shared method createChangeDescriptionMenuItems(), which is used in both addChangeItemsForView() and addChangeItemsForLanguage()
- ViewMenuTask.changeStates() - fixed the issue of the CheckMenuItem selected indicator (the check) not changing when menu items are selected
- Testing with Classic Komet discovered that there is a ConcurrentModificationException on Classic initialization.  This seems to have been caused by the converting to ObservableLanguageCoordinateWithOverride, but not directly caused by.  Modified the ObservableCoordinateAbstract.setValue() to copy the listener list and to use the copy to call the listeners.

Before changes:

There is a 0 appended in the Menu text, and the language coordinate Change description preference selected is Regular name.
Note that the Navigator does not have any "SOLOR" in the names, which is only available for Fully Qualified Name.

![image](https://github.com/user-attachments/assets/75d6b570-a443-430b-a00c-e8fe6af76084)

When Fully Qualify Name is selected, SOLOR is in the navigator text.  But the starburst icon is still grey, not orange.  The starburst icon only changes to orange color when there are overrides.

![image](https://github.com/user-attachments/assets/50221653-bb83-4ff6-adc7-4fd24e723f6e)

Change allowed states, initially with default of ACTIVE, INACTIVE.  Before selecting ACTIVE.

![image](https://github.com/user-attachments/assets/3559b30f-f2af-43d9-acb3-370ddbb6fd1c)

Change allowed states, after selecting ACTIVE.  Note that the ACTIVE CheckMenuItem is not selected with a check.

![image](https://github.com/user-attachments/assets/951805d0-1a5a-4a5f-bf91-801ec4467576)


After changes:

Since there is only one language, there is now no longer an appended index in the Change language coordinate menu text.

![image](https://github.com/user-attachments/assets/883fa08c-b3e0-4ec1-b8df-fca12a686271)

When the Fully Qualified Name Change description preference is selected, the starburst icon is now orange because the ObservableLanguageCoordinateWithOverride class is being used.

![image](https://github.com/user-attachments/assets/e50f2d68-35d2-4725-82a4-53ea10faca07)

Change allowed states, after selecting ACTIVE.  ACTIVE is now checked.

![image](https://github.com/user-attachments/assets/d3d1f8e8-ac33-49ec-b3bc-be93dae0e892)
