### PR TITLE
Add initial value to property to prevent NPE

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/FilterOptionsPopup.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/FilterOptionsPopup.java
@@ -37,7 +37,7 @@ public class FilterOptionsPopup extends PopupControl {
     }
 
     // initialFilterOptionsProperty
-    private final ObjectProperty<FilterOptions> initialFilterOptionsProperty = new SimpleObjectProperty<>(this, "initialFilterOPpions");
+    private final ObjectProperty<FilterOptions> initialFilterOptionsProperty = new SimpleObjectProperty<>(this, "initialFilterOptions", new FilterOptions());
     public final ObjectProperty<FilterOptions> initialFilterOptionsProperty() {
         return initialFilterOptionsProperty;
     }


### PR DESCRIPTION
After the changes in #619 , when the initialFilterOptionsProperty gets queried, as it doesn't have an initial value, causes a NPE.

This PR is a quick fix to avoid such NPE, but typically the initial value should be set via setter.