### PR TITLE
Feature/Finished/IIA-2066: We should store empty components using Integer.MIN_VALUE, IIA-1910, IIA-1915

### DIFF
--- a/framework/src/main/java/dev/ikm/komet/framework/observable/ObservableSemanticVersion.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/observable/ObservableSemanticVersion.java
@@ -104,11 +104,10 @@ public final class ObservableSemanticVersion
                  && (observableField.fieldProperty.getValue().value() != null)) {
                     // Check if the previous value is different from the changed value.
                     // This check is required for C-List C-Set
-                    if (observableField.value() instanceof IntIdSet || observableField.value() instanceof IntIdList) {
-                        IntIdCollection valueList = (IntIdCollection) observableField.value();
-                        IntIdCollection fileValueList = (IntIdCollection) observableField.fieldProperty.getValue().value();
+                    if (observableField.value() instanceof IntIdCollection valueList) {
+                        IntIdCollection fieldValueList = (IntIdCollection) observableField.fieldProperty.getValue().value();
 
-                        if (!Arrays.equals(valueList.toArray(), fileValueList.toArray())) {
+                        if (!Arrays.equals(valueList.toArray(), fieldValueList.toArray())) {
                             // Creating uncommitted version records. e.g., (c)hello, (u)hello1, (u)hello12, (u)hello123
                             autoSaveSematicVersion(observableField.value(), index);
                         }

--- a/framework/src/main/java/dev/ikm/komet/framework/observable/ObservableSemanticVersion.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/observable/ObservableSemanticVersion.java
@@ -15,6 +15,9 @@
  */
 package dev.ikm.komet.framework.observable;
 
+import dev.ikm.tinkar.common.id.IntIdCollection;
+import dev.ikm.tinkar.common.id.IntIdList;
+import dev.ikm.tinkar.common.id.IntIdSet;
 import dev.ikm.tinkar.coordinate.Coordinates;
 import dev.ikm.tinkar.coordinate.stamp.calculator.Latest;
 import dev.ikm.tinkar.coordinate.stamp.calculator.StampCalculator;
@@ -40,7 +43,7 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
 
-import java.util.Objects;
+import java.util.Arrays;
 
 public final class ObservableSemanticVersion
         extends ObservableVersion<SemanticVersionRecord>
@@ -98,13 +101,21 @@ public final class ObservableSemanticVersion
                 // ObservableSemanticVersion and the SemanticVersion (record).
                 // ObservableSemanticVersion owns the versionProperty<SemanticVersion>
                 if (observableField.value() != null // Create a version only when new value is not null.
-                 && (observableField.fieldProperty.getValue().value() != null &&
-                 // Check if the previous value is different from the changed value.
-                 // This check is required for C-List C-Set
-                 !Objects.equals(observableField.value().toString(), observableField.fieldProperty.getValue().value().toString()))
-                ) {
-                    // Creating uncommitted version records. e.g., (c)hello, (u)hello1, (u)hello12, (u)hello123
-                    autoSaveSematicVersion(observableField.value(), index);
+                 && (observableField.fieldProperty.getValue().value() != null)) {
+                    // Check if the previous value is different from the changed value.
+                    // This check is required for C-List C-Set
+                    if (observableField.value() instanceof IntIdSet || observableField.value() instanceof IntIdList) {
+                        IntIdCollection valueList = (IntIdCollection) observableField.value();
+                        IntIdCollection fileValueList = (IntIdCollection) observableField.fieldProperty.getValue().value();
+
+                        if (!Arrays.equals(valueList.toArray(), fileValueList.toArray())) {
+                            // Creating uncommitted version records. e.g., (c)hello, (u)hello1, (u)hello12, (u)hello123
+                            autoSaveSematicVersion(observableField.value(), index);
+                        }
+                    } else {
+                        // Creating uncommitted version records. e.g., (c)hello, (u)hello1, (u)hello12, (u)hello123
+                        autoSaveSematicVersion(observableField.value(), index);
+                    }
                 }
             };
             observableField.setAutoSaveChangeListener(autoSave);

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLComponentControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLComponentControl.java
@@ -48,6 +48,7 @@ import java.util.function.Predicate;
  * @see KLComponentListControl
  */
 public class KLComponentControl extends Control {
+    public static int EMPTY_NID = Integer.MIN_VALUE;
 
     private static final String SEARCH_TEXT_VALUE = "search.text.value";
 
@@ -86,7 +87,7 @@ public class KLComponentControl extends Control {
 
     // -- empty
     public boolean isEmpty() {
-        return getEntity() == null;
+        return getEntity() == null || getEntity().nid() == KLComponentControl.EMPTY_NID;
     }
 
     // -- title
@@ -108,7 +109,7 @@ public class KLComponentControl extends Control {
     /**
      * This property holds the {@link Entity} that has been added to the control
      */
-    private final ObjectProperty<EntityProxy> entityProperty = new SimpleObjectProperty<>(this, "entity", null);
+    private final ObjectProperty<EntityProxy> entityProperty = new SimpleObjectProperty<>(this, "entity", EntityProxy.make(EMPTY_NID));
     public final ObjectProperty<EntityProxy> entityProperty() { return entityProperty; }
     public final EntityProxy getEntity() {
         return entityProperty.get() == null ? null : EntityProxy.make(entityProperty.get().nid());

--- a/kview/src/main/java/dev/ikm/komet/kview/klfields/KlFieldHelper.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/klfields/KlFieldHelper.java
@@ -1,6 +1,5 @@
 package dev.ikm.komet.kview.klfields;
 
-import static dev.ikm.tinkar.terms.TinkarTerm.ANONYMOUS_CONCEPT;
 import static dev.ikm.tinkar.terms.TinkarTerm.BYTE_ARRAY_FIELD;
 import static dev.ikm.tinkar.terms.TinkarTerm.IMAGE_FIELD;
 import static dev.ikm.tinkar.terms.TinkarTerm.INTEGER_FIELD;
@@ -11,6 +10,7 @@ import dev.ikm.komet.framework.observable.ObservablePatternVersion;
 import dev.ikm.komet.framework.observable.ObservableSemanticSnapshot;
 import dev.ikm.komet.framework.observable.ObservableSemanticVersion;
 import dev.ikm.komet.framework.view.ViewProperties;
+import dev.ikm.komet.kview.controls.KLComponentControl;
 import dev.ikm.komet.kview.controls.KLReadOnlyBaseControl;
 import dev.ikm.komet.kview.controls.KLReadOnlyComponentControl;
 import dev.ikm.komet.kview.controls.KLReadOnlyComponentListControl;
@@ -33,6 +33,7 @@ import dev.ikm.tinkar.entity.PatternEntityVersion;
 import dev.ikm.tinkar.entity.PatternVersionRecord;
 import dev.ikm.tinkar.entity.SemanticEntityVersion;
 import dev.ikm.tinkar.terms.EntityFacade;
+import dev.ikm.tinkar.terms.EntityProxy;
 import dev.ikm.tinkar.terms.TinkarTerm;
 import javafx.scene.Node;
 import javafx.scene.control.Tooltip;
@@ -110,7 +111,7 @@ public class KlFieldHelper {
         MutableList<Object> fieldsValues = Lists.mutable.ofInitialCapacity(patternVersion.fieldDefinitions().size());
         patternVersion.fieldDefinitions().forEach(f -> {
             if (f.dataTypeNid() == TinkarTerm.COMPONENT_FIELD.nid()) {
-                fieldsValues.add(ANONYMOUS_CONCEPT);
+                fieldsValues.add(EntityProxy.make(KLComponentControl.EMPTY_NID));
             } else if (f.dataTypeNid() == TinkarTerm.STRING_FIELD.nid()
                     || f.dataTypeNid() == TinkarTerm.STRING.nid()) {
                 fieldsValues.add("");
@@ -199,7 +200,11 @@ public class KlFieldHelper {
                 stringBuilder.append(str);
             } else if (observableField.valueProperty().get() != null) {
                 // TODO re-evaluate if toString is the right approach for complex datatypes.
-                stringBuilder.append(observableField.valueProperty().get().toString());
+                if (observableField.value() instanceof EntityProxy entityProxy) {
+                    stringBuilder.append(entityProxy.nid());
+                } else {
+                    stringBuilder.append(observableField.valueProperty().get().toString());
+                }
             }
 
             stringBuilder.append("|");

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/SemanticFieldsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/SemanticFieldsController.java
@@ -33,7 +33,7 @@ import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.VIEW_PROPERTIES;
 import static dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel.SEMANTIC;
 import static dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel.WINDOW_TOPIC;
 import static dev.ikm.tinkar.provider.search.Indexer.FIELD_INDEX;
-import static dev.ikm.tinkar.terms.TinkarTerm.ANONYMOUS_CONCEPT;
+import static dev.ikm.tinkar.terms.TinkarTerm.COMPONENT_FIELD;
 import static dev.ikm.tinkar.terms.TinkarTerm.IMAGE_FIELD;
 import dev.ikm.komet.framework.events.EntityVersionChangeEvent;
 import dev.ikm.komet.framework.events.EvtBusFactory;
@@ -44,6 +44,7 @@ import dev.ikm.komet.framework.observable.ObservableSemantic;
 import dev.ikm.komet.framework.observable.ObservableSemanticSnapshot;
 import dev.ikm.komet.framework.observable.ObservableSemanticVersion;
 import dev.ikm.komet.framework.view.ViewProperties;
+import dev.ikm.komet.kview.controls.KLComponentControl;
 import dev.ikm.komet.kview.controls.Toast;
 import dev.ikm.komet.kview.events.genediting.GenEditingEvent;
 import dev.ikm.komet.kview.events.genediting.PropertyPanelEvent;
@@ -136,6 +137,10 @@ public class SemanticFieldsController {
         observableFields.forEach(observableField -> {
             if (observableField.dataTypeNid() == IMAGE_FIELD.nid()) {
                 invalid.set(observableField.valueProperty().get() == null || (((byte[]) observableField.valueProperty().get()).length == 0));
+            }
+            if (observableField.dataTypeNid() == COMPONENT_FIELD.nid()) {
+                EntityProxy entityProxy = (EntityProxy) observableField.value();
+                invalid.set(entityProxy == null || entityProxy.nid()  == KLComponentControl.EMPTY_NID);
             }
             if (!invalid.get()) {
                 invalid.set((observableField.value() == null || observableField.value().toString().isEmpty()));
@@ -264,7 +269,7 @@ public class SemanticFieldsController {
         }
         observableFields.forEach(observableField -> {
             if (genEditingViewModel.getPropertyValue(MODE) == CREATE && observableField.value() instanceof EntityProxy entityProxy){
-                if(entityProxy.nid() == ANONYMOUS_CONCEPT.nid()){
+                if(entityProxy.nid() == KLComponentControl.EMPTY_NID){
                     observableField.valueProperty().setValue(null);
                 }
             }


### PR DESCRIPTION
Fixes: 
1. https://ikmdev.atlassian.net/browse/IIA-2066
2. https://ikmdev.atlassian.net/browse/IIA-1910
3. https://ikmdev.atlassian.net/browse/IIA-1915

Empty components are stored using Integer.MIN_VALUE as it is a reserved value in the database. That would also start to be the default value for component field.

Side note and for future reference: While using Integer.MIN_VALUE for empty component fields, we cannot call toString on the observable when it is storing that value as Tinker will throw an exception in that case.