### PR TITLE
feature/finished/IIA-2393: Typeahead remains visible even after pressing enter

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/AutoCompleteTextFieldSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/AutoCompleteTextFieldSkin.java
@@ -75,6 +75,8 @@ public class AutoCompleteTextFieldSkin<T> extends FXTextFieldSkin {
             textField.setValue((T) autoCompletePopup.getItems().get(selectedIndex));
         }
 
+        timeline.stop();
+
         if (autoCompletePopup != null) {
             autoCompletePopup.hide();
         }


### PR DESCRIPTION
Fixes: https://ikmdev.atlassian.net/browse/IIA-2393?atlOrigin=eyJpIjoiNTA3YjA5ZWM5ZWYzNDNkM2JmZDYyODU5MDIwNmM1ZDQiLCJwIjoiaiJ9