### PR TITLE
Feature/finished/iia 1897 confirm clear dialog for semantic create

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/fxutils/FXUtils.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/fxutils/FXUtils.java
@@ -32,6 +32,8 @@ import javafx.scene.text.Text;
 import javafx.stage.Window;
 import javafx.util.Duration;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executor;
@@ -277,4 +279,36 @@ public abstract class FXUtils {
         // Add the listener to the window panel
         targetPane.sceneProperty().addListener(windowSceneSyncListener);
     }
+
+    /**
+     * Gets the topmost Pane from the provided parentNode.
+     * @param parentNode The node to start from
+     * @return The topmost pane, or null if
+     */
+    public static Pane getTopmostPane(Node parentNode) {
+        List<Pane> paneHierarchy = new ArrayList<>();
+
+        getTopmostPaneHierarchy(paneHierarchy, parentNode);
+
+        return paneHierarchy.isEmpty() ? null : paneHierarchy.getLast();
+    }
+
+    /**
+     * Recursively goes through each parent and accumulates in order the Panes that are
+     * are in the hierarchy.
+     * @param paneHierarchy List to put the Pane objects into
+     * @param node The current node in the parent hierarchy
+     */
+    private static void getTopmostPaneHierarchy(List<Pane> paneHierarchy, Node node) {
+        var parent = node.getParent();
+
+        if (parent instanceof Pane pane) {
+            paneHierarchy.add(pane);
+        }
+
+        if (parent != null) {
+            getTopmostPaneHierarchy(paneHierarchy, parent);
+        }
+    }
+
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ConfirmClearDialogController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ConfirmClearDialogController.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 Integrated Knowledge Management (support@ikm.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.ikm.komet.kview.mvvm.view.genediting;
+
+import dev.ikm.komet.kview.controls.GlassPane;
+import dev.ikm.komet.kview.fxutils.FXUtils;
+import javafx.fxml.FXML;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.layout.Pane;
+import org.carlfx.cognitive.loader.FXMLMvvmLoader;
+import org.carlfx.cognitive.loader.JFXNode;
+
+import java.util.concurrent.CompletableFuture;
+
+import static dev.ikm.komet.kview.fxutils.FXUtils.runOnFxThread;
+
+/**
+ * Controller class for managing GitHub information view in the changeset exchange functionality.
+ */
+public class ConfirmClearDialogController {
+
+    @FXML
+    private Button cancelButton;
+
+    @FXML
+    private Button confirmButton;
+
+    /**
+     * Creates the dialog, providing the CompletableFuture that provides the modal behavior of the dialog.
+     * @param parentNode The node to start at to determine the topmost Pane, which is required for the GlassPane
+     * @return CompletableFuture with a Boolean type, Boolean value of true is returned when the confirm button is pressed
+     */
+    public static CompletableFuture<Boolean> showConfirmClearDialog(Node parentNode) {
+        // Create a CompletableFuture that will be completed when the user makes a choice
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+
+        // Show dialog on JavaFX thread
+        runOnFxThread(() -> {
+            GlassPane glassPane = new GlassPane(FXUtils.getTopmostPane(parentNode));
+
+            final JFXNode<Pane, ConfirmClearDialogController> githubInfoNode = FXMLMvvmLoader
+                    .make(ConfirmClearDialogController.class.getResource("confirm-clear-dialog.fxml"));
+            final Pane dialogPane = githubInfoNode.node();
+            final ConfirmClearDialogController controller = githubInfoNode.controller();
+
+            controller.confirmButton.setOnAction(_ -> {
+                glassPane.removeContent(dialogPane);
+                glassPane.hide();
+                future.complete(true); // Complete with true on close
+            });
+
+            controller.cancelButton.setOnAction(_ -> {
+                glassPane.removeContent(dialogPane);
+                glassPane.hide();
+                future.complete(false); // Complete with true on close
+            });
+
+            glassPane.addContent(dialogPane);
+            glassPane.show();
+        });
+
+        return future;
+    }
+
+}

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/confirm-clear-dialog.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/confirm-clear-dialog.fxml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox fx:id="dialogPane" prefWidth="560.0" spacing="20.0" styleClass="dialog-pane" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.genediting.ConfirmClearDialogController">
+    <VBox alignment="CENTER_LEFT" spacing="8.0">
+         <Label prefHeight="25.0" styleClass="title-label" text="Confirm Clear Form" />
+        <Label text="Are you sure you want to clear the form? All entered data will be lost." />
+    </VBox>
+    <HBox alignment="BOTTOM_RIGHT" spacing="12.0">
+      <Button fx:id="cancelButton" minHeight="32.0" mnemonicParsing="false" prefHeight="32.0" prefWidth="88.0" styleClass="close-button" text="CANCEL" />
+        <Button fx:id="confirmButton" minHeight="32.0" mnemonicParsing="false" prefHeight="32.0" prefWidth="88.0" styleClass="edit-concept-submit-button" text="CONFIRM">
+        </Button>
+    </HBox>
+</VBox>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -5470,9 +5470,9 @@ Styling a context menu for kview ui/ux controls
 }
 
 /*****************************
-* GitHub Dialogs
+* Dialogs
 *****************************/
-.github-pane {
+.dialog-pane, .github-pane {
     -fx-background-color: -Grey-White;
     -fx-background-radius: 8;
     -fx-border-radius: 6;
@@ -5482,6 +5482,10 @@ Styling a context menu for kview ui/ux controls
     -fx-padding: 24px;
     -fx-effect: dropshadow(three-pass-box, rgba(0, 0, 0, 0.2), 8, 0, 0, 4);
 }
+
+/*****************************
+* GitHub Dialogs
+*****************************/
 
 .github-pane .title-label {
     -fx-font-family: "Noto Sans Medium";

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -5483,10 +5483,16 @@ Styling a context menu for kview ui/ux controls
     -fx-effect: dropshadow(three-pass-box, rgba(0, 0, 0, 0.2), 8, 0, 0, 4);
 }
 
+.dialog-pane .title-label {
+    -fx-font-family: "Noto Sans Medium";
+    -fx-font-size: 18px;
+    -fx-font-weight: 500;
+    -fx-text-fill: -Grey-12;
+}
+
 /*****************************
 * GitHub Dialogs
 *****************************/
-
 .github-pane .title-label {
     -fx-font-family: "Noto Sans Medium";
     -fx-font-size: 18px;


### PR DESCRIPTION
Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-1897

Summary of changes:

- Created new confirm-clear-dialog.fxml and ConfirmClearDialogController
- Followed the pattern for GitHub exchange and sync dialogs, with the dialog created on a GlassPane
- This dialog is only created in CREATE mode

Tested on Windows and Mac.

Recommend that a standard pattern/library be created for all dialogs in Komet, for those created on a GlassPane.

Before changes:

Before pressing CLEAR FORM.

![image](https://github.com/user-attachments/assets/0054b7bf-3611-4ea0-bf62-b323b779875e)

No confirmation dialog when CLEAR FORM button pressed.

![image](https://github.com/user-attachments/assets/f84a27c6-b79d-486d-9177-137ea4bd17d8)

After changes:

GitHub Preferences dialog remains the same (with now sharing .dialog-pane, .github-pane css)

![image](https://github.com/user-attachments/assets/0d68f696-e08f-4278-8316-cd3c662d54f0)

Before pressing CLEAR FORM.

![image](https://github.com/user-attachments/assets/5d3d9e42-dbf3-4ccc-bbb4-5dd981a265f4)

Dialog now displayed when CLEAR FORM pressed.

![image](https://github.com/user-attachments/assets/e27fa51c-c4da-4cfe-95cc-4b99a486a15d)

When CANCEL is pressed the dialog is hidden, without the form being cleared.

![image](https://github.com/user-attachments/assets/96a2ee33-6a18-49dd-b533-99cd0fadcd34)

When CONFIRM is pressed the dialog is hidden, and the form is cleared.

![image](https://github.com/user-attachments/assets/463e8038-d406-42d2-94fb-5305cdf9350e)

