### PR TITLE
feature/finished/IIA-2163-added-semantic-identicon

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingDetailsController.java
@@ -48,6 +48,8 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TitledPane;
 import javafx.scene.control.ToggleButton;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
 import javafx.scene.layout.*;
 import javafx.scene.text.Text;
 import org.carlfx.cognitive.loader.*;
@@ -163,6 +165,9 @@ public class GenEditingDetailsController {
     @FXML
     private HBox conceptHeaderControlToolBarHbox;
 
+    @FXML
+    private ImageView identiconImageView;
+
     @InjectViewModel
     private StampViewModel stampViewModel;
 
@@ -220,6 +225,14 @@ public class GenEditingDetailsController {
         // Check if the properties panel is initially open and add draggable nodes if needed
         if (propertiesToggleButton.isSelected() || isOpen(propertiesSlideoutTrayPane)) {
             updateDraggableNodesForPropertiesPanel(true);
+        }
+
+        // Identicon
+        if (refComponent.isNotNull().get()) {
+            EntityFacade semantic = genEditingViewModel.getPropertyValue(SEMANTIC);
+
+            Image identicon = Identicon.generateIdenticonImage(semantic.publicId());
+            identiconImageView.setImage(identicon);
         }
     }
 

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
@@ -5,6 +5,8 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.Cursor?>
 <?import javafx.scene.Group?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.shape.*?>
 <?import javafx.scene.text.*?>
@@ -234,19 +236,22 @@
                <top>
                   <BorderPane prefHeight="103.0" prefWidth="894.0" styleClass="concept-detail-banner-background" BorderPane.alignment="CENTER">
                      <center>
-                        <GridPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="66.0" prefWidth="507.0" styleClass="concept-detail-banner-background">
+                        <GridPane hgap="8.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="66.0" prefWidth="507.0" styleClass="concept-detail-banner-background">
                            <columnConstraints>
                               <ColumnConstraints halignment="LEFT" maxWidth="586.0" minWidth="-Infinity" prefWidth="42.0" />
                               <ColumnConstraints halignment="LEFT" hgrow="ALWAYS" maxWidth="1.7976931348623157E308" minWidth="234.0" prefWidth="416.0" />
                            </columnConstraints>
                            <rowConstraints>
-                              <RowConstraints minHeight="10.0" />
+                              <RowConstraints minHeight="48.0" prefHeight="56.0" />
                               <RowConstraints maxHeight="77.0" minHeight="0.0" prefHeight="24.0" vgrow="SOMETIMES" />
                               <RowConstraints maxHeight="65.0" minHeight="-Infinity" prefHeight="22.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="9.0" prefHeight="22.0" vgrow="NEVER" />
                            </rowConstraints>
                            <children>
-                              <Label fx:id="semanticTitleText" alignment="TOP_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="40.0" prefWidth="495.0" text="SEMANTIC TITLE" textFill="#212430" wrapText="true" GridPane.columnSpan="2">
+                              <ImageView fx:id="identiconImageView" fitWidth="44.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="0" GridPane.rowIndex="0">
+                                 <Image url="@../images/identicon-placeholder.png" />
+                              </ImageView>
+                              <Label fx:id="semanticTitleText" alignment="TOP_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="40.0" prefWidth="495.0" text="SEMANTIC TITLE" textFill="#212430" wrapText="true" GridPane.columnIndex="1" GridPane.rowIndex="0">
                                  <font>
                                     <Font name="Open Sans Regular" size="17.0" />
                                  </font>
@@ -254,8 +259,8 @@
                                     <Tooltip fx:id="conceptNameTooltip" text="Empty Tooltip" />
                                  </tooltip>
                               </Label>
-                              <Label fx:id="semanticDescriptionLabel" text="Semantic for Test Performed Pattern" GridPane.columnSpan="2" GridPane.rowIndex="1" />
-                              <TextFlow GridPane.columnSpan="2" GridPane.rowIndex="2" GridPane.rowSpan="2">
+                              <Label fx:id="semanticDescriptionLabel" text="Semantic for Test Performed Pattern" GridPane.columnSpan="2" GridPane.rowIndex="1" GridPane.columnIndex="1" />
+                              <TextFlow GridPane.columnSpan="2" GridPane.rowIndex="2" GridPane.columnIndex="1" GridPane.rowSpan="1">
                                  <children>
                                     <Text fx:id="semanticMeaningLabelText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="semantic-banner-label" text="Meaning:  " />
                                     <Text fx:id="semanticMeaningText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="semantic-banner-value" text="[]" />


### PR DESCRIPTION
Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-2163

Summary of changes:

- added ImageView to genediting-details.fxml
- set the ImageView's Image in the controller, using the publicId

I verified that same image is displayed in the Semantic details window as is displayed in the Pattern browser Semantic list.

Before change:

No identicon is displayed in the Semantic window.

![image](https://github.com/user-attachments/assets/ac722715-15c1-4377-92ed-2956fc579c83)

After change:

Identicon is displayed in the Semantic window, and matches the Pattern browser identicon.

![image](https://github.com/user-attachments/assets/9613b20a-f714-4703-894d-7722a052ba72)
