### PR TITLE
Feature/finished/IIA-2097, IIA-2138, IIA-2272, IIA-2350: search performance improvement

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/NextGenSearchController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/NextGenSearchController.java
@@ -114,7 +114,7 @@ public class NextGenSearchController extends AbstractBasicController {
     private static final PseudoClass FILTER_SHOWING = PseudoClass.getPseudoClass("filter-showing");
 
     @FXML
-    private StackPane root;
+    private Pane root;
 
     @FXML
     private ListView searchResultsListView;

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SearchCellDescriptionSemantic.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SearchCellDescriptionSemantic.java
@@ -1,0 +1,69 @@
+package dev.ikm.komet.kview.mvvm.view.search;
+
+import dev.ikm.komet.framework.Identicon;
+import dev.ikm.komet.framework.view.ObservableViewNoOverride;
+import dev.ikm.tinkar.coordinate.stamp.calculator.LatestVersionSearchResult;
+import dev.ikm.tinkar.entity.ConceptEntity;
+import dev.ikm.tinkar.entity.Entity;
+import dev.ikm.tinkar.entity.SemanticEntityVersion;
+import javafx.geometry.Insets;
+import javafx.scene.Node;
+import javafx.scene.control.ListCell;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import org.carlfx.cognitive.loader.FXMLMvvmLoader;
+import org.carlfx.cognitive.loader.JFXNode;
+
+import static dev.ikm.komet.kview.mvvm.view.search.NextGenSearchController.getDragAndDropType;
+import static dev.ikm.komet.kview.mvvm.view.search.NextGenSearchController.setUpDraggable;
+
+public class SearchCellDescriptionSemantic extends ListCell<LatestVersionSearchResult> {
+    public static final String SORT_SEMANTIC_RESULT_CONCEPT_FXML = "search-result-semantic-entry.fxml";
+
+    private SortResultSemanticEntryController controller;
+    private Node content;
+    private ObservableViewNoOverride observableViewNoOverride;
+
+    public SearchCellDescriptionSemantic(ObservableViewNoOverride observableViewNoOverride) {
+        JFXNode<Pane, SortResultSemanticEntryController> searchSemanticEntryJFXNode = FXMLMvvmLoader
+                .make(SortResultSemanticEntryController.class.getResource(SORT_SEMANTIC_RESULT_CONCEPT_FXML));
+
+        this.observableViewNoOverride = observableViewNoOverride;
+        content = searchSemanticEntryJFXNode.node();
+        controller = searchSemanticEntryJFXNode.controller();
+    }
+
+    @Override
+    protected void updateItem(LatestVersionSearchResult item, boolean empty) {
+        super.updateItem(item, empty);
+
+        if (item == null || empty) {
+            setGraphic(null);
+        } else {
+            SemanticEntityVersion semantic = item.latestVersion().get();
+
+            controller.setIdenticon(Identicon.generateIdenticonImage(semantic.publicId()));
+            controller.setSemanticText(formatHighlightedString(item.highlightedString()));
+            Entity entity = Entity.getConceptForSemantic(semantic.nid()).get();
+            controller.setData((ConceptEntity) entity);
+            if (semantic.active()) {
+                controller.getRetiredHBox().getChildren().remove(controller.getRetiredLabel());
+                controller.increaseTextFlowWidth();
+            }
+            controller.setWindowView(observableViewNoOverride);
+
+            VBox.setMargin(content, new Insets(2, 0, 2, 0));
+
+            setUpDraggable(content, entity, getDragAndDropType(entity));
+
+            setGraphic(content);
+        }
+    }
+
+    private String formatHighlightedString(String highlightedString) {
+        String string = (highlightedString == null) ? "" : highlightedString;
+        return string.replaceAll("<B>", "")
+                .replaceAll("</B>", "")
+                .replaceAll("\\s+", " ");
+    }
+}

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SearchCellTopComponent.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SearchCellTopComponent.java
@@ -55,7 +55,6 @@ public class SearchCellTopComponent extends ListCell<Map.Entry<SearchPanelContro
         VBox.setMargin(parentPane, new Insets(8, 0, 8, 0));
 
         setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
-        setText(null);
     }
 
     @Override
@@ -77,23 +76,13 @@ public class SearchCellTopComponent extends ListCell<Map.Entry<SearchPanelContro
                 controller.setData(entity);
                 controller.setComponentText(topText);
 
-//                                controller.getDescriptionsVBox().getChildren().clear();
-//                                latestVersionSearchResults.forEach(latestVersionSearchResult -> {
-//                                    Label descrLabel = new Label(formatHighlightedString(latestVersionSearchResult.highlightedString()));
-//                                    descrLabel.getStyleClass().add("search-entry-description-label");
-//                                    controller.getDescriptionsVBox().getChildren().add(descrLabel);
-//                                    controller.getDescriptionsVBox().getStyleClass().add("search-entry-descr-container");
-//                                    VBox.setMargin(descrLabel, new Insets(0, 7, 7, 7));
-//                                    descrLabel.setPadding(new Insets(8));
-//                                });
                 controller.getDescriptionListViewItems().setAll(item.getValue());
-
 
                 if (entityVersion.active()) {
                     controller.getRetiredHBox().getChildren().remove(controller.getRetiredLabel());
                 }
                 controller.setRetired(!entityVersion.active());
-//                VBox.setMargin(parentPane, new Insets(8, 0, 8, 0));
+
                 setUpDraggable(parentPane, entity, CONCEPT);
 
                 setGraphic(parentPane);

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SearchCellTopComponent.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SearchCellTopComponent.java
@@ -1,0 +1,106 @@
+package dev.ikm.komet.kview.mvvm.view.search;
+
+import dev.ikm.komet.framework.Identicon;
+import dev.ikm.komet.framework.search.SearchPanelController;
+import dev.ikm.komet.framework.view.ObservableViewNoOverride;
+import dev.ikm.komet.framework.view.ViewProperties;
+import dev.ikm.tinkar.coordinate.stamp.calculator.Latest;
+import dev.ikm.tinkar.coordinate.stamp.calculator.LatestVersionSearchResult;
+import dev.ikm.tinkar.entity.Entity;
+import dev.ikm.tinkar.entity.EntityVersion;
+import javafx.geometry.Insets;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.ListCell;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import org.carlfx.cognitive.loader.Config;
+import org.carlfx.cognitive.loader.FXMLMvvmLoader;
+import org.carlfx.cognitive.loader.JFXNode;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static dev.ikm.komet.kview.mvvm.model.DragAndDropType.CONCEPT;
+import static dev.ikm.komet.kview.mvvm.view.search.NextGenSearchController.setUpDraggable;
+import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.CURRENT_JOURNAL_WINDOW_TOPIC;
+import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.VIEW_PROPERTIES;
+
+public class SearchCellTopComponent extends ListCell<Map.Entry<SearchPanelController.NidTextRecord, List<LatestVersionSearchResult>>> {
+
+    public static final String SORT_CONCEPT_RESULT_CONCEPT_FXML = "search-result-concept-entry.fxml";
+
+    private final ViewProperties viewProperties;
+    private final ObservableViewNoOverride observableViewNoOverride;
+
+    private final SortResultConceptEntryController controller;
+    private final Pane parentPane;
+
+    public SearchCellTopComponent(ViewProperties viewProperties, UUID jornalTopic, ObservableViewNoOverride observableViewNoOverride) {
+        this.viewProperties = viewProperties;
+        this.observableViewNoOverride = observableViewNoOverride;
+
+        Config config = new Config(SortResultConceptEntryController.class.getResource(SORT_CONCEPT_RESULT_CONCEPT_FXML));
+        config.updateViewModel("searchEntryViewModel", (searchEntryViewModel) ->
+                searchEntryViewModel
+                        .addProperty(VIEW_PROPERTIES, viewProperties)
+                        .addProperty(CURRENT_JOURNAL_WINDOW_TOPIC, jornalTopic)
+        );
+
+        JFXNode<Pane, SortResultConceptEntryController> searchConceptEntryJFXNode = FXMLMvvmLoader.make(config);
+
+        parentPane = searchConceptEntryJFXNode.node();
+        controller = searchConceptEntryJFXNode.controller();
+
+        VBox.setMargin(parentPane, new Insets(8, 0, 8, 0));
+
+        setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+        setText(null);
+    }
+
+    @Override
+    protected void updateItem(Map.Entry<SearchPanelController.NidTextRecord, List<LatestVersionSearchResult>> item, boolean empty) {
+        super.updateItem(item, empty);
+
+        if (item == null || empty) {
+            setGraphic(null);
+        } else {
+            int topNid = item.getKey().nid();
+            String topText = viewProperties.nodeView().calculator().getFullyQualifiedDescriptionTextWithFallbackOrNid(topNid); // top text I assume is the title text
+            Latest<EntityVersion> latestTopVersion = viewProperties.nodeView().calculator().latest(topNid);
+            if (latestTopVersion.isPresent()) {
+                EntityVersion entityVersion = latestTopVersion.get();
+
+                controller.setIdenticon(Identicon.generateIdenticonImage(entityVersion.publicId()));
+                controller.setWindowView(observableViewNoOverride);
+                Entity entity = Entity.get(entityVersion.nid()).get();
+                controller.setData(entity);
+                controller.setComponentText(topText);
+
+//                                controller.getDescriptionsVBox().getChildren().clear();
+//                                latestVersionSearchResults.forEach(latestVersionSearchResult -> {
+//                                    Label descrLabel = new Label(formatHighlightedString(latestVersionSearchResult.highlightedString()));
+//                                    descrLabel.getStyleClass().add("search-entry-description-label");
+//                                    controller.getDescriptionsVBox().getChildren().add(descrLabel);
+//                                    controller.getDescriptionsVBox().getStyleClass().add("search-entry-descr-container");
+//                                    VBox.setMargin(descrLabel, new Insets(0, 7, 7, 7));
+//                                    descrLabel.setPadding(new Insets(8));
+//                                });
+                controller.getDescriptionListViewItems().setAll(item.getValue());
+
+
+                if (entityVersion.active()) {
+                    controller.getRetiredHBox().getChildren().remove(controller.getRetiredLabel());
+                }
+                controller.setRetired(!entityVersion.active());
+//                VBox.setMargin(parentPane, new Insets(8, 0, 8, 0));
+                setUpDraggable(parentPane, entity, CONCEPT);
+
+                setGraphic(parentPane);
+            }
+            else {
+                setGraphic(null);
+            }
+        }
+    }
+}

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SortResultConceptEntryController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SortResultConceptEntryController.java
@@ -23,21 +23,25 @@ import dev.ikm.komet.kview.events.MakeConceptWindowEvent;
 import dev.ikm.komet.kview.events.ShowNavigationalPanelEvent;
 import dev.ikm.komet.kview.events.pattern.MakePatternWindowEvent;
 import dev.ikm.komet.kview.mvvm.view.AbstractBasicController;
+import dev.ikm.tinkar.coordinate.stamp.calculator.LatestVersionSearchResult;
 import dev.ikm.tinkar.entity.ConceptEntity;
 import dev.ikm.tinkar.entity.Entity;
 import dev.ikm.tinkar.entity.EntityVersion;
 import dev.ikm.tinkar.entity.PatternEntity;
+import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.geometry.Side;
 import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TitledPane;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import org.carlfx.cognitive.loader.InjectViewModel;
 import org.carlfx.cognitive.viewmodel.SimpleViewModel;
@@ -49,6 +53,10 @@ import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.VIEW_PROPERTIES;
 
 
 public class SortResultConceptEntryController extends AbstractBasicController {
+
+
+    @FXML
+    private TitledPane descriptionsTitledPane;
 
     @FXML
     private HBox searchEntryHBox;
@@ -65,8 +73,11 @@ public class SortResultConceptEntryController extends AbstractBasicController {
     @FXML
     private Label retiredLabel;
 
+//    @FXML
+//    private VBox descriptionsVBox;
+
     @FXML
-    private VBox descriptionsVBox;
+    private ListView<LatestVersionSearchResult> descriptionsListView;
 
     @FXML
     private Button showContextButton;
@@ -116,6 +127,26 @@ public class SortResultConceptEntryController extends AbstractBasicController {
                 contextMenu.show(showContextButton, Side.BOTTOM, 0, 0);
             }
         });
+
+        descriptionsListView.setCellFactory(param -> new ListCell<>() {
+
+            @Override
+            protected void updateItem(LatestVersionSearchResult item, boolean empty) {
+                if (item == null || empty) {
+                    setText(null);
+                } else {
+                    setText(formatHighlightedString(item.highlightedString()));
+                }
+            }
+        });
+
+    }
+
+    private String formatHighlightedString(String highlightedString) {
+        String string = (highlightedString == null) ? "" : highlightedString;
+        return string.replaceAll("<B>", "")
+                .replaceAll("</B>", "")
+                .replaceAll("\\s+", " ");
     }
 
     @FXML
@@ -159,9 +190,11 @@ public class SortResultConceptEntryController extends AbstractBasicController {
         this.componentText.setText(topText);
     }
 
-    public VBox getDescriptionsVBox() {
-        return this.descriptionsVBox;
-    }
+//    public VBox getDescriptionsVBox() {
+//        return this.descriptionsVBox;
+//    }
+
+    public ObservableList<LatestVersionSearchResult> getDescriptionListViewItems() { return descriptionsListView.getItems(); }
 
     @Override
     public void updateView() {
@@ -195,5 +228,4 @@ public class SortResultConceptEntryController extends AbstractBasicController {
     public <T extends ViewModel> T getViewModel() {
         return null;
     }
-
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SortResultConceptEntryController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SortResultConceptEntryController.java
@@ -28,11 +28,13 @@ import dev.ikm.tinkar.entity.ConceptEntity;
 import dev.ikm.tinkar.entity.Entity;
 import dev.ikm.tinkar.entity.EntityVersion;
 import dev.ikm.tinkar.entity.PatternEntity;
+import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.geometry.Side;
 import javafx.scene.control.Button;
+import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
@@ -41,6 +43,8 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
 import org.carlfx.cognitive.loader.InjectViewModel;
 import org.carlfx.cognitive.viewmodel.SimpleViewModel;
@@ -53,8 +57,10 @@ import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.VIEW_PROPERTIES;
 
 public class SortResultConceptEntryController extends AbstractBasicController {
 
+    private static final int LIST_VIEW_CELL_SIZE = 40;
+
     @FXML
-    private HBox searchEntryHBox;
+    private Pane searchEntryContainer;
 
     @FXML
     private ImageView identicon;
@@ -94,15 +100,15 @@ public class SortResultConceptEntryController extends AbstractBasicController {
         eventBus = EvtBusFactory.getDefaultEvtBus();
         showContextButton.setVisible(false);
         contextMenu.setHideOnEscape(true);
-        searchEntryHBox.setOnMouseEntered(mouseEvent -> showContextButton.setVisible(entity instanceof ConceptEntity));
-        searchEntryHBox.setOnMouseExited(mouseEvent -> {
+        searchEntryContainer.setOnMouseEntered(mouseEvent -> showContextButton.setVisible(entity instanceof ConceptEntity));
+        searchEntryContainer.setOnMouseExited(mouseEvent -> {
             if (!contextMenu.isShowing()) {
                 showContextButton.setVisible(false);
             }
         });
         showContextButton.setOnAction(event -> contextMenu.show(showContextButton, Side.BOTTOM, 0, 0));
 
-        searchEntryHBox.setOnMouseClicked(mouseEvent -> {
+        searchEntryContainer.setOnMouseClicked(mouseEvent -> {
             // double left click creates the concept window
             if (mouseEvent.getButton().equals(MouseButton.PRIMARY)) {
                 if (mouseEvent.getClickCount() == 2) {
@@ -120,18 +126,31 @@ public class SortResultConceptEntryController extends AbstractBasicController {
             }
         });
 
+        descriptionsListView.setFixedCellSize(LIST_VIEW_CELL_SIZE);
+        descriptionsListView.getItems().addListener((ListChangeListener<? super LatestVersionSearchResult>) change -> updateListViewPrefHeight());
+        updateListViewPrefHeight();
+
         descriptionsListView.setCellFactory(param -> new ListCell<>() {
+            StackPane cellContainer = new StackPane();
+            Label label = new Label();
+
+            {
+                cellContainer.getChildren().add(label);
+                setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+
+                cellContainer.getStyleClass().add("cell-container");
+            }
 
             @Override
             protected void updateItem(LatestVersionSearchResult item, boolean empty) {
                 if (item == null || empty) {
-                    setText(null);
+                    setGraphic(null);
                 } else {
-                    setText(formatHighlightedString(item.highlightedString()));
+                    label.setText(formatHighlightedString(item.highlightedString()));
+                    setGraphic(cellContainer);
                 }
             }
         });
-
     }
 
     private String formatHighlightedString(String highlightedString) {
@@ -143,7 +162,6 @@ public class SortResultConceptEntryController extends AbstractBasicController {
 
     @FXML
     private void populateConcept(ActionEvent actionEvent) {
-        actionEvent.consume();
         if (entity instanceof ConceptEntity conceptEntity) {
             eventBus.publish(JOURNAL_TOPIC, new MakeConceptWindowEvent(this,
                     MakeConceptWindowEvent.OPEN_CONCEPT_FROM_CONCEPT, conceptEntity));
@@ -152,7 +170,6 @@ public class SortResultConceptEntryController extends AbstractBasicController {
 
     @FXML
     private void openInConceptNavigator(ActionEvent actionEvent) {
-        actionEvent.consume();
         if (entity instanceof ConceptEntity conceptEntity) {
             eventBus.publish(JOURNAL_TOPIC, new ShowNavigationalPanelEvent(this, ShowNavigationalPanelEvent.SHOW_CONCEPT_NAVIGATIONAL_FROM_CONCEPT, conceptEntity));
         }
@@ -212,5 +229,14 @@ public class SortResultConceptEntryController extends AbstractBasicController {
     @Override
     public <T extends ViewModel> T getViewModel() {
         return null;
+    }
+
+    private void updateListViewPrefHeight() {
+        int itemsNumber = descriptionsListView.getItems().size();
+        /* adding a number to LIST_VIEW_CELL_SIZE to account for padding, etc */
+        double newPrefHeight = itemsNumber * (LIST_VIEW_CELL_SIZE + 3);
+        double maxHeight = descriptionsListView.getMaxHeight();
+
+        descriptionsListView.setPrefHeight(Math.min(newPrefHeight, maxHeight));
     }
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SortResultConceptEntryController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SortResultConceptEntryController.java
@@ -37,7 +37,6 @@ import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
-import javafx.scene.control.TitledPane;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseButton;
@@ -54,10 +53,6 @@ import static dev.ikm.komet.kview.mvvm.viewmodel.FormViewModel.VIEW_PROPERTIES;
 
 public class SortResultConceptEntryController extends AbstractBasicController {
 
-
-    @FXML
-    private TitledPane descriptionsTitledPane;
-
     @FXML
     private HBox searchEntryHBox;
 
@@ -72,9 +67,6 @@ public class SortResultConceptEntryController extends AbstractBasicController {
 
     @FXML
     private Label retiredLabel;
-
-//    @FXML
-//    private VBox descriptionsVBox;
 
     @FXML
     private ListView<LatestVersionSearchResult> descriptionsListView;
@@ -190,25 +182,18 @@ public class SortResultConceptEntryController extends AbstractBasicController {
         this.componentText.setText(topText);
     }
 
-//    public VBox getDescriptionsVBox() {
-//        return this.descriptionsVBox;
-//    }
-
     public ObservableList<LatestVersionSearchResult> getDescriptionListViewItems() { return descriptionsListView.getItems(); }
 
     @Override
     public void updateView() {
-
     }
 
     @Override
     public void clearView() {
-
     }
 
     @Override
     public void cleanup() {
-
     }
 
     public void setData(Entity<EntityVersion> entity) {

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SortResultSemanticEntryController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/SortResultSemanticEntryController.java
@@ -20,13 +20,10 @@ import dev.ikm.komet.framework.events.EvtBusFactory;
 import dev.ikm.komet.framework.view.ObservableViewNoOverride;
 import dev.ikm.komet.kview.events.MakeConceptWindowEvent;
 import dev.ikm.komet.kview.events.ShowNavigationalPanelEvent;
-import dev.ikm.komet.kview.events.pattern.MakePatternWindowEvent;
 import dev.ikm.tinkar.entity.ConceptEntity;
 import dev.ikm.tinkar.entity.Entity;
 import dev.ikm.tinkar.entity.EntityVersion;
-import dev.ikm.tinkar.entity.PatternEntity;
 import dev.ikm.tinkar.entity.SemanticEntity;
-import dev.ikm.tinkar.entity.SemanticEntityVersion;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.geometry.Side;
@@ -37,6 +34,7 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
 
@@ -45,7 +43,7 @@ import static dev.ikm.komet.kview.events.EventTopics.JOURNAL_TOPIC;
 public class SortResultSemanticEntryController  {
 
     @FXML
-    private HBox searchEntryHBox;
+    private Pane searchEntryContainer;
 
     @FXML
     private ImageView identicon;
@@ -84,15 +82,15 @@ public class SortResultSemanticEntryController  {
         eventBus = EvtBusFactory.getDefaultEvtBus();
         showContextButton.setVisible(false);
         contextMenu.setHideOnEscape(true);
-        searchEntryHBox.setOnMouseEntered(mouseEvent -> showContextButton.setVisible(true));
-        searchEntryHBox.setOnMouseExited(mouseEvent -> {
+        searchEntryContainer.setOnMouseEntered(mouseEvent -> showContextButton.setVisible(true));
+        searchEntryContainer.setOnMouseExited(mouseEvent -> {
             if (!contextMenu.isShowing()) {
                 showContextButton.setVisible(false);
             }
         });
         showContextButton.setOnAction(event -> contextMenu.show(showContextButton, Side.BOTTOM, 0, 0));
 
-        searchEntryHBox.setOnMouseClicked(mouseEvent -> {
+        searchEntryContainer.setOnMouseClicked(mouseEvent -> {
             // double left click creates the concept window
             if (mouseEvent.getButton().equals(MouseButton.PRIMARY)){
                 if (mouseEvent.getClickCount() == 2) {

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -196,12 +196,11 @@
 
 /* focus purely on the arrow */
 .titled-pane:focused > .title > .arrow-button > .arrow {
-    -fx-background-color: -Secondary-05;
-    -fx-shape: "M7.91 8.29508L6.5 9.70508L12.5 15.7051L18.5 9.70508L17.09 8.29508L12.5 12.8751L7.91 8.29508Z";
-    -fx-background-insets: -1, 0;
+    -fx-effect: null;
+    -fx-background-insets: 0;
+    -fx-background-radius: 0;
 }
 .titled-pane > .title > .arrow-button {
-    -fx-background-color: null;
     -fx-background-insets: 0;
     -fx-background-radius: 0;
     -fx-padding: 0.0em 0.583em 0.0em 0.0em; /* 0 7 0 0 */
@@ -2859,16 +2858,91 @@ Timeline Year line segment (will overlay change circles)
 }
 
 /*********************************************************************************
- * End of Pattern UI elements                                                    *
+ * Next Gen Search                                                               *
  *********************************************************************************/
 
+.next-gen-search-main-container .outer-list-view {
+    -fx-background-color: -Grey-9;
+}
 
-/********************************************************************************
- * Start of Journal > Search Concept UI elements                                *
- ********************************************************************************/
+.next-gen-search-main-container .outer-list-view > .virtual-flow > .clipped-container > .sheet > .list-cell {
+    -fx-background-color: transparent;
+    -fx-padding: 3px 6px 3px 12px;
+}
+
+.next-gen-search-main-container .outer-list-view .scroll-bar {
+    -fx-background-color: transparent;
+    -fx-padding: 2px 0 0 0;
+}
+
+.next-gen-search-main-container .outer-list-view .scroll-bar:vertical .increment-button,
+.next-gen-search-main-container .outer-list-view .scroll-bar:vertical .decrement-button,
+.next-gen-search-main-container .outer-list-view .scroll-bar:vertical .increment-arrow,
+.next-gen-search-main-container .outer-list-view .scroll-bar:vertical .decrement-arrow {
+     -fx-background-color:transparent;
+     -fx-background-radius: 0em;
+     -fx-padding: 0 2 0 2;
+}
+
+.next-gen-search-main-container .outer-list-view .scroll-bar:vertical .thumb {
+    -fx-background-color: #a9aeb8;
+    -fx-background-insets: 3px 5px 3px 1px;
+    -fx-background-radius: 16px;
+}
 
 .search-vertical-scroll-area {
     -fx-background-color: -Grey-9;
+}
+
+.next-gen-search-main-container .descriptions-list-view {
+    -fx-background-color: #f1f3f8;
+    -fx-padding: 3px 0 0 0;
+}
+
+.next-gen-search-main-container .descriptions-list-view .scroll-bar {
+    -fx-background-color: transparent;
+    -fx-padding: 2px 0 0 0;
+}
+
+.next-gen-search-main-container .descriptions-list-view .scroll-bar:vertical .increment-button,
+.next-gen-search-main-container .descriptions-list-view .scroll-bar:vertical .decrement-button,
+.next-gen-search-main-container .descriptions-list-view .scroll-bar:vertical .increment-arrow,
+.next-gen-search-main-container .descriptions-list-view .scroll-bar:vertical .decrement-arrow {
+    -fx-background-color:transparent;
+    -fx-background-radius: 0em;
+    -fx-padding: 0 2 0 2;
+}
+
+.next-gen-search-main-container .descriptions-list-view .scroll-bar:vertical .thumb {
+    -fx-background-color: #777;
+    -fx-background-insets: 3 5 3 0;
+    -fx-background-radius: 16px;
+}
+
+/* Cells and Cells content */
+.next-gen-search-main-container .descriptions-list-view .list-cell {
+    -fx-background-color: transparent;
+    -fx-border-color: transparent;
+
+    -fx-padding: 0 6px 5 6px;
+}
+
+.next-gen-search-main-container .descriptions-list-view .list-cell .cell-container {
+    -fx-font-family: "Noto Sans";
+    -fx-font-size: 12px;
+
+    -fx-background-color: white;
+    -fx-background-radius: 3px;
+    -fx-border-radius: 3px;
+
+    -fx-effect: dropshadow(gaussian , rgba(0,0,0,0.2) , 4, 0.0 , 0 , 2 );
+
+    height: 75;
+    -fx-pref-height: height;
+    -fx-max-height: height;
+
+    -fx-padding: 5 6 5 10;
+    -fx-alignment: center_left;
 }
 
 .search-button,
@@ -2923,21 +2997,41 @@ Timeline Year line segment (will overlay change circles)
     -fx-text-fill: white;
 }
 
+.search-entry-container {
+    -fx-border-radius: 2px;
+    -fx-background-radius: 2px;
+    -fx-background-color: white;
+
+    -fx-padding: 4px 5px 7px 5px;
+
+    -fx-spacing: 3px;
+}
+
+.next-gen-search-main-container .search-entry-container .identicon-container {
+    -fx-padding: 0 0 0 4px;
+}
+
 .search-entry-hbox {
     -fx-border-radius: 2px;
     -fx-background-radius: 2px;
     -fx-background-color: white;
 }
 
+.next-gen-search-main-container .search-entry-header {
+    -fx-alignment: center_left;
+}
+
+.search-entry-text-container {
+    -fx-padding: 6px 0 5px 0;
+}
+
 .search-entry-text {
     -fx-font-family: "Noto Sans";
     -fx-font-size: 14px;
-    -fx-font-style: normal;
-    -fx-font-weight: bold;
+
     -fx-line-height: 16px;
     -fx-letter-spacing: 0.2px;
     -fx-fill: -Natural-Grey-Dark;
-
 }
 
 .search-entry-expanded {
@@ -3180,8 +3274,6 @@ Timeline Year line segment (will overlay change circles)
 .pattern-instance-hbox {
     -fx-font-family: "Noto Sans";
     -fx-font-size: 12px;
-    -fx-font-style: normal;
-    -fx-font-weight: 400;
 
     -fx-background-color: white;
     -fx-background-radius: 3px;

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -2863,6 +2863,7 @@ Timeline Year line segment (will overlay change circles)
 
 .next-gen-search-main-container .outer-list-view {
     -fx-background-color: -Grey-9;
+    -fx-padding: 10px 0 10px 0;
 }
 
 .next-gen-search-main-container .outer-list-view > .virtual-flow > .clipped-container > .sheet > .list-cell {
@@ -2956,6 +2957,8 @@ Timeline Year line segment (will overlay change circles)
 
 .search-hbox {
     -fx-background-color: -Grey-9;
+    -fx-border-color: #444;
+    -fx-border-width: 0 0 1px 0;
 }
 
 .search-text-field {
@@ -3015,6 +3018,14 @@ Timeline Year line segment (will overlay change circles)
     -fx-border-radius: 2px;
     -fx-background-radius: 2px;
     -fx-background-color: white;
+}
+
+.search-entry-hbox .search-entry-left-pane {
+    -fx-spacing: 4px;
+}
+
+.search-entry-hbox .search-entry-left-pane .semantic-text-container {
+    -fx-padding: -1 0 0 3;
 }
 
 .next-gen-search-main-container .search-entry-header {

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/next-gen-search.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/next-gen-search.fxml
@@ -13,52 +13,47 @@
 <?import javafx.scene.control.ListView?>
 <StackPane fx:id="root" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.search.NextGenSearchController">
     <children>
-                <VBox prefHeight="900.0" prefWidth="372.0" styleClass="search-vertical-scroll-area">
-                    <children>
-                        <HBox prefHeight="61.0" prefWidth="372.0" styleClass="search-hbox" VBox.vgrow="NEVER">
-                            <VBox.margin>
-                                <Insets />
-                            </VBox.margin>
-                            <children>
-                                <VBox prefHeight="61.0" prefWidth="350.0">
-                                    <children>
-                                        <HBox prefHeight="100.0" prefWidth="200.0">
-                                            <children>
-                                                <AutoCompleteTextField fx:id="searchField" onAction="#doSearch" prefWidth="424.0" promptText="🔍  Search" styleClass="search-text-field">
-                                                   <cursor>
-                                                      <Cursor fx:constant="TEXT" />
-                                                   </cursor>
-                                                </AutoCompleteTextField>
-                                                <Button fx:id="filterPane" mnemonicParsing="false" styleClass="search-button, filter-button">
-                                                    <graphic>
-                                                        <Region focusTraversable="true">
-                                                            <styleClass>
-                                                                <String fx:value="icon" />
-                                                                <String fx:value="search-button-region" />
-                                                            </styleClass>
-                                                        </Region>
-                                                    </graphic>
-                                                </Button>
-                                            </children>
-                                            <padding>
-                                                <Insets bottom="12.0" />
-                                            </padding>
-                                        </HBox>
-                                        <Button fx:id="sortByButton" mnemonicParsing="false" onAction="#showSearchOptions" prefHeight="25.0" prefWidth="345.0" styleClass="search-sort-button" text="SORT BY: TOP COMPONENT" />
-                                    </children>
-                                </VBox>
-                            </children>
-                            <padding>
-                                <Insets bottom="12.0" left="12.0" right="8.0" top="12.0" />
-                            </padding>
-                        </HBox>
-<!--                        <VBox fx:id="resultsVBox">-->
-<!--                            <VBox.margin>-->
-<!--                                <Insets bottom="4.0" left="12.0" right="12.0" />-->
-<!--                            </VBox.margin>-->
-<!--                        </VBox>-->
-                        <ListView fx:id="searchResultsListView" VBox.vgrow="ALWAYS"/>
-                    </children>
-                </VBox>
+            <VBox prefHeight="900.0" prefWidth="372.0" styleClass="search-vertical-scroll-area">
+                <children>
+                    <HBox prefHeight="61.0" prefWidth="372.0" styleClass="search-hbox" VBox.vgrow="NEVER">
+                        <VBox.margin>
+                            <Insets />
+                        </VBox.margin>
+                        <children>
+                            <VBox prefHeight="61.0" prefWidth="350.0">
+                                <children>
+                                    <HBox prefHeight="100.0" prefWidth="200.0">
+                                        <children>
+                                            <AutoCompleteTextField fx:id="searchField" onAction="#doSearch" prefWidth="424.0" promptText="🔍  Search" styleClass="search-text-field">
+                                               <cursor>
+                                                  <Cursor fx:constant="TEXT" />
+                                               </cursor>
+                                            </AutoCompleteTextField>
+                                            <Button fx:id="filterPane" mnemonicParsing="false" styleClass="search-button, filter-button">
+                                                <graphic>
+                                                    <Region focusTraversable="true">
+                                                        <styleClass>
+                                                            <String fx:value="icon" />
+                                                            <String fx:value="search-button-region" />
+                                                        </styleClass>
+                                                    </Region>
+                                                </graphic>
+                                            </Button>
+                                        </children>
+                                        <padding>
+                                            <Insets bottom="12.0" />
+                                        </padding>
+                                    </HBox>
+                                    <Button fx:id="sortByButton" mnemonicParsing="false" onAction="#showSearchOptions" prefHeight="25.0" prefWidth="345.0" styleClass="search-sort-button" text="SORT BY: TOP COMPONENT" />
+                                </children>
+                            </VBox>
+                        </children>
+                        <padding>
+                            <Insets bottom="12.0" left="12.0" right="8.0" top="12.0" />
+                        </padding>
+                    </HBox>
+                    <ListView fx:id="searchResultsListView" VBox.vgrow="ALWAYS"/>
+                </children>
+            </VBox>
     </children>
 </StackPane>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/next-gen-search.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/next-gen-search.fxml
@@ -44,7 +44,7 @@
                                             <Insets bottom="12.0" />
                                         </padding>
                                     </HBox>
-                                    <Button fx:id="sortByButton" mnemonicParsing="false" onAction="#showSearchOptions" prefHeight="25.0" prefWidth="345.0" styleClass="search-sort-button" text="SORT BY: TOP COMPONENT" />
+                                    <Button fx:id="sortByButton" mnemonicParsing="false" onAction="#showSearchOptions" prefHeight="25.0" prefWidth="345.0" styleClass="search-sort-button" />
                                 </children>
                             </VBox>
                         </children>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/next-gen-search.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/next-gen-search.fxml
@@ -4,18 +4,15 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Cursor?>
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
 <?import dev.ikm.komet.kview.controls.AutoCompleteTextField?>
+<?import javafx.scene.control.ListView?>
 <StackPane fx:id="root" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.search.NextGenSearchController">
     <children>
-        <ScrollPane fitToHeight="true" fitToWidth="true" maxHeight="1.7976931348623157E308" minWidth="-Infinity" prefWidth="372.0">
-            <content>
                 <VBox prefHeight="900.0" prefWidth="372.0" styleClass="search-vertical-scroll-area">
                     <children>
                         <HBox prefHeight="61.0" prefWidth="372.0" styleClass="search-hbox" VBox.vgrow="NEVER">
@@ -55,14 +52,13 @@
                                 <Insets bottom="12.0" left="12.0" right="8.0" top="12.0" />
                             </padding>
                         </HBox>
-                        <VBox fx:id="resultsVBox">
-                            <VBox.margin>
-                                <Insets bottom="4.0" left="12.0" right="12.0" />
-                            </VBox.margin>
-                        </VBox>
+<!--                        <VBox fx:id="resultsVBox">-->
+<!--                            <VBox.margin>-->
+<!--                                <Insets bottom="4.0" left="12.0" right="12.0" />-->
+<!--                            </VBox.margin>-->
+<!--                        </VBox>-->
+                        <ListView fx:id="searchResultsListView" VBox.vgrow="ALWAYS"/>
                     </children>
                 </VBox>
-            </content>
-        </ScrollPane>
     </children>
 </StackPane>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/next-gen-search.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/next-gen-search.fxml
@@ -11,49 +11,42 @@
 
 <?import dev.ikm.komet.kview.controls.AutoCompleteTextField?>
 <?import javafx.scene.control.ListView?>
-<StackPane fx:id="root" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.search.NextGenSearchController">
+<VBox fx:id="root" stylesheets="@../kview.css" styleClass="next-gen-search-main-container" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.search.NextGenSearchController">
     <children>
-            <VBox prefHeight="900.0" prefWidth="372.0" styleClass="search-vertical-scroll-area">
-                <children>
-                    <HBox prefHeight="61.0" prefWidth="372.0" styleClass="search-hbox" VBox.vgrow="NEVER">
-                        <VBox.margin>
-                            <Insets />
-                        </VBox.margin>
-                        <children>
-                            <VBox prefHeight="61.0" prefWidth="350.0">
-                                <children>
-                                    <HBox prefHeight="100.0" prefWidth="200.0">
-                                        <children>
-                                            <AutoCompleteTextField fx:id="searchField" onAction="#doSearch" prefWidth="424.0" promptText="🔍  Search" styleClass="search-text-field">
-                                               <cursor>
-                                                  <Cursor fx:constant="TEXT" />
-                                               </cursor>
-                                            </AutoCompleteTextField>
-                                            <Button fx:id="filterPane" mnemonicParsing="false" styleClass="search-button, filter-button">
-                                                <graphic>
-                                                    <Region focusTraversable="true">
-                                                        <styleClass>
-                                                            <String fx:value="icon" />
-                                                            <String fx:value="search-button-region" />
-                                                        </styleClass>
-                                                    </Region>
-                                                </graphic>
-                                            </Button>
-                                        </children>
-                                        <padding>
-                                            <Insets bottom="12.0" />
-                                        </padding>
-                                    </HBox>
-                                    <Button fx:id="sortByButton" mnemonicParsing="false" onAction="#showSearchOptions" prefHeight="25.0" prefWidth="345.0" styleClass="search-sort-button" />
-                                </children>
-                            </VBox>
-                        </children>
-                        <padding>
-                            <Insets bottom="12.0" left="12.0" right="8.0" top="12.0" />
-                        </padding>
-                    </HBox>
-                    <ListView fx:id="searchResultsListView" VBox.vgrow="ALWAYS"/>
-                </children>
-            </VBox>
+        <HBox prefHeight="61.0" prefWidth="372.0" styleClass="search-hbox" VBox.vgrow="NEVER">
+            <children>
+                <VBox prefHeight="61.0" prefWidth="350.0">
+                    <children>
+                        <HBox prefHeight="100.0" prefWidth="200.0">
+                            <children>
+                                <AutoCompleteTextField fx:id="searchField" onAction="#doSearch" prefWidth="424.0" promptText="🔍  Search" styleClass="search-text-field">
+                                   <cursor>
+                                      <Cursor fx:constant="TEXT" />
+                                   </cursor>
+                                </AutoCompleteTextField>
+                                <Button fx:id="filterPane" mnemonicParsing="false" styleClass="search-button, filter-button">
+                                    <graphic>
+                                        <Region focusTraversable="true">
+                                            <styleClass>
+                                                <String fx:value="icon" />
+                                                <String fx:value="search-button-region" />
+                                            </styleClass>
+                                        </Region>
+                                    </graphic>
+                                </Button>
+                            </children>
+                            <padding>
+                                <Insets bottom="12.0" />
+                            </padding>
+                        </HBox>
+                        <Button fx:id="sortByButton" mnemonicParsing="false" onAction="#showSearchOptions" prefHeight="25.0" prefWidth="345.0" styleClass="search-sort-button" />
+                    </children>
+                </VBox>
+            </children>
+            <padding>
+                <Insets bottom="12.0" left="12.0" right="8.0" top="12.0" />
+            </padding>
+        </HBox>
+        <ListView fx:id="searchResultsListView" styleClass="outer-list-view" VBox.vgrow="ALWAYS"/>
     </children>
-</StackPane>
+</VBox>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/search-result-concept-entry.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/search-result-concept-entry.fxml
@@ -113,27 +113,7 @@
                   <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
                </padding>
             </HBox>
-            <TitledPane fx:id="descriptionsTitledPane" animated="false" expanded="false" styleClass="search-entry-title-pane" text="DESCRIPTION SEMANTICS" VBox.vgrow="ALWAYS">
-<!--                  <VBox fx:id="descriptionsVBox" prefWidth="100.0">-->
-<!--                     <children>-->
-<!--                        <Label prefHeight="30.0" prefWidth="302.0" styleClass="search-entry-description-label" text="Tetralogy of Fallot (disorder)">-->
-<!--                           <VBox.margin>-->
-<!--                              <Insets bottom="7.0" left="7.0" right="7.0" />-->
-<!--                           </VBox.margin>-->
-<!--                           <padding>-->
-<!--                              <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />-->
-<!--                           </padding>-->
-<!--                        </Label>-->
-<!--                        <Label layoutX="28.0" layoutY="28.0" prefHeight="30.0" prefWidth="302.0" styleClass="search-entry-description-label" text="Tetralogy of Fallot (disorder)">-->
-<!--                           <VBox.margin>-->
-<!--                              <Insets bottom="7.0" left="7.0" right="7.0" />-->
-<!--                           </VBox.margin>-->
-<!--                           <padding>-->
-<!--                              <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />-->
-<!--                           </padding>-->
-<!--                        </Label>-->
-<!--                     </children>-->
-<!--                  </VBox>-->
+            <TitledPane animated="false" expanded="false" styleClass="search-entry-title-pane" text="DESCRIPTION SEMANTICS" VBox.vgrow="ALWAYS">
                 <content>
                     <ListView fx:id="descriptionsListView" />
                 </content>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/search-result-concept-entry.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/search-result-concept-entry.fxml
@@ -13,118 +13,130 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.SVGPath?>
-<?import javafx.scene.text.Text?>
-<?import javafx.scene.text.TextFlow?>
 
 <?import javafx.scene.control.ListView?>
-<HBox fx:id="searchEntryHBox" prefWidth="332.0" styleClass="search-entry-hbox" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.search.SortResultConceptEntryController">
-   <children>
-      <VBox HBox.hgrow="ALWAYS">
-         <children>
-            <HBox fx:id="retiredHBox" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefWidth="346.0" spacing="11.0" VBox.vgrow="NEVER">
-               <children>
-                  <ImageView fx:id="identicon" fitHeight="24.0" fitWidth="24.0" pickOnBounds="true" preserveRatio="true">
-                     <HBox.margin>
-                        <Insets />
-                     </HBox.margin>
-                     <image>
-                        <Image url="@../images/heart-placeholder.png" />
-                     </image>
-                  </ImageView>
-                  <Label id="retiredLabelId" fx:id="retiredLabel" minWidth="-Infinity" styleClass="search-retired-label" text="Retired">
-                     <HBox.margin>
-                        <Insets />
-                     </HBox.margin>
-                     <padding>
-                        <Insets bottom="6.0" left="3.0" right="3.0" top="6.0" />
-                     </padding>
-                  </Label>
-                  <TextFlow prefWidth="253.0">
-                     <children>
-                        <Text fx:id="componentText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="search-entry-text" text="Chronic nonspecific lung disease (disorder)" />
-                     </children>
-                     <HBox.margin>
-                        <Insets />
-                     </HBox.margin>
-                  </TextFlow>
-                  <Button fx:id="showContextButton" contentDisplay="GRAPHIC_ONLY" mnemonicParsing="false" styleClass="search-result-context-button" text="Button">
-                     <graphic>
-                        <SVGPath content="M0 2a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M7 2a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M7 9a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M0 9a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M0 16a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M7 16a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" fill="#9a9da0" stroke="#9a9da0" strokeLineCap="ROUND" strokeLineJoin="ROUND" />
-                     </graphic>
-                     <contextMenu>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.text.Text?>
+<?import javafx.scene.text.TextFlow?>
+<VBox xmlns:fx="http://javafx.com/fxml/1" fx:id="searchEntryContainer" prefWidth="332.0"
+      styleClass="search-entry-container"
+      stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23"
+      fx:controller="dev.ikm.komet.kview.mvvm.view.search.SortResultConceptEntryController">
+    <children>
+        <BorderPane>
+            <center>
+                <HBox fx:id="retiredHBox" styleClass="search-entry-header" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
+                      prefWidth="346.0" spacing="11.0" VBox.vgrow="NEVER">
+                    <children>
+                        <StackPane styleClass="identicon-container">
+                            <ImageView fx:id="identicon" fitHeight="20.0" fitWidth="20.0" pickOnBounds="true"
+                                       preserveRatio="true">
+                                <image>
+                                    <Image url="@../images/heart-placeholder.png"/>
+                                </image>
+                            </ImageView>
+                        </StackPane>
+                        <Label id="retiredLabelId" fx:id="retiredLabel" minWidth="-Infinity"
+                               styleClass="search-retired-label" text="Retired">
+                            <HBox.margin>
+                                <Insets/>
+                            </HBox.margin>
+                            <padding>
+                                <Insets bottom="6.0" left="3.0" right="3.0" top="6.0"/>
+                            </padding>
+                        </Label>
+                        <TextFlow styleClass="search-entry-text-container" prefWidth="253.0">
+                            <children>
+                                <Text fx:id="componentText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="search-entry-text" text="Chronic nonspecific lung disease (disorder)" />
+                            </children>
+                        </TextFlow>
+                    </children>
+                </HBox>
+            </center>
+            <right>
+                <Button fx:id="showContextButton" contentDisplay="GRAPHIC_ONLY" mnemonicParsing="false"
+                        styleClass="search-result-context-button" text="Button">
+                    <graphic>
+                        <SVGPath
+                                content="M0 2a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M7 2a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M7 9a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M0 9a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M0 16a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M7 16a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"
+                                fill="#9a9da0" stroke="#9a9da0" strokeLineCap="ROUND" strokeLineJoin="ROUND"/>
+                    </graphic>
+                    <contextMenu>
                         <ContextMenu fx:id="contextMenu" styleClass="search-context-menu-container">
-                          <items>
-                            <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Populate concept" onAction="#populateConcept">
-                                 <graphic>
-                                    <Region styleClass="populate-icon">
-                                       <padding>
-                                          <Insets right="16.0" />
-                                       </padding></Region>
-                                 </graphic>
-                              </MenuItem>
-                             <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Open in Concept Navigator" onAction="#openInConceptNavigator">
-                                <graphic>
-                                   <Region styleClass="populate-icon">
-                                      <padding>
-                                         <Insets right="16.0" />
-                                      </padding>
-                                   </Region>
-                                </graphic>
-                             </MenuItem>
-                             <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Send to Journal">
-                                <graphic>
-                                   <Region styleClass="arrow-icon">
-                                       <padding>
-                                          <Insets right="16.0" />
-                                       </padding></Region>
-                                </graphic>
-                             </MenuItem>
-                             <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Send to Chapter">
-                                <graphic>
-                                   <Region styleClass="arrow-icon">
-                                      <padding>
-                                         <Insets right="16.0" />
-                                      </padding></Region>
-                                </graphic>
-                             </MenuItem>
-                             <SeparatorMenuItem mnemonicParsing="false" styleClass="search-option-menu-line" />
-                              <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Copy">
-                                 <graphic>
-                                    <SVGPath content="M9.43837 6.99586L9.43837 8.56292L11.4092 8.56292L11.4092 10.5614L12.9763 10.5614L12.9763 8.56292L15.0024 8.56292L15.0024 6.99586L12.9763 6.99586L12.9763 4.99741L11.4092 4.99741L11.4092 6.99586L9.43837 6.99586Z M1.6665 15.1645L1.6665 9.36525C1.66649 8.96838 1.66649 8.62428 1.68968 8.34039C1.71421 8.04011 1.76854 7.73908 1.91648 7.44873C2.13637 7.01718 2.48722 6.66633 2.91877 6.44644C3.20912 6.2985 3.51015 6.24417 3.81043 6.21964C4.09431 6.19645 4.4384 6.19645 4.83526 6.19646L6.19639 6.19646L6.19639 4.83534C6.19638 4.43846 6.19637 4.0944 6.21956 3.81051C6.24409 3.51023 6.29842 3.2092 6.44636 2.91885C6.66625 2.4873 7.01711 2.13644 7.44865 1.91656C7.739 1.76862 8.04003 1.71429 8.34031 1.68976C8.62423 1.66656 8.96834 1.66657 9.36528 1.66658L15.1643 1.66658C15.5612 1.66657 15.9053 1.66656 16.1892 1.68976C16.4895 1.71429 16.7906 1.76862 17.0809 1.91656C17.5125 2.13644 17.8633 2.4873 18.0832 2.91885C18.2311 3.2092 18.2855 3.51023 18.31 3.81051C18.3332 4.09443 18.3332 4.43854 18.3332 4.83547L18.3332 10.6345C18.3332 11.0314 18.3332 11.3755 18.31 11.6594C18.2855 11.9597 18.2311 12.2608 18.0832 12.5511C17.8633 12.9826 17.5125 13.3335 17.0809 13.5534C16.7906 13.7013 16.4895 13.7557 16.1892 13.7802C15.9054 13.8034 15.5613 13.8034 15.1644 13.8034L13.8033 13.8034L13.8033 15.1645C13.8033 15.5614 13.8033 15.9055 13.7801 16.1893C13.7556 16.4896 13.7013 16.7906 13.5533 17.081C13.3334 17.5125 12.9826 17.8634 12.551 18.0833C12.2607 18.2312 11.9596 18.2855 11.6594 18.3101C11.3755 18.3333 11.0314 18.3333 10.6345 18.3333L4.83527 18.3333C4.4384 18.3333 4.09432 18.3333 3.81043 18.3101C3.51015 18.2855 3.20912 18.2312 2.91877 18.0833C2.48723 17.8634 2.13637 17.5125 1.91648 17.081C1.76854 16.7906 1.71421 16.4896 1.68968 16.1893C1.66649 15.9054 1.66649 15.5613 1.6665 15.1645ZM3.25154 16.0617C3.23418 15.8493 3.23357 15.5696 3.23357 15.1338L3.23357 9.39593C3.23357 8.9601 3.23418 8.68046 3.25154 8.468C3.26816 8.26457 3.29614 8.19275 3.31274 8.16016C3.38239 8.02348 3.49352 7.91235 3.6302 7.8427C3.66279 7.8261 3.73462 7.79811 3.93804 7.78149C4.1505 7.76414 4.43014 7.76352 4.86597 7.76352L6.19639 7.76352L6.19639 10.6346C6.19638 11.0314 6.19637 11.3756 6.21956 11.6594C6.2441 11.9597 6.29842 12.2608 6.44636 12.5511C6.66625 12.9826 7.01711 13.3335 7.44865 13.5534C7.739 13.7013 8.04003 13.7557 8.34031 13.7802C8.6242 13.8034 8.96831 13.8034 9.36518 13.8034L12.2362 13.8034L12.2362 15.1338C12.2362 15.5696 12.2356 15.8493 12.2183 16.0617C12.2016 16.2651 12.1737 16.337 12.1571 16.3696C12.0874 16.5062 11.9763 16.6174 11.8396 16.687C11.807 16.7036 11.7352 16.7316 11.5318 16.7482C11.3193 16.7656 11.0397 16.7662 10.6038 16.7662L4.86597 16.7662C4.43014 16.7662 4.1505 16.7656 3.93804 16.7482C3.73462 16.7316 3.66279 16.7036 3.6302 16.687C3.49352 16.6174 3.38239 16.5062 3.31274 16.3696C3.29614 16.337 3.26816 16.2651 3.25154 16.0617ZM7.78142 11.5318C7.76406 11.3194 7.76345 11.0397 7.76345 10.6039L7.76345 4.86605C7.76345 4.43022 7.76406 4.15058 7.78142 3.93812C7.79804 3.73469 7.82602 3.66287 7.84262 3.63028C7.91227 3.4936 8.0234 3.38247 8.16009 3.31282C8.19267 3.29622 8.2645 3.26823 8.46792 3.25161C8.68039 3.23426 8.96003 3.23365 9.39585 3.23365L15.1337 3.23364C15.5695 3.23364 15.8492 3.23426 16.0616 3.25161C16.2651 3.26823 16.3369 3.29622 16.3695 3.31282C16.5062 3.38247 16.6173 3.4936 16.6869 3.63028C16.7035 3.66287 16.7315 3.73469 16.7481 3.93812C16.7655 4.15058 16.7661 4.43022 16.7661 4.86605L16.7661 10.6039C16.7661 11.0397 16.7655 11.3194 16.7481 11.5318C16.7315 11.7353 16.7035 11.8071 16.6869 11.8397C16.6173 11.9764 16.5062 12.0875 16.3695 12.1571C16.3369 12.1737 16.2651 12.2017 16.0616 12.2183C15.8492 12.2357 15.5695 12.2363 15.1337 12.2363L9.39586 12.2363C8.96003 12.2363 8.68039 12.2357 8.46792 12.2183C8.2645 12.2017 8.19267 12.1737 8.16009 12.1571C8.0234 12.0875 7.91227 11.9764 7.84262 11.8397C7.82602 11.8071 7.79804 11.7353 7.78142 11.5318Z" fill="WHITE" fillRule="EVEN_ODD" />
-                                 </graphic>
-                              </MenuItem>
-                             <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Save to Favorites">
-                                <graphic>
-                                   <Region styleClass="favorites-icon">
-                                      <padding>
-                                         <Insets right="16.0" />
-                                      </padding></Region>
-                                </graphic>
-                             </MenuItem>
-                          </items>
+                            <items>
+                                <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item"
+                                          text="Populate concept" onAction="#populateConcept">
+                                    <graphic>
+                                        <Region styleClass="populate-icon">
+                                            <padding>
+                                                <Insets right="16.0"/>
+                                            </padding>
+                                        </Region>
+                                    </graphic>
+                                </MenuItem>
+                                <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item"
+                                          text="Open in Concept Navigator" onAction="#openInConceptNavigator">
+                                    <graphic>
+                                        <Region styleClass="populate-icon">
+                                            <padding>
+                                                <Insets right="16.0"/>
+                                            </padding>
+                                        </Region>
+                                    </graphic>
+                                </MenuItem>
+                                <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item"
+                                          text="Send to Journal">
+                                    <graphic>
+                                        <Region styleClass="arrow-icon">
+                                            <padding>
+                                                <Insets right="16.0"/>
+                                            </padding>
+                                        </Region>
+                                    </graphic>
+                                </MenuItem>
+                                <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item"
+                                          text="Send to Chapter">
+                                    <graphic>
+                                        <Region styleClass="arrow-icon">
+                                            <padding>
+                                                <Insets right="16.0"/>
+                                            </padding>
+                                        </Region>
+                                    </graphic>
+                                </MenuItem>
+                                <SeparatorMenuItem mnemonicParsing="false"
+                                                   styleClass="search-option-menu-line"/>
+                                <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item"
+                                          text="Copy">
+                                    <graphic>
+                                        <SVGPath
+                                                content="M9.43837 6.99586L9.43837 8.56292L11.4092 8.56292L11.4092 10.5614L12.9763 10.5614L12.9763 8.56292L15.0024 8.56292L15.0024 6.99586L12.9763 6.99586L12.9763 4.99741L11.4092 4.99741L11.4092 6.99586L9.43837 6.99586Z M1.6665 15.1645L1.6665 9.36525C1.66649 8.96838 1.66649 8.62428 1.68968 8.34039C1.71421 8.04011 1.76854 7.73908 1.91648 7.44873C2.13637 7.01718 2.48722 6.66633 2.91877 6.44644C3.20912 6.2985 3.51015 6.24417 3.81043 6.21964C4.09431 6.19645 4.4384 6.19645 4.83526 6.19646L6.19639 6.19646L6.19639 4.83534C6.19638 4.43846 6.19637 4.0944 6.21956 3.81051C6.24409 3.51023 6.29842 3.2092 6.44636 2.91885C6.66625 2.4873 7.01711 2.13644 7.44865 1.91656C7.739 1.76862 8.04003 1.71429 8.34031 1.68976C8.62423 1.66656 8.96834 1.66657 9.36528 1.66658L15.1643 1.66658C15.5612 1.66657 15.9053 1.66656 16.1892 1.68976C16.4895 1.71429 16.7906 1.76862 17.0809 1.91656C17.5125 2.13644 17.8633 2.4873 18.0832 2.91885C18.2311 3.2092 18.2855 3.51023 18.31 3.81051C18.3332 4.09443 18.3332 4.43854 18.3332 4.83547L18.3332 10.6345C18.3332 11.0314 18.3332 11.3755 18.31 11.6594C18.2855 11.9597 18.2311 12.2608 18.0832 12.5511C17.8633 12.9826 17.5125 13.3335 17.0809 13.5534C16.7906 13.7013 16.4895 13.7557 16.1892 13.7802C15.9054 13.8034 15.5613 13.8034 15.1644 13.8034L13.8033 13.8034L13.8033 15.1645C13.8033 15.5614 13.8033 15.9055 13.7801 16.1893C13.7556 16.4896 13.7013 16.7906 13.5533 17.081C13.3334 17.5125 12.9826 17.8634 12.551 18.0833C12.2607 18.2312 11.9596 18.2855 11.6594 18.3101C11.3755 18.3333 11.0314 18.3333 10.6345 18.3333L4.83527 18.3333C4.4384 18.3333 4.09432 18.3333 3.81043 18.3101C3.51015 18.2855 3.20912 18.2312 2.91877 18.0833C2.48723 17.8634 2.13637 17.5125 1.91648 17.081C1.76854 16.7906 1.71421 16.4896 1.68968 16.1893C1.66649 15.9054 1.66649 15.5613 1.6665 15.1645ZM3.25154 16.0617C3.23418 15.8493 3.23357 15.5696 3.23357 15.1338L3.23357 9.39593C3.23357 8.9601 3.23418 8.68046 3.25154 8.468C3.26816 8.26457 3.29614 8.19275 3.31274 8.16016C3.38239 8.02348 3.49352 7.91235 3.6302 7.8427C3.66279 7.8261 3.73462 7.79811 3.93804 7.78149C4.1505 7.76414 4.43014 7.76352 4.86597 7.76352L6.19639 7.76352L6.19639 10.6346C6.19638 11.0314 6.19637 11.3756 6.21956 11.6594C6.2441 11.9597 6.29842 12.2608 6.44636 12.5511C6.66625 12.9826 7.01711 13.3335 7.44865 13.5534C7.739 13.7013 8.04003 13.7557 8.34031 13.7802C8.6242 13.8034 8.96831 13.8034 9.36518 13.8034L12.2362 13.8034L12.2362 15.1338C12.2362 15.5696 12.2356 15.8493 12.2183 16.0617C12.2016 16.2651 12.1737 16.337 12.1571 16.3696C12.0874 16.5062 11.9763 16.6174 11.8396 16.687C11.807 16.7036 11.7352 16.7316 11.5318 16.7482C11.3193 16.7656 11.0397 16.7662 10.6038 16.7662L4.86597 16.7662C4.43014 16.7662 4.1505 16.7656 3.93804 16.7482C3.73462 16.7316 3.66279 16.7036 3.6302 16.687C3.49352 16.6174 3.38239 16.5062 3.31274 16.3696C3.29614 16.337 3.26816 16.2651 3.25154 16.0617ZM7.78142 11.5318C7.76406 11.3194 7.76345 11.0397 7.76345 10.6039L7.76345 4.86605C7.76345 4.43022 7.76406 4.15058 7.78142 3.93812C7.79804 3.73469 7.82602 3.66287 7.84262 3.63028C7.91227 3.4936 8.0234 3.38247 8.16009 3.31282C8.19267 3.29622 8.2645 3.26823 8.46792 3.25161C8.68039 3.23426 8.96003 3.23365 9.39585 3.23365L15.1337 3.23364C15.5695 3.23364 15.8492 3.23426 16.0616 3.25161C16.2651 3.26823 16.3369 3.29622 16.3695 3.31282C16.5062 3.38247 16.6173 3.4936 16.6869 3.63028C16.7035 3.66287 16.7315 3.73469 16.7481 3.93812C16.7655 4.15058 16.7661 4.43022 16.7661 4.86605L16.7661 10.6039C16.7661 11.0397 16.7655 11.3194 16.7481 11.5318C16.7315 11.7353 16.7035 11.8071 16.6869 11.8397C16.6173 11.9764 16.5062 12.0875 16.3695 12.1571C16.3369 12.1737 16.2651 12.2017 16.0616 12.2183C15.8492 12.2357 15.5695 12.2363 15.1337 12.2363L9.39586 12.2363C8.96003 12.2363 8.68039 12.2357 8.46792 12.2183C8.2645 12.2017 8.19267 12.1737 8.16009 12.1571C8.0234 12.0875 7.91227 11.9764 7.84262 11.8397C7.82602 11.8071 7.79804 11.7353 7.78142 11.5318Z"
+                                                fill="WHITE" fillRule="EVEN_ODD"/>
+                                    </graphic>
+                                </MenuItem>
+                                <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item"
+                                          text="Save to Favorites">
+                                    <graphic>
+                                        <Region styleClass="favorites-icon">
+                                            <padding>
+                                                <Insets right="16.0"/>
+                                            </padding>
+                                        </Region>
+                                    </graphic>
+                                </MenuItem>
+                            </items>
                         </ContextMenu>
-                     </contextMenu>
-                  </Button>
-               </children>
-               <VBox.margin>
-                  <Insets />
-               </VBox.margin>
-               <padding>
-                  <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
-               </padding>
-            </HBox>
-            <TitledPane animated="false" expanded="false" styleClass="search-entry-title-pane" text="DESCRIPTION SEMANTICS" VBox.vgrow="ALWAYS">
-                <content>
-                    <ListView fx:id="descriptionsListView" />
-                </content>
-               <VBox.margin>
-                  <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
-               </VBox.margin>
-            </TitledPane>
-         </children>
-      </VBox>
-   </children>
-   <opaqueInsets>
-      <Insets bottom="4.0" />
-   </opaqueInsets>
-</HBox>
+                    </contextMenu>
+                </Button>
+            </right>
+        </BorderPane>
+        <TitledPane animated="false" expanded="false" styleClass="search-entry-title-pane"
+                    text="DESCRIPTION SEMANTICS"
+                    VBox.vgrow="ALWAYS">
+            <content>
+                <ListView maxHeight="426.0" fx:id="descriptionsListView" styleClass="descriptions-list-view"/>
+            </content>
+        </TitledPane>
+    </children>
+</VBox>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/search-result-concept-entry.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/search-result-concept-entry.fxml
@@ -16,7 +16,8 @@
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
 
-<HBox fx:id="searchEntryHBox" prefHeight="100.0" prefWidth="332.0" styleClass="search-entry-hbox" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.search.SortResultConceptEntryController">
+<?import javafx.scene.control.ListView?>
+<HBox fx:id="searchEntryHBox" prefWidth="332.0" styleClass="search-entry-hbox" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.search.SortResultConceptEntryController">
    <children>
       <VBox HBox.hgrow="ALWAYS">
          <children>
@@ -112,29 +113,30 @@
                   <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
                </padding>
             </HBox>
-            <TitledPane animated="false" expanded="false" styleClass="search-entry-title-pane" text="DESCRIPTION SEMANTICS" VBox.vgrow="ALWAYS">
-               <content>
-                  <VBox fx:id="descriptionsVBox" prefWidth="100.0">
-                     <children>
-                        <Label prefHeight="30.0" prefWidth="302.0" styleClass="search-entry-description-label" text="Tetralogy of Fallot (disorder)">
-                           <VBox.margin>
-                              <Insets bottom="7.0" left="7.0" right="7.0" />
-                           </VBox.margin>
-                           <padding>
-                              <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
-                           </padding>
-                        </Label>
-                        <Label layoutX="28.0" layoutY="28.0" prefHeight="30.0" prefWidth="302.0" styleClass="search-entry-description-label" text="Tetralogy of Fallot (disorder)">
-                           <VBox.margin>
-                              <Insets bottom="7.0" left="7.0" right="7.0" />
-                           </VBox.margin>
-                           <padding>
-                              <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
-                           </padding>
-                        </Label>
-                     </children>
-                  </VBox>
-               </content>
+            <TitledPane fx:id="descriptionsTitledPane" animated="false" expanded="false" styleClass="search-entry-title-pane" text="DESCRIPTION SEMANTICS" VBox.vgrow="ALWAYS">
+<!--                  <VBox fx:id="descriptionsVBox" prefWidth="100.0">-->
+<!--                     <children>-->
+<!--                        <Label prefHeight="30.0" prefWidth="302.0" styleClass="search-entry-description-label" text="Tetralogy of Fallot (disorder)">-->
+<!--                           <VBox.margin>-->
+<!--                              <Insets bottom="7.0" left="7.0" right="7.0" />-->
+<!--                           </VBox.margin>-->
+<!--                           <padding>-->
+<!--                              <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />-->
+<!--                           </padding>-->
+<!--                        </Label>-->
+<!--                        <Label layoutX="28.0" layoutY="28.0" prefHeight="30.0" prefWidth="302.0" styleClass="search-entry-description-label" text="Tetralogy of Fallot (disorder)">-->
+<!--                           <VBox.margin>-->
+<!--                              <Insets bottom="7.0" left="7.0" right="7.0" />-->
+<!--                           </VBox.margin>-->
+<!--                           <padding>-->
+<!--                              <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />-->
+<!--                           </padding>-->
+<!--                        </Label>-->
+<!--                     </children>-->
+<!--                  </VBox>-->
+                <content>
+                    <ListView fx:id="descriptionsListView" />
+                </content>
                <VBox.margin>
                   <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
                </VBox.margin>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/search-result-semantic-entry.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/search/search-result-semantic-entry.fxml
@@ -8,117 +8,110 @@
 <?import javafx.scene.control.SeparatorMenuItem?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.SVGPath?>
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
 
-<?import javafx.scene.layout.VBox?>
-<HBox fx:id="searchEntryHBox" prefHeight="30.0" prefWidth="332.0" styleClass="search-entry-hbox" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.search.SortResultSemanticEntryController">
-   <children>
-      <VBox HBox.hgrow="ALWAYS">
-         <children>
-            <HBox fx:id="retiredHBox" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefWidth="346.0" spacing="4.0" VBox.vgrow="NEVER">
-               <children>
-                  <ImageView fx:id="identicon" fitHeight="24.0" fitWidth="24.0" pickOnBounds="true" preserveRatio="true">
-                     <HBox.margin>
+<BorderPane fx:id="searchEntryContainer" prefHeight="30.0" prefWidth="332.0" styleClass="search-entry-hbox" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.search.SortResultSemanticEntryController">
+    <center>
+        <HBox fx:id="retiredHBox" styleClass="search-entry-left-pane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefWidth="346.0" VBox.vgrow="NEVER">
+            <children>
+                <ImageView fx:id="identicon" fitHeight="24.0" fitWidth="20.0" pickOnBounds="true" preserveRatio="true">
+                    <HBox.margin>
                         <Insets bottom="4.0" left="6.0" top="4.0" />
-                     </HBox.margin>
-                     <image>
+                    </HBox.margin>
+                    <image>
                         <Image url="@../images/heart-placeholder.png" />
-                     </image>
-                  </ImageView>
-                  <Label id="retiredLabelId" fx:id="retiredLabel" minWidth="-Infinity" styleClass="search-retired-label" text="Retired">
-                     <padding>
+                    </image>
+                </ImageView>
+                <Label id="retiredLabelId" fx:id="retiredLabel" minWidth="-Infinity" styleClass="search-retired-label" text="Retired">
+                    <padding>
                         <Insets bottom="6.0" left="3.0" right="3.0" top="6.0" />
-                     </padding>
-                     <HBox.margin>
+                    </padding>
+                    <HBox.margin>
                         <Insets top="4.0" />
-                     </HBox.margin>
-                  </Label>
-                  <TextFlow fx:id="textFlow" maxWidth="-Infinity" minWidth="-Infinity" prefWidth="164.0">
-                     <children>
+                    </HBox.margin>
+                </Label>
+                <TextFlow fx:id="textFlow" styleClass="semantic-text-container" maxWidth="-Infinity" minWidth="-Infinity" prefWidth="164.0">
+                    <children>
                         <Text fx:id="semanticText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="search-semantic-entry-text" text="Tetralogy of Fallot  (disorder)" />
-                     </children>
-                     <HBox.margin>
+                    </children>
+                    <HBox.margin>
                         <Insets bottom="8.0" left="2.0" right="36.0" top="8.0" />
-                     </HBox.margin>
-                  </TextFlow>
-                  <Button fx:id="showContextButton" contentDisplay="GRAPHIC_ONLY" mnemonicParsing="false" styleClass="search-result-context-button" text="Button">
-                     <graphic>
-                        <SVGPath content="M0 2a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M7 2a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M7 9a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M0 9a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M0 16a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M7 16a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" fill="#9a9da0" stroke="#9a9da0" strokeLineCap="ROUND" strokeLineJoin="ROUND" />
-                     </graphic>
-                     <contextMenu>
-                        <ContextMenu fx:id="contextMenu" styleClass="search-context-menu-container">
-                           <items>
-                              <MenuItem mnemonicParsing="false" onAction="#populateConcept" styleClass="search-context-menu-item" text="Populate concept">
-                                 <graphic>
-                                    <Region styleClass="populate-icon">
-                                       <padding>
-                                          <Insets right="16.0" />
-                                       </padding>
-                                    </Region>
-                                 </graphic>
-                              </MenuItem>
-                              <MenuItem mnemonicParsing="false" onAction="#openInConceptNavigator" styleClass="search-context-menu-item" text="Open in Concept Navigator">
-                                 <graphic>
-                                    <Region styleClass="populate-icon">
-                                       <padding>
-                                          <Insets right="16.0" />
-                                       </padding>
-                                    </Region>
-                                 </graphic>
-                              </MenuItem>
-                              <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Send to Journal">
-                                 <graphic>
-                                    <Region styleClass="arrow-icon">
-                                       <padding>
-                                          <Insets right="16.0" />
-                                       </padding>
-                                    </Region>
-                                 </graphic>
-                              </MenuItem>
-                              <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Send to Chapter">
-                                 <graphic>
-                                    <Region styleClass="arrow-icon">
-                                       <padding>
-                                          <Insets right="16.0" />
-                                       </padding>
-                                    </Region>
-                                 </graphic>
-                              </MenuItem>
-                              <SeparatorMenuItem mnemonicParsing="false" styleClass="search-option-menu-line" />
-                              <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Copy">
-                                 <graphic>
-                                    <SVGPath content="M9.43837 6.99586L9.43837 8.56292L11.4092 8.56292L11.4092 10.5614L12.9763 10.5614L12.9763 8.56292L15.0024 8.56292L15.0024 6.99586L12.9763 6.99586L12.9763 4.99741L11.4092 4.99741L11.4092 6.99586L9.43837 6.99586Z M1.6665 15.1645L1.6665 9.36525C1.66649 8.96838 1.66649 8.62428 1.68968 8.34039C1.71421 8.04011 1.76854 7.73908 1.91648 7.44873C2.13637 7.01718 2.48722 6.66633 2.91877 6.44644C3.20912 6.2985 3.51015 6.24417 3.81043 6.21964C4.09431 6.19645 4.4384 6.19645 4.83526 6.19646L6.19639 6.19646L6.19639 4.83534C6.19638 4.43846 6.19637 4.0944 6.21956 3.81051C6.24409 3.51023 6.29842 3.2092 6.44636 2.91885C6.66625 2.4873 7.01711 2.13644 7.44865 1.91656C7.739 1.76862 8.04003 1.71429 8.34031 1.68976C8.62423 1.66656 8.96834 1.66657 9.36528 1.66658L15.1643 1.66658C15.5612 1.66657 15.9053 1.66656 16.1892 1.68976C16.4895 1.71429 16.7906 1.76862 17.0809 1.91656C17.5125 2.13644 17.8633 2.4873 18.0832 2.91885C18.2311 3.2092 18.2855 3.51023 18.31 3.81051C18.3332 4.09443 18.3332 4.43854 18.3332 4.83547L18.3332 10.6345C18.3332 11.0314 18.3332 11.3755 18.31 11.6594C18.2855 11.9597 18.2311 12.2608 18.0832 12.5511C17.8633 12.9826 17.5125 13.3335 17.0809 13.5534C16.7906 13.7013 16.4895 13.7557 16.1892 13.7802C15.9054 13.8034 15.5613 13.8034 15.1644 13.8034L13.8033 13.8034L13.8033 15.1645C13.8033 15.5614 13.8033 15.9055 13.7801 16.1893C13.7556 16.4896 13.7013 16.7906 13.5533 17.081C13.3334 17.5125 12.9826 17.8634 12.551 18.0833C12.2607 18.2312 11.9596 18.2855 11.6594 18.3101C11.3755 18.3333 11.0314 18.3333 10.6345 18.3333L4.83527 18.3333C4.4384 18.3333 4.09432 18.3333 3.81043 18.3101C3.51015 18.2855 3.20912 18.2312 2.91877 18.0833C2.48723 17.8634 2.13637 17.5125 1.91648 17.081C1.76854 16.7906 1.71421 16.4896 1.68968 16.1893C1.66649 15.9054 1.66649 15.5613 1.6665 15.1645ZM3.25154 16.0617C3.23418 15.8493 3.23357 15.5696 3.23357 15.1338L3.23357 9.39593C3.23357 8.9601 3.23418 8.68046 3.25154 8.468C3.26816 8.26457 3.29614 8.19275 3.31274 8.16016C3.38239 8.02348 3.49352 7.91235 3.6302 7.8427C3.66279 7.8261 3.73462 7.79811 3.93804 7.78149C4.1505 7.76414 4.43014 7.76352 4.86597 7.76352L6.19639 7.76352L6.19639 10.6346C6.19638 11.0314 6.19637 11.3756 6.21956 11.6594C6.2441 11.9597 6.29842 12.2608 6.44636 12.5511C6.66625 12.9826 7.01711 13.3335 7.44865 13.5534C7.739 13.7013 8.04003 13.7557 8.34031 13.7802C8.6242 13.8034 8.96831 13.8034 9.36518 13.8034L12.2362 13.8034L12.2362 15.1338C12.2362 15.5696 12.2356 15.8493 12.2183 16.0617C12.2016 16.2651 12.1737 16.337 12.1571 16.3696C12.0874 16.5062 11.9763 16.6174 11.8396 16.687C11.807 16.7036 11.7352 16.7316 11.5318 16.7482C11.3193 16.7656 11.0397 16.7662 10.6038 16.7662L4.86597 16.7662C4.43014 16.7662 4.1505 16.7656 3.93804 16.7482C3.73462 16.7316 3.66279 16.7036 3.6302 16.687C3.49352 16.6174 3.38239 16.5062 3.31274 16.3696C3.29614 16.337 3.26816 16.2651 3.25154 16.0617ZM7.78142 11.5318C7.76406 11.3194 7.76345 11.0397 7.76345 10.6039L7.76345 4.86605C7.76345 4.43022 7.76406 4.15058 7.78142 3.93812C7.79804 3.73469 7.82602 3.66287 7.84262 3.63028C7.91227 3.4936 8.0234 3.38247 8.16009 3.31282C8.19267 3.29622 8.2645 3.26823 8.46792 3.25161C8.68039 3.23426 8.96003 3.23365 9.39585 3.23365L15.1337 3.23364C15.5695 3.23364 15.8492 3.23426 16.0616 3.25161C16.2651 3.26823 16.3369 3.29622 16.3695 3.31282C16.5062 3.38247 16.6173 3.4936 16.6869 3.63028C16.7035 3.66287 16.7315 3.73469 16.7481 3.93812C16.7655 4.15058 16.7661 4.43022 16.7661 4.86605L16.7661 10.6039C16.7661 11.0397 16.7655 11.3194 16.7481 11.5318C16.7315 11.7353 16.7035 11.8071 16.6869 11.8397C16.6173 11.9764 16.5062 12.0875 16.3695 12.1571C16.3369 12.1737 16.2651 12.2017 16.0616 12.2183C15.8492 12.2357 15.5695 12.2363 15.1337 12.2363L9.39586 12.2363C8.96003 12.2363 8.68039 12.2357 8.46792 12.2183C8.2645 12.2017 8.19267 12.1737 8.16009 12.1571C8.0234 12.0875 7.91227 11.9764 7.84262 11.8397C7.82602 11.8071 7.79804 11.7353 7.78142 11.5318Z" fill="WHITE" fillRule="EVEN_ODD" />
-                                 </graphic>
-                              </MenuItem>
-                              <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Save to Favorites">
-                                 <graphic>
-                                    <Region styleClass="favorites-icon">
-                                       <padding>
-                                          <Insets right="16.0" />
-                                       </padding>
-                                    </Region>
-                                 </graphic>
-                              </MenuItem>
-                           </items>
-                        </ContextMenu>
-                     </contextMenu>
-                  </Button>
-               </children>
-               <VBox.margin>
-                  <Insets />
-               </VBox.margin>
-               <padding>
-                  <Insets bottom="3.0" left="3.0" right="3.0" top="3.0" />
-               </padding>
-            </HBox>
-         </children>
-      </VBox>
-   </children>
-   <opaqueInsets>
-      <Insets bottom="4.0" />
-   </opaqueInsets>
-</HBox>
+                    </HBox.margin>
+                </TextFlow>
+            </children>
+            <padding>
+                <Insets bottom="3.0" left="3.0" right="3.0" top="3.0" />
+            </padding>
+        </HBox>
+    </center>
+    <right>
+        <Button fx:id="showContextButton" contentDisplay="GRAPHIC_ONLY" mnemonicParsing="false" styleClass="search-result-context-button" text="Button" BorderPane.alignment="CENTER_RIGHT">
+            <graphic>
+                <SVGPath content="M0 2a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M7 2a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M7 9a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M0 9a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M0 16a2 2 0 1 0 4 0a2 2 0 1 0 -4 0 M7 16a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" fill="#9a9da0" stroke="#9a9da0" strokeLineCap="ROUND" strokeLineJoin="ROUND" />
+            </graphic>
+            <contextMenu>
+                <ContextMenu fx:id="contextMenu" styleClass="search-context-menu-container">
+                    <items>
+                        <MenuItem mnemonicParsing="false" onAction="#populateConcept" styleClass="search-context-menu-item" text="Populate concept">
+                            <graphic>
+                                <Region styleClass="populate-icon">
+                                    <padding>
+                                        <Insets right="16.0" />
+                                    </padding>
+                                </Region>
+                            </graphic>
+                        </MenuItem>
+                        <MenuItem mnemonicParsing="false" onAction="#openInConceptNavigator" styleClass="search-context-menu-item" text="Open in Concept Navigator">
+                            <graphic>
+                                <Region styleClass="populate-icon">
+                                    <padding>
+                                        <Insets right="16.0" />
+                                    </padding>
+                                </Region>
+                            </graphic>
+                        </MenuItem>
+                        <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Send to Journal">
+                            <graphic>
+                                <Region styleClass="arrow-icon">
+                                    <padding>
+                                        <Insets right="16.0" />
+                                    </padding>
+                                </Region>
+                            </graphic>
+                        </MenuItem>
+                        <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Send to Chapter">
+                            <graphic>
+                                <Region styleClass="arrow-icon">
+                                    <padding>
+                                        <Insets right="16.0" />
+                                    </padding>
+                                </Region>
+                            </graphic>
+                        </MenuItem>
+                        <SeparatorMenuItem mnemonicParsing="false" styleClass="search-option-menu-line" />
+                        <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Copy">
+                            <graphic>
+                                <SVGPath content="M9.43837 6.99586L9.43837 8.56292L11.4092 8.56292L11.4092 10.5614L12.9763 10.5614L12.9763 8.56292L15.0024 8.56292L15.0024 6.99586L12.9763 6.99586L12.9763 4.99741L11.4092 4.99741L11.4092 6.99586L9.43837 6.99586Z M1.6665 15.1645L1.6665 9.36525C1.66649 8.96838 1.66649 8.62428 1.68968 8.34039C1.71421 8.04011 1.76854 7.73908 1.91648 7.44873C2.13637 7.01718 2.48722 6.66633 2.91877 6.44644C3.20912 6.2985 3.51015 6.24417 3.81043 6.21964C4.09431 6.19645 4.4384 6.19645 4.83526 6.19646L6.19639 6.19646L6.19639 4.83534C6.19638 4.43846 6.19637 4.0944 6.21956 3.81051C6.24409 3.51023 6.29842 3.2092 6.44636 2.91885C6.66625 2.4873 7.01711 2.13644 7.44865 1.91656C7.739 1.76862 8.04003 1.71429 8.34031 1.68976C8.62423 1.66656 8.96834 1.66657 9.36528 1.66658L15.1643 1.66658C15.5612 1.66657 15.9053 1.66656 16.1892 1.68976C16.4895 1.71429 16.7906 1.76862 17.0809 1.91656C17.5125 2.13644 17.8633 2.4873 18.0832 2.91885C18.2311 3.2092 18.2855 3.51023 18.31 3.81051C18.3332 4.09443 18.3332 4.43854 18.3332 4.83547L18.3332 10.6345C18.3332 11.0314 18.3332 11.3755 18.31 11.6594C18.2855 11.9597 18.2311 12.2608 18.0832 12.5511C17.8633 12.9826 17.5125 13.3335 17.0809 13.5534C16.7906 13.7013 16.4895 13.7557 16.1892 13.7802C15.9054 13.8034 15.5613 13.8034 15.1644 13.8034L13.8033 13.8034L13.8033 15.1645C13.8033 15.5614 13.8033 15.9055 13.7801 16.1893C13.7556 16.4896 13.7013 16.7906 13.5533 17.081C13.3334 17.5125 12.9826 17.8634 12.551 18.0833C12.2607 18.2312 11.9596 18.2855 11.6594 18.3101C11.3755 18.3333 11.0314 18.3333 10.6345 18.3333L4.83527 18.3333C4.4384 18.3333 4.09432 18.3333 3.81043 18.3101C3.51015 18.2855 3.20912 18.2312 2.91877 18.0833C2.48723 17.8634 2.13637 17.5125 1.91648 17.081C1.76854 16.7906 1.71421 16.4896 1.68968 16.1893C1.66649 15.9054 1.66649 15.5613 1.6665 15.1645ZM3.25154 16.0617C3.23418 15.8493 3.23357 15.5696 3.23357 15.1338L3.23357 9.39593C3.23357 8.9601 3.23418 8.68046 3.25154 8.468C3.26816 8.26457 3.29614 8.19275 3.31274 8.16016C3.38239 8.02348 3.49352 7.91235 3.6302 7.8427C3.66279 7.8261 3.73462 7.79811 3.93804 7.78149C4.1505 7.76414 4.43014 7.76352 4.86597 7.76352L6.19639 7.76352L6.19639 10.6346C6.19638 11.0314 6.19637 11.3756 6.21956 11.6594C6.2441 11.9597 6.29842 12.2608 6.44636 12.5511C6.66625 12.9826 7.01711 13.3335 7.44865 13.5534C7.739 13.7013 8.04003 13.7557 8.34031 13.7802C8.6242 13.8034 8.96831 13.8034 9.36518 13.8034L12.2362 13.8034L12.2362 15.1338C12.2362 15.5696 12.2356 15.8493 12.2183 16.0617C12.2016 16.2651 12.1737 16.337 12.1571 16.3696C12.0874 16.5062 11.9763 16.6174 11.8396 16.687C11.807 16.7036 11.7352 16.7316 11.5318 16.7482C11.3193 16.7656 11.0397 16.7662 10.6038 16.7662L4.86597 16.7662C4.43014 16.7662 4.1505 16.7656 3.93804 16.7482C3.73462 16.7316 3.66279 16.7036 3.6302 16.687C3.49352 16.6174 3.38239 16.5062 3.31274 16.3696C3.29614 16.337 3.26816 16.2651 3.25154 16.0617ZM7.78142 11.5318C7.76406 11.3194 7.76345 11.0397 7.76345 10.6039L7.76345 4.86605C7.76345 4.43022 7.76406 4.15058 7.78142 3.93812C7.79804 3.73469 7.82602 3.66287 7.84262 3.63028C7.91227 3.4936 8.0234 3.38247 8.16009 3.31282C8.19267 3.29622 8.2645 3.26823 8.46792 3.25161C8.68039 3.23426 8.96003 3.23365 9.39585 3.23365L15.1337 3.23364C15.5695 3.23364 15.8492 3.23426 16.0616 3.25161C16.2651 3.26823 16.3369 3.29622 16.3695 3.31282C16.5062 3.38247 16.6173 3.4936 16.6869 3.63028C16.7035 3.66287 16.7315 3.73469 16.7481 3.93812C16.7655 4.15058 16.7661 4.43022 16.7661 4.86605L16.7661 10.6039C16.7661 11.0397 16.7655 11.3194 16.7481 11.5318C16.7315 11.7353 16.7035 11.8071 16.6869 11.8397C16.6173 11.9764 16.5062 12.0875 16.3695 12.1571C16.3369 12.1737 16.2651 12.2017 16.0616 12.2183C15.8492 12.2357 15.5695 12.2363 15.1337 12.2363L9.39586 12.2363C8.96003 12.2363 8.68039 12.2357 8.46792 12.2183C8.2645 12.2017 8.19267 12.1737 8.16009 12.1571C8.0234 12.0875 7.91227 11.9764 7.84262 11.8397C7.82602 11.8071 7.79804 11.7353 7.78142 11.5318Z" fill="WHITE" fillRule="EVEN_ODD" />
+                            </graphic>
+                        </MenuItem>
+                        <MenuItem mnemonicParsing="false" styleClass="search-context-menu-item" text="Save to Favorites">
+                            <graphic>
+                                <Region styleClass="favorites-icon">
+                                    <padding>
+                                        <Insets right="16.0" />
+                                    </padding>
+                                </Region>
+                            </graphic>
+                        </MenuItem>
+                    </items>
+                </ContextMenu>
+            </contextMenu>
+        </Button>
+    </right>
+</BorderPane>


### PR DESCRIPTION
Fixes:

1. https://ikmdev.atlassian.net/browse/IIA-2097
2. https://ikmdev.atlassian.net/browse/IIA-2138
3. https://ikmdev.atlassian.net/browse/IIA-2272
4. https://ikmdev.atlassian.net/browse/IIA-2350
-----------
## Summary of Changes

This PR improves the performance and memory consumption of next gen search by (preliminary tests show an increase in performance of at least 2x): 
- virtualizing the results
- off-loading loading the description semantics UI to when the user expands a search result (when in top component mode)
- reducing number of nodes used to show the UI

This PR also improves the aesthetics of next gen search:
- Improves overall look of search results for every search type (top component, description semantics and UUID) and also improves the look of next gen search as a whole
- Makes the search field and search button area sticky (when user scrolls these components remain visible)

Search might still perform poorly if the memory of the system is filled up. Komet takes about 5gb of memory while running which makes this more likely to happen.

### Before
![image](https://github.com/user-attachments/assets/c0b004ea-9407-40e4-bf5a-030f1dec636a)

### After
![image](https://github.com/user-attachments/assets/bec1b541-704a-4bf7-b264-013b8eef3899)
 