### PR TITLE
feature/finished/IIA-2455-stamp-exclusions-not-being-checked

### DIFF
--- a/framework/src/main/java/dev/ikm/komet/framework/view/ObservableStampCoordinateWithOverride.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ObservableStampCoordinateWithOverride.java
@@ -15,17 +15,17 @@
  */
 package dev.ikm.komet.framework.view;
 
-import javafx.beans.value.ObservableValue;
-import org.eclipse.collections.api.set.ImmutableSet;
 import dev.ikm.tinkar.common.id.IntIdList;
 import dev.ikm.tinkar.common.id.IntIdSet;
 import dev.ikm.tinkar.common.id.IntIds;
-import dev.ikm.tinkar.coordinate.stamp.StampCoordinateRecord;
 import dev.ikm.tinkar.coordinate.stamp.StampCoordinate;
+import dev.ikm.tinkar.coordinate.stamp.StampCoordinateRecord;
 import dev.ikm.tinkar.coordinate.stamp.StampPositionRecord;
 import dev.ikm.tinkar.coordinate.stamp.StateSet;
 import dev.ikm.tinkar.terms.ConceptFacade;
 import dev.ikm.tinkar.terms.EntityProxy;
+import javafx.beans.value.ObservableValue;
+import org.eclipse.collections.api.set.ImmutableSet;
 
 public class ObservableStampCoordinateWithOverride extends ObservableStampCoordinateBase {
 
@@ -178,7 +178,7 @@ public class ObservableStampCoordinateWithOverride extends ObservableStampCoordi
         }
 
         if (!this.excludedModuleSpecificationsProperty().isOverridden()) {
-            ImmutableSet<ConceptFacade> excludedModuleSet = newValue.moduleNids().map(nid -> EntityProxy.Concept.make(nid));
+            ImmutableSet<ConceptFacade> excludedModuleSet = newValue.excludedModuleNids().map(nid -> EntityProxy.Concept.make(nid));
             if (!excludedModuleSet.equals(this.excludedModuleSpecificationsProperty().get())) {
                 this.excludedModuleSpecificationsProperty().setAll(excludedModuleSet.castToSet());
             }


### PR DESCRIPTION
Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-2455

Summary of changes:  The ObservableStampCoordinateWithOverride.baseCoordinateChangeListenerRemoved() method was copying the incorrect field for the excludedModuleSet.  Changed to use the correct field excludedModuleNids.

Note that the data does not have Primordial or Sandbox, so an IllegalStateException occurs, which needs to be worked in a separate Bug ticket.

Before change:  Excluded modules were not being checked correctly, and the check was not propagating to the child view coordinate menus.

After change:

Parent view coordinate menu with Development excluded (checked).

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/68ddec39-aded-4967-86f7-6c1f2a7d986f" />


Child view coordinate menu with Development excluded (checked).

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/23df60f3-2577-490b-9742-9d0ea5f7e14d" />

