### PR TITLE
feature/finished/IIA-2298: [TE Feedback] Add Semantic Field Values to Semantic Tooltip in Pattern Browser for "Primitive" data types

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/navigation/SemanticTooltip.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/navigation/SemanticTooltip.java
@@ -1,0 +1,96 @@
+package dev.ikm.komet.kview.mvvm.view.navigation;
+
+import dev.ikm.komet.framework.view.ViewProperties;
+import dev.ikm.tinkar.coordinate.stamp.calculator.Latest;
+import dev.ikm.tinkar.entity.PatternVersionRecord;
+import dev.ikm.tinkar.entity.SemanticEntity;
+import dev.ikm.tinkar.entity.SemanticEntityVersion;
+import javafx.geometry.HPos;
+import javafx.scene.control.Label;
+import javafx.scene.control.Separator;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.VBox;
+import javafx.util.Duration;
+import org.eclipse.collections.api.list.ImmutableList;
+
+public class SemanticTooltip extends Tooltip {
+
+    private final BorderPane mainContainer;
+    private final Label title;
+    private final GridPane grid;
+    private final VBox valuesContainer;
+
+    private final ViewProperties viewProperties;
+
+    public SemanticTooltip(ViewProperties viewProperties) {
+        this.viewProperties = viewProperties;
+
+        mainContainer = new BorderPane();
+        title = new Label();
+        grid = new GridPane();
+        valuesContainer = new VBox(new Separator(), grid);
+
+        mainContainer.setTop(title);
+        mainContainer.setCenter(valuesContainer);
+
+        title.setWrapText(true);
+
+        setupGridPane();
+
+        setGraphic(mainContainer);
+
+        setShowDuration(Duration.seconds(10));
+
+        // CSS
+        getStyleClass().add("semantic-tooltip");
+        mainContainer.getStyleClass().add("main-container");
+        title.getStyleClass().add("title");
+        valuesContainer.getStyleClass().add("values-container");
+        grid.getStyleClass().add("grid");
+    }
+
+    private void setupGridPane() {
+        ColumnConstraints column1 = new ColumnConstraints();
+        column1.setPercentWidth(50);
+        ColumnConstraints column2 = new ColumnConstraints();
+        column2.setPercentWidth(50);
+        column2.setHalignment(HPos.RIGHT);
+        grid.getColumnConstraints().addAll(column1, column2);
+    }
+
+    public void update(SemanticEntity<?> semanticEntity, String titleText) {
+        Latest<? extends SemanticEntityVersion> latestId = viewProperties.calculator().latest(semanticEntity);
+        ImmutableList fields = latestId.get().fieldValues();
+        PatternVersionRecord patternVersionRecord = (PatternVersionRecord) viewProperties.calculator().latest(latestId.get().pattern()).get();
+
+        this.title.setText(titleText);
+
+        grid.getChildren().clear();
+        int rowIndex = 0;
+        for (int i = 0; i < patternVersionRecord.fieldDefinitions().size(); ++i) {
+            String fieldTitle = patternVersionRecord.fieldDefinitions().get(i).meaning().description();
+            String fieldValue = fields.get(i).toString();
+
+            Label titleLabel = new Label(fieldTitle + ":");
+            Label valueLabel = new Label(fieldValue);
+            titleLabel.getStyleClass().add("field-title");
+            valueLabel.getStyleClass().add("field-value");
+
+            grid.add(titleLabel, 0, rowIndex);
+            grid.add(valueLabel, 1, rowIndex);
+
+            ++rowIndex;
+
+            if (i < patternVersionRecord.fieldDefinitions().size() - 1) {
+                Separator line = new Separator();
+                GridPane.setColumnSpan(line, 2);
+                grid.add(line, 0, rowIndex);
+
+                ++rowIndex;
+            }
+        }
+    }
+}

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -2946,6 +2946,10 @@ Timeline Year line segment (will overlay change circles)
     -fx-alignment: center_left;
 }
 
+.next-gen-search-main-container .descriptions-list-view .list-cell .cell-container:hover {
+    -fx-background-color: #f6f6f6;
+}
+
 .search-button,
 .search-button.filter-button {
     -fx-background-color: -Grey-9;
@@ -5414,6 +5418,55 @@ Styling a context menu for kview ui/ux controls
 
 .properties-tab-container-content .controls-container {
     -fx-padding: 0 12px 0 0;
+}
+
+/******************* Tooltip for Semantic in Pattern Browser ******************/
+
+.semantic-tooltip {
+    -fx-padding: 15 0 10 0;
+}
+
+.semantic-tooltip .main-container {
+    -fx-max-width: 400px;
+    -fx-padding: 0;
+}
+
+.semantic-tooltip .title {
+    -fx-font-family: "Noto Sans";
+    -fx-font-size: 16px;
+
+    -fx-max-height: 300px;
+    -fx-padding: 15 15 10 15;
+}
+
+.semantic-tooltip .values-container .grid {
+    -fx-padding: 5 15 20 15;
+    -fx-max-width: 450px;
+}
+
+.semantic-tooltip .values-container > .separator .line {
+    -fx-border-color: #111 transparent transparent transparent,
+                      transparent;
+}
+
+.semantic-tooltip .values-container .grid .label {
+
+    -fx-font-size: 12px;
+    -fx-padding: 10px 0 13px 0;
+}
+
+.semantic-tooltip .values-container .grid .field-title.label {
+    -fx-font-family: "Noto Sans Semibold";
+    -fx-text-fill: #999;
+}
+
+.semantic-tooltip .values-container .grid .field-value.label {
+    -fx-font-family: "Noto Sans";
+    -fx-text-fill: #f0f0f0;
+}
+
+.semantic-tooltip .values-container .grid > .separator .line {
+    -fx-border-color: #494949 transparent transparent transparent, transparent;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Fixes: https://ikmdev.atlassian.net/browse/IIA-2298?atlOrigin=eyJpIjoiMWJhYzdmMDc4YjY2NDg5ZWJmZDFiMzNjYjE4NjY4NGIiLCJwIjoiaiJ9

-------

Added tooltip to semantics in Pattern Browser. For the following fields:
- string
- boolean
- integer
- float

![image](https://github.com/user-attachments/assets/a122496c-d8dd-42ea-8431-84d59c637467)

