### PR TITLE
Update filter options property whenever an option is changed

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/DateFilterTitledPaneSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/DateFilterTitledPaneSkin.java
@@ -1,10 +1,10 @@
 package dev.ikm.komet.kview.controls.skin;
 
-import dev.ikm.komet.kview.controls.FilterOptions;
-import dev.ikm.komet.kview.controls.RangeCalendarControl;
 import dev.ikm.komet.kview.controls.DateFilterTitledPane;
 import dev.ikm.komet.kview.controls.DateRange;
+import dev.ikm.komet.kview.controls.FilterOptions;
 import dev.ikm.komet.kview.controls.IconRegion;
+import dev.ikm.komet.kview.controls.RangeCalendarControl;
 import dev.ikm.komet.kview.controls.TruncatedTextFlow;
 import javafx.collections.FXCollections;
 import javafx.css.PseudoClass;
@@ -194,7 +194,7 @@ public class DateFilterTitledPaneSkin extends TitledPaneSkin {
                             .filter(DateRange::exclude)
                             .forEach(dr -> currentOption.excludedOptions().add(dr.toString()));
                 }
-                control.setOption(currentOption);
+                control.setOption(currentOption.copy());
             }
         }));
 

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterTitledPaneSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterTitledPaneSkin.java
@@ -241,7 +241,7 @@ public class FilterTitledPaneSkin extends TitledPaneSkin {
         subscription = subscription.and(control.optionProperty().subscribe((_, _) -> setupTitledPane()));
         subscription = subscription.and(control.expandedProperty().subscribe((_, expanded) -> {
             if (!expanded) {
-                control.setOption(currentOption);
+                control.setOption(currentOption.copy());
                 selectedOption.setText(getOptionText(currentOption));
             }
         }));


### PR DESCRIPTION
by the user interaction.

This allows detecting any changes in the filter options, without waiting for the user to press the Apply button.

The Apply button remains enabled, but it won't do anything other than collapsing the options, since the changes are already set.