### PR TITLE
feature/finished/IIA-1992-fix-concurrent-modification-exception-copy-list

### DIFF
--- a/framework/src/main/java/dev/ikm/komet/framework/view/ObservableCoordinateAbstract.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ObservableCoordinateAbstract.java
@@ -78,8 +78,10 @@ public abstract class ObservableCoordinateAbstract<T extends ImmutableCoordinate
         if (!Objects.equals(oldValue, value)) {
             changeBaseCoordinate(this.immutableCoordinate, oldValue, value);
 
-            // iterate through the listener ArrayList without concurrency issues using the iterator
-            var iterator = changeListenerList.iterator();
+            // copy the listener list to avoid the ConcurrentModificationException
+            var copiedListenerList = new ArrayList<ChangeListener<? super T>>(changeListenerList);
+
+            var iterator = copiedListenerList.iterator();
             while (iterator.hasNext()) {
                 iterator.next().changed(immutableCoordinate, oldValue, value);
             }


### PR DESCRIPTION
This is a quick fix for the ConcurrentModificationException.
Carl could reproduce on Mac, which behaves differently than Windows with concurrent access to the ArrayList during iteration.
Changed to not use the iterator directly to using a copy of the listener list instead.
