### PR TITLE
Improve ConceptNavigator performance

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorTreeCell.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/KLConceptNavigatorTreeCell.java
@@ -19,6 +19,7 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.shape.Path;
 
 import java.util.BitSet;
+import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
 import static dev.ikm.komet.kview.controls.ConceptNavigatorTreeItem.PS_STATE;
@@ -38,7 +39,7 @@ public class KLConceptNavigatorTreeCell extends TreeCell<ConceptFacade> {
      * {@link dev.ikm.komet.kview.controls.skin.KLConceptNavigatorTreeViewSkin}.
      */
     static {
-        ConceptNavigatorHelper.setConceptNavigatorAccessor(new ConceptNavigatorHelper.ConceptNavigatorAccessor() {
+        ConceptNavigatorHelper.setConceptNavigatorCellAccessor(new ConceptNavigatorHelper.ConceptNavigatorCellAccessor() {
 
             @Override
             public void markCellDirty(KLConceptNavigatorTreeCell treeCell) {
@@ -50,10 +51,6 @@ public class KLConceptNavigatorTreeCell extends TreeCell<ConceptFacade> {
                 treeCell.unselectItem();
             }
 
-            @Override
-            public ConceptNavigatorTreeItem getConceptNavigatorTreeItem(KLConceptNavigatorControl treeView, int nid, int parentNid) {
-                return null;
-            }
         });
     }
 

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/ConceptNavigatorHelper.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/ConceptNavigatorHelper.java
@@ -4,6 +4,8 @@ import dev.ikm.komet.kview.controls.ConceptNavigatorTreeItem;
 import dev.ikm.komet.kview.controls.KLConceptNavigatorControl;
 import dev.ikm.komet.kview.controls.KLConceptNavigatorTreeCell;
 
+import java.util.concurrent.Future;
+
 /**
  * Helper class to access internal methods of controls package.
  */
@@ -12,18 +14,12 @@ public class ConceptNavigatorHelper {
     private static ConceptNavigatorAccessor accessor;
 
     public interface ConceptNavigatorAccessor {
-        void markCellDirty(KLConceptNavigatorTreeCell treeCell);
-        void unselectItem(KLConceptNavigatorTreeCell treeCell);
-
+        Future<Boolean> fetchChildrenTask(KLConceptNavigatorControl treeView, ConceptNavigatorTreeItem item);
         ConceptNavigatorTreeItem getConceptNavigatorTreeItem(KLConceptNavigatorControl treeView, int nid, int parentNid);
     }
 
-    public static void markCellDirty(KLConceptNavigatorTreeCell treeCell) {
-        accessor.markCellDirty(treeCell);
-    }
-
-    public static void unselectItem(KLConceptNavigatorTreeCell treeCell) {
-        accessor.unselectItem(treeCell);
+    public static Future<Boolean> fetchChildrenTask(KLConceptNavigatorControl treeView, ConceptNavigatorTreeItem item) {
+        return accessor.fetchChildrenTask(treeView, item);
     }
 
     public static ConceptNavigatorTreeItem getConceptNavigatorTreeItem(KLConceptNavigatorControl treeView, int nid, int parentNid) {
@@ -33,5 +29,25 @@ public class ConceptNavigatorHelper {
     public static void setConceptNavigatorAccessor(ConceptNavigatorAccessor accessor) {
         ConceptNavigatorHelper.accessor = accessor;
     }
+
+    private static ConceptNavigatorCellAccessor cellAccessor;
+
+    public interface ConceptNavigatorCellAccessor {
+        void markCellDirty(KLConceptNavigatorTreeCell treeCell);
+        void unselectItem(KLConceptNavigatorTreeCell treeCell);
+    }
+
+    public static void markCellDirty(KLConceptNavigatorTreeCell treeCell) {
+        cellAccessor.markCellDirty(treeCell);
+    }
+
+    public static void unselectItem(KLConceptNavigatorTreeCell treeCell) {
+        cellAccessor.unselectItem(treeCell);
+    }
+
+    public static void setConceptNavigatorCellAccessor(ConceptNavigatorCellAccessor cellAccessor) {
+        ConceptNavigatorHelper.cellAccessor = cellAccessor;
+    }
+
 
 }


### PR DESCRIPTION
This PR fixes some performance issues with datasets like GUDID, by introducing three changes:
- cache `Navigator::isLeaf` calls
- fetch children for a given treeItem in a background thread
- prune collapsed branches to reduce model in memory

There are some side effects now, as the process is not synchronous anymore, and visual hints will be needed, as a follow-up, to show that some tasks are running without immediate UI results (for instance, expanding the treeView for a search result with a huge number of children).