### PR TITLE
Feature/finished/iia 1896 added confirm reset dialog

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ConfirmationDialogController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ConfirmationDialogController.java
@@ -79,8 +79,11 @@ public class ConfirmationDialogController {
     }
 
     /**
-     * Creates the dialog, providing the CompletableFuture that provides the modal behavior of the dialog.
+     * Creates the confirmation dialog with a title and message, providing the CompletableFuture that provides
+     * the modal behavior of the dialog.
      * @param parentNode The node to start at to determine the topmost Pane, which is required for the GlassPane
+     * @param title The title of the confirmation dialog
+     * @param message The message to display in the confirmation dialog
      * @return CompletableFuture with a Boolean type, Boolean value of true is returned when the confirm button is pressed
      */
     public static CompletableFuture<Boolean> showConfirmationDialog(Node parentNode, String title, String message) {

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ConfirmationDialogController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ConfirmationDialogController.java
@@ -17,34 +17,73 @@ package dev.ikm.komet.kview.mvvm.view.genediting;
 
 import dev.ikm.komet.kview.controls.GlassPane;
 import dev.ikm.komet.kview.fxutils.FXUtils;
+import dev.ikm.komet.kview.mvvm.viewmodel.ConfirmationDialogViewModel;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
+import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
 import org.carlfx.cognitive.loader.FXMLMvvmLoader;
+import org.carlfx.cognitive.loader.InjectViewModel;
 import org.carlfx.cognitive.loader.JFXNode;
 
+import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 
 import static dev.ikm.komet.kview.fxutils.FXUtils.runOnFxThread;
+import static dev.ikm.komet.kview.mvvm.viewmodel.ConfirmationDialogViewModel.ConfirmationPropertyName.CONFIRMATION_DIALOG_MESSAGE;
+import static dev.ikm.komet.kview.mvvm.viewmodel.ConfirmationDialogViewModel.ConfirmationPropertyName.CONFIRMATION_DIALOG_TITLE;
 
 /**
- * Controller class for managing GitHub information view in the changeset exchange functionality.
+ * Controller for the Confirmation dialog
  */
-public class ConfirmClearDialogController {
+public class ConfirmationDialogController {
 
+    /**
+     * The URL to the controller's FXML file
+     */
+    public static final URL CONFIRMATION_DIALOG_FXML_URL = ConfirmationDialogController.class.getResource("confirmation-dialog.fxml");
+    /**
+     * The instance variable name for the view model
+     */
+    public static final String CONFIRMATION_DIALOG_VIEW_MODEL = "viewModel";
+
+    /**
+     * The title of the confirmation dialog, which value is set by the view model title property
+     */
+    @FXML
+    private Label title;
+    /**
+     * The message of the confirmation dialog, which value is set by the view model message property
+     */
+    @FXML
+    private Label message;
     @FXML
     private Button cancelButton;
-
     @FXML
     private Button confirmButton;
+
+    /**
+     * The view model for the controller, which provides the view text for the confirmation dialog
+     */
+    @InjectViewModel
+    private ConfirmationDialogViewModel viewModel;
+
+    /**
+     * Bind the title and message to the view model properties
+     */
+    @FXML
+    public void initialize() {
+        title.textProperty().bind(viewModel.getProperty(CONFIRMATION_DIALOG_TITLE));
+        message.textProperty().bind(viewModel.getProperty(CONFIRMATION_DIALOG_MESSAGE));
+    }
 
     /**
      * Creates the dialog, providing the CompletableFuture that provides the modal behavior of the dialog.
      * @param parentNode The node to start at to determine the topmost Pane, which is required for the GlassPane
      * @return CompletableFuture with a Boolean type, Boolean value of true is returned when the confirm button is pressed
      */
-    public static CompletableFuture<Boolean> showConfirmClearDialog(Node parentNode) {
+    public static CompletableFuture<Boolean> showConfirmationDialog(Node parentNode, String title, String message) {
         // Create a CompletableFuture that will be completed when the user makes a choice
         CompletableFuture<Boolean> future = new CompletableFuture<>();
 
@@ -52,10 +91,15 @@ public class ConfirmClearDialogController {
         runOnFxThread(() -> {
             GlassPane glassPane = new GlassPane(FXUtils.getTopmostPane(parentNode));
 
-            final JFXNode<Pane, ConfirmClearDialogController> githubInfoNode = FXMLMvvmLoader
-                    .make(ConfirmClearDialogController.class.getResource("confirm-clear-dialog.fxml"));
+            final JFXNode<Pane, ConfirmationDialogController> githubInfoNode = FXMLMvvmLoader
+                    .make(CONFIRMATION_DIALOG_FXML_URL);
             final Pane dialogPane = githubInfoNode.node();
-            final ConfirmClearDialogController controller = githubInfoNode.controller();
+            final ConfirmationDialogController controller = githubInfoNode.controller();
+            var viewModel = githubInfoNode.getViewModel(CONFIRMATION_DIALOG_VIEW_MODEL).get();
+
+            // set the view model property values
+            viewModel.setPropertyValue(CONFIRMATION_DIALOG_TITLE, title);
+            viewModel.setPropertyValue(CONFIRMATION_DIALOG_MESSAGE, message);
 
             controller.confirmButton.setOnAction(_ -> {
                 glassPane.removeContent(dialogPane);

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ConfirmationDialogController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ConfirmationDialogController.java
@@ -94,11 +94,11 @@ public class ConfirmationDialogController {
         runOnFxThread(() -> {
             GlassPane glassPane = new GlassPane(FXUtils.getTopmostPane(parentNode));
 
-            final JFXNode<Pane, ConfirmationDialogController> githubInfoNode = FXMLMvvmLoader
+            final JFXNode<Pane, ConfirmationDialogController> confDialogNode = FXMLMvvmLoader
                     .make(CONFIRMATION_DIALOG_FXML_URL);
-            final Pane dialogPane = githubInfoNode.node();
-            final ConfirmationDialogController controller = githubInfoNode.controller();
-            var viewModel = githubInfoNode.getViewModel(CONFIRMATION_DIALOG_VIEW_MODEL).get();
+            final Pane dialogPane = confDialogNode.node();
+            final ConfirmationDialogController controller = confDialogNode.controller();
+            var viewModel = confDialogNode.getViewModel(CONFIRMATION_DIALOG_VIEW_MODEL).get();
 
             // set the view model property values
             viewModel.setPropertyValue(CONFIRMATION_DIALOG_TITLE, title);

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ReferenceComponentController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/ReferenceComponentController.java
@@ -29,6 +29,8 @@ import java.util.UUID;
 import static dev.ikm.komet.kview.events.genediting.GenEditingEvent.CONFIRM_REFERENCE_COMPONENT;
 import static dev.ikm.komet.kview.events.genediting.PropertyPanelEvent.CLOSE_PANEL;
 import static dev.ikm.komet.kview.klfields.KlFieldHelper.createDefaultFieldValues;
+import static dev.ikm.komet.kview.mvvm.view.genediting.SemanticFieldsController.CONFIRM_CLEAR_MESSAGE;
+import static dev.ikm.komet.kview.mvvm.view.genediting.SemanticFieldsController.CONFIRM_CLEAR_TITLE;
 import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.VIEW_PROPERTIES;
 import static dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel.*;
 import static dev.ikm.tinkar.coordinate.stamp.StampFields.*;
@@ -89,7 +91,7 @@ public class ReferenceComponentController {
     @FXML
     private void clearForm(ActionEvent actionEvent) {
         if (klComponentControl.entityProperty().get() != null) {
-            ConfirmClearDialogController.showConfirmClearDialog(this.cancelButton)
+            ConfirmationDialogController.showConfirmationDialog(this.cancelButton, CONFIRM_CLEAR_TITLE, CONFIRM_CLEAR_MESSAGE)
                     .thenAccept(confirmed -> {
                         if (confirmed) {
                             klComponentControl.entityProperty().set(null);

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/SemanticFieldsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/SemanticFieldsController.java
@@ -303,7 +303,7 @@ public class SemanticFieldsController {
         } else {
             ConfirmationDialogController.showConfirmationDialog(this.cancelButton,
                             "Confirm Reset Form",
-                            "You're changes will be lost if you reset the form. Are you sure you want to continue?")
+                            "Your changes will be lost if you reset the form. Are you sure you want to continue?")
                     .thenAccept(confirmed -> {
                         if (confirmed) {
                             doTheClearOrResetForm();

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/SemanticFieldsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/SemanticFieldsController.java
@@ -73,6 +73,15 @@ public class SemanticFieldsController {
 
     private static final Logger LOG = LoggerFactory.getLogger(SemanticFieldsController.class);
 
+    /**
+     * Provide the standard Confirm Clear dialog title for use in other classes
+     */
+    public static final String CONFIRM_CLEAR_TITLE = "Confirm Clear Form";
+    /**
+     * Provide the standard Confirm Clear dialog message for use in other classes
+     */
+    public static final String CONFIRM_CLEAR_MESSAGE =  "Are you sure you want to clear the form? All entered data will be lost.";
+
     @FXML
     private VBox editFieldsVBox;
     @FXML
@@ -285,14 +294,21 @@ public class SemanticFieldsController {
     private void clearOrResetForm(ActionEvent actionEvent) {
         // if create mode display the confirm clear dialog
         if (genEditingViewModel.getPropertyValue(MODE) == CREATE) {
-            ConfirmClearDialogController.showConfirmClearDialog(this.cancelButton)
+            ConfirmationDialogController.showConfirmationDialog(this.cancelButton, CONFIRM_CLEAR_TITLE, CONFIRM_CLEAR_MESSAGE)
                     .thenAccept(confirmed -> {
                         if (confirmed) {
                             doTheClearOrResetForm();
                         }
                     });
         } else {
-            doTheClearOrResetForm();
+            ConfirmationDialogController.showConfirmationDialog(this.cancelButton,
+                            "Confirm Reset Form",
+                            "You're changes will be lost if you reset the form. Are you sure you want to continue?")
+                    .thenAccept(confirmed -> {
+                        if (confirmed) {
+                            doTheClearOrResetForm();
+                        }
+                    });
         }
     }
 

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/ConfirmationDialogViewModel.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/ConfirmationDialogViewModel.java
@@ -1,0 +1,26 @@
+package dev.ikm.komet.kview.mvvm.viewmodel;
+
+import org.carlfx.cognitive.viewmodel.SimpleViewModel;
+
+import static dev.ikm.komet.kview.mvvm.viewmodel.ConfirmationDialogViewModel.ConfirmationPropertyName.CONFIRMATION_DIALOG_MESSAGE;
+import static dev.ikm.komet.kview.mvvm.viewmodel.ConfirmationDialogViewModel.ConfirmationPropertyName.CONFIRMATION_DIALOG_TITLE;
+
+public class ConfirmationDialogViewModel extends SimpleViewModel {
+
+    /**
+     * The properties of the view model.
+     */
+    public enum ConfirmationPropertyName {
+        CONFIRMATION_DIALOG_TITLE,
+        CONFIRMATION_DIALOG_MESSAGE
+    }
+
+    /**
+     * Initialize the SimpleViewModel with the properties.
+     */
+    public ConfirmationDialogViewModel() {
+        addProperty(CONFIRMATION_DIALOG_TITLE, "");
+        addProperty(CONFIRMATION_DIALOG_MESSAGE, "");
+    }
+
+}

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/confirmation-dialog.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/confirmation-dialog.fxml
@@ -4,11 +4,10 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-
-<VBox fx:id="dialogPane" prefWidth="560.0" spacing="20.0" styleClass="dialog-pane" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.genediting.ConfirmClearDialogController">
+<VBox fx:id="dialogPane" prefWidth="560.0" spacing="20.0" styleClass="dialog-pane" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.genediting.ConfirmationDialogController">
     <VBox alignment="CENTER_LEFT" spacing="8.0">
-         <Label prefHeight="25.0" styleClass="title-label" text="Confirm Clear Form" />
-        <Label text="Are you sure you want to clear the form? All entered data will be lost." />
+         <Label fx:id="title" prefHeight="25.0" styleClass="title-label" text="Confirm Clear Form" />
+        <Label fx:id="message" text="Are you sure you want to clear the form? All entered data will be lost." />
     </VBox>
     <HBox alignment="BOTTOM_RIGHT" spacing="12.0">
       <Button fx:id="cancelButton" minHeight="32.0" mnemonicParsing="false" prefHeight="32.0" prefWidth="88.0" styleClass="close-button" text="CANCEL" />


### PR DESCRIPTION
Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-1896

Summary of changes:

- Refactored the Confirm Clear dialog to be a generic Confirmation dialog that contains a title, message, Cancel and Confirm buttons
- Created a SimpleViewModel for the title and message properties

Recommend expanding on this an adding a refactor story to create a common, global, dialog class that is responsible for creating the standard Komet application dialog which uses the GlassPane.

Before change:

No Confirm Reset dialog.

After change:

Confirm Reset dialog is displayed.

![image](https://github.com/user-attachments/assets/ecfcad6b-76c1-4d1e-a566-82c211e50f3f)
