### PR TITLE
Feature/finished/iia 2051 autosave fix for reordering set

### DIFF
--- a/framework/src/main/java/dev/ikm/komet/framework/observable/ObservableSemanticVersion.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/observable/ObservableSemanticVersion.java
@@ -101,7 +101,7 @@ public final class ObservableSemanticVersion
                  && (observableField.fieldProperty.getValue().value() != null &&
                  // Check if the previous value is different from the changed value.
                  // This check is required for C-List C-Set
-                 !Objects.equals(observableField.value(), observableField.fieldProperty.getValue().value()))
+                 !Objects.equals(observableField.value().toString(), observableField.fieldProperty.getValue().value().toString()))
                 ) {
                     // Creating uncommitted version records. e.g., (c)hello, (u)hello1, (u)hello12, (u)hello123
                     autoSaveSematicVersion(observableField.value(), index);

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLIntegerControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLIntegerControlSkin.java
@@ -92,7 +92,7 @@ public class KLIntegerControlSkin extends KLDebounceControlSkin<KLIntegerControl
                     control.setShowError(true);
                     // want to still return the value. If the value is 1 and then the user enters "-1" then tries
                     // start hitting backspace from the right of "-1" the text will get stuck and not take the deletion
-                    return change;
+                    return null;
                 }
             }
         }));

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/SemanticFieldsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/SemanticFieldsController.java
@@ -349,6 +349,9 @@ public class SemanticFieldsController {
                    try {
 //                       EntityService.get().endLoadPhase();
                        createSemanticVersionTransactionTask(transaction).get(); // get() will block until transaction is finished (will refresh view calculator caches)
+                       //update the observableSemantic version and observableSemanticSnapShot
+                       observableSemantic = ObservableEntity.get(semantic.nid());
+                       observableSemanticSnapshot = observableSemantic.getSnapshot(getViewProperties().calculator());
                        processCommittedValues();
                        enableDisableButtons();
                        // EventBus implementation changes to refresh the details area if commit successful


### PR DESCRIPTION
Before editing Set:
<img width="917" alt="image" src="https://github.com/user-attachments/assets/8b80db57-6876-4c34-86bd-2dc057b54b68" />

Changed the order of set.:
<img width="905" alt="image" src="https://github.com/user-attachments/assets/112951df-a523-42d2-b010-f8fd0ee77449" />

Closed journal window AND
Reopened journal window:
<img width="913" alt="image" src="https://github.com/user-attachments/assets/61859ec3-794d-4fc2-9584-d58353e5bc20" />

Hit Submit, Semantic set change saved:  
<img width="922" alt="image" src="https://github.com/user-attachments/assets/488be730-da99-49d1-9f9a-efe982da3380" />

Reopened edit properties: New order is reflected:
<img width="907" alt="image" src="https://github.com/user-attachments/assets/ca24e8d1-f2f1-420d-b39e-d468c26ac7f6" />


  
  

   