### PR TITLE
feature/finished/IIA-2218-2215-conf-msg-edit-other-name-conf-clear-adding-ref-component

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ReferenceComponentController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ReferenceComponentController.java
@@ -1,18 +1,5 @@
 package dev.ikm.komet.kview.mvvm.view.genediting;
 
-import static dev.ikm.komet.kview.events.genediting.GenEditingEvent.CONFIRM_REFERENCE_COMPONENT;
-import static dev.ikm.komet.kview.events.genediting.PropertyPanelEvent.CLOSE_PANEL;
-import static dev.ikm.komet.kview.klfields.KlFieldHelper.createDefaultFieldValues;
-import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.VIEW_PROPERTIES;
-import static dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel.PATTERN;
-import static dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel.REF_COMPONENT;
-import static dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel.SEMANTIC;
-import static dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel.STAMP_VIEW_MODEL;
-import static dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel.WINDOW_TOPIC;
-import static dev.ikm.tinkar.coordinate.stamp.StampFields.AUTHOR;
-import static dev.ikm.tinkar.coordinate.stamp.StampFields.MODULE;
-import static dev.ikm.tinkar.coordinate.stamp.StampFields.PATH;
-import static dev.ikm.tinkar.coordinate.stamp.StampFields.STATUS;
 import dev.ikm.komet.framework.events.EvtBusFactory;
 import dev.ikm.komet.framework.view.ViewProperties;
 import dev.ikm.komet.kview.controls.KLComponentControl;
@@ -21,17 +8,7 @@ import dev.ikm.komet.kview.events.genediting.GenEditingEvent;
 import dev.ikm.komet.kview.events.genediting.PropertyPanelEvent;
 import dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel;
 import dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel;
-import dev.ikm.tinkar.entity.ConceptEntity;
-import dev.ikm.tinkar.entity.Entity;
-import dev.ikm.tinkar.entity.EntityService;
-import dev.ikm.tinkar.entity.RecordListBuilder;
-import dev.ikm.tinkar.entity.SemanticEntity;
-import dev.ikm.tinkar.entity.SemanticEntityVersion;
-import dev.ikm.tinkar.entity.SemanticRecord;
-import dev.ikm.tinkar.entity.SemanticRecordBuilder;
-import dev.ikm.tinkar.entity.SemanticVersionRecord;
-import dev.ikm.tinkar.entity.SemanticVersionRecordBuilder;
-import dev.ikm.tinkar.entity.StampEntity;
+import dev.ikm.tinkar.entity.*;
 import dev.ikm.tinkar.entity.transaction.Transaction;
 import dev.ikm.tinkar.terms.EntityFacade;
 import dev.ikm.tinkar.terms.EntityProxy;
@@ -48,6 +25,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
+
+import static dev.ikm.komet.kview.events.genediting.GenEditingEvent.CONFIRM_REFERENCE_COMPONENT;
+import static dev.ikm.komet.kview.events.genediting.PropertyPanelEvent.CLOSE_PANEL;
+import static dev.ikm.komet.kview.klfields.KlFieldHelper.createDefaultFieldValues;
+import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.VIEW_PROPERTIES;
+import static dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel.*;
+import static dev.ikm.tinkar.coordinate.stamp.StampFields.*;
 
 public class ReferenceComponentController {
 
@@ -104,7 +88,15 @@ public class ReferenceComponentController {
 
     @FXML
     private void clearForm(ActionEvent actionEvent) {
-        klComponentControl.entityProperty().set(null);
+        if (klComponentControl.entityProperty().get() != null) {
+            ConfirmClearDialogController.showConfirmClearDialog(this.cancelButton)
+                    .thenAccept(confirmed -> {
+                        if (confirmed) {
+                            klComponentControl.entityProperty().set(null);
+                        }
+                    });
+        }
+
         actionEvent.consume();
     }
 

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PropertiesController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PropertiesController.java
@@ -326,7 +326,8 @@ public class PropertiesController {
             if (evt.getEventType() == PatternDescriptionEvent.PATTERN_ADD_FQN) {
                 confirmationPaneViewModel.setPropertyValue(CONFIRMATION_TITLE, "Fully Qualified Name Added");
                 confirmationPaneViewModel.setPropertyValue(CONFIRMATION_MESSAGE, "");
-            } else if (evt.getEventType() == PatternDescriptionEvent.PATTERN_ADD_OTHER_NAME) {
+            } else if (evt.getEventType() == PatternDescriptionEvent.PATTERN_ADD_OTHER_NAME ||
+                                    evt.getEventType() == PatternDescriptionEvent.PATTERN_EDIT_OTHER_NAME) {
                 confirmationPaneViewModel.setPropertyValue(CONFIRMATION_TITLE, "Other Name Added");
                 confirmationPaneViewModel.setPropertyValue(CONFIRMATION_MESSAGE, "");
             }


### PR DESCRIPTION
Jira tickets:

https://ikmdev.atlassian.net/browse/IIA-2218
https://ikmdev.atlassian.net/browse/IIA-2215

Summary of changes:

- IIA-2218 - added display of the confirmation message pane when an other name is edited
- IIA-2215 - added confirmation dialog when the CLEAR button is pressed on the Reference Component

Before changes:

IIA-2218 there was not a confirmation message pane

![image](https://github.com/user-attachments/assets/c0bb3138-adda-4014-8ddc-c6ae810c70c0)

IIA-2215 there was not a confirmation dialog

![image](https://github.com/user-attachments/assets/d35bb52f-bd6a-4526-bdcd-5c3e3762d8c7)

After changes:

IIA-2218 now the confirmation pane is displayed with "Other Name Added" message

Editing Other Name before pressing DONE

![image](https://github.com/user-attachments/assets/e1d36b86-da10-4674-b5e6-56080b61ae61)

Editing Other Name after pressing DONE, note that "Other Name Added" is now displayed

![image](https://github.com/user-attachments/assets/4d487ec5-bec3-4992-9881-ee39aee0400c)

IIA-2215 now the confirmation dialog is displayed, allowing the user to confirm clearing the Reference Component

![image](https://github.com/user-attachments/assets/5c847399-ac87-487b-bf15-14afa55635dd)
