### PR TITLE
Feature/Finished/IIA-2241: Display UUID for Semantics in Semantic Window AND Prevent Semantic Metadata from Overlapping When Shrinking Semantic Window

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingDetailsController.java
@@ -32,6 +32,7 @@ import dev.ikm.komet.kview.events.genediting.GenEditingEvent;
 import dev.ikm.komet.kview.events.genediting.PropertyPanelEvent;
 import dev.ikm.komet.kview.fxutils.FXUtils;
 import dev.ikm.komet.kview.klfields.KlFieldHelper;
+import dev.ikm.komet.kview.mvvm.model.DataModelHelper;
 import dev.ikm.komet.kview.mvvm.view.stamp.StampEditController;
 import dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel;
 import dev.ikm.komet.kview.mvvm.viewmodel.StampViewModel;
@@ -71,8 +72,10 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static dev.ikm.komet.kview.events.genediting.PropertyPanelEvent.*;
 import static dev.ikm.komet.kview.fxutils.SlideOutTrayHelper.*;
@@ -176,6 +179,12 @@ public class GenEditingDetailsController {
     @FXML
     private ImageView identiconImageView;
 
+    @FXML
+    private TextField uuidTextFieldLabel;
+
+    @FXML
+    private Tooltip identifierTooltip;
+
     @InjectViewModel
     private StampViewModel stampViewModel;
 
@@ -243,6 +252,18 @@ public class GenEditingDetailsController {
             Image identicon = Identicon.generateIdenticonImage(semantic.publicId());
             identiconImageView.setImage(identicon);
         }
+
+        // UUID
+        EntityFacade semanticComponent = genEditingViewModel.getPropertyValue(SEMANTIC);
+
+        List<String> idList = semanticComponent.publicId().asUuidList().stream()
+                .map(UUID::toString)
+                .collect(Collectors.toList());
+        idList.addAll(DataModelHelper.getIdsToAppend(genEditingViewModel.getViewProperties().calculator(), semanticComponent.toProxy()));
+        String idString = String.join(", ", idList);
+
+        uuidTextFieldLabel.setText(idString);
+        identifierTooltip.setText(idString);
     }
 
     /**

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
@@ -238,7 +238,7 @@
                   </VBox>
                </center>
                <top>
-                  <BorderPane prefHeight="103.0" prefWidth="894.0" styleClass="concept-detail-banner-background" BorderPane.alignment="CENTER">
+                  <BorderPane prefHeight="180.0" prefWidth="894.0" styleClass="concept-detail-banner-background" BorderPane.alignment="CENTER">
                      <center>
                         <GridPane hgap="8.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="66.0" prefWidth="507.0" styleClass="concept-detail-banner-background">
                            <columnConstraints>
@@ -273,6 +273,21 @@
                                     <Text fx:id="semanticPurposeText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="semantic-banner-value" text="[]" />
                                  </children>
                               </TextFlow>
+                              <HBox alignment="CENTER_LEFT" prefWidth="300" GridPane.columnSpan="2" GridPane.rowIndex="3" GridPane.columnIndex="1" GridPane.rowSpan="1" >
+                                 <Label text="IDENTIFIER: ">
+                                    <font>
+                                       <Font name="Noto Sans Bold" size="10.0" />
+                                    </font>
+                                 </Label>
+                                 <TextField fx:id="uuidTextFieldLabel" editable="false" styleClass="copyable-label" HBox.hgrow="ALWAYS">
+                                    <font>
+                                       <Font name="Noto Sans" size="10.0" />
+                                    </font>
+                                    <tooltip>
+                                       <Tooltip fx:id="identifierTooltip" />
+                                    </tooltip>
+                                 </TextField>
+                              </HBox>
                            </children>
                            <padding>
                               <Insets bottom="8.0" left="12.0" right="8.0" top="8.0" />


### PR DESCRIPTION
Fixes:
1. https://ikmdev.atlassian.net/browse/IIA-2241
2. https://ikmdev.atlassian.net/browse/IIA-2242

![image](https://github.com/user-attachments/assets/e20e4b94-98bb-4ede-a583-91a55253e59f)
