### PR TITLE
IIA-1896 increased the prefWidth so text on Mac isn't truncated

### DIFF
--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/confirmation-dialog.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/confirmation-dialog.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-<VBox fx:id="dialogPane" prefWidth="560.0" spacing="20.0" styleClass="dialog-pane" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.genediting.ConfirmationDialogController">
+<VBox fx:id="dialogPane" prefWidth="580.0" spacing="20.0" styleClass="dialog-pane" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.genediting.ConfirmationDialogController">
     <VBox alignment="CENTER_LEFT" spacing="8.0">
          <Label fx:id="title" prefHeight="25.0" styleClass="title-label" text="Confirm Clear Form" />
         <Label fx:id="message" text="Are you sure you want to clear the form? All entered data will be lost." />


### PR DESCRIPTION
Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-1896

This is a simple fix to increase the prefWidth so the message text is not truncated on Mac.