### PR TITLE
Add Language Coordinates to FilterOptions control

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/FilterOptions.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/FilterOptions.java
@@ -3,7 +3,6 @@ package dev.ikm.komet.kview.controls;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
@@ -19,18 +18,22 @@ public class FilterOptions implements Serializable {
     private static final ResourceBundle resources = ResourceBundle.getBundle("dev.ikm.komet.kview.controls.filter-options");
 
     public enum OPTION_ITEM {
+        // Main Coordinates
         NAVIGATOR("navigator", ""),
         TYPE("type", ""),
         HEADER("header", ""),
         STATUS("status", "Status"),
+        TIME("time", ""),
         MODULE("module", "Module"),
         PATH("path", "Path"),
-        LANGUAGE("language", "Model concept, Tinkar Model concept, Language"),
-        DESCRIPTION_TYPE("description", ""),
         KIND_OF("kindof", ""),
         MEMBERSHIP("membership", ""),
         SORT_BY("sortby", ""),
-        DATE("date", "");
+        // Language Coordinates
+        LANGUAGE("language", "Model concept, Tinkar Model concept, Language"),
+        DIALECT("dialect", ""),
+        PATTERN("pattern", ""),
+        DESCRIPTION_TYPE("description", "");
 
         private final String name;
         private final String path;
@@ -52,6 +55,7 @@ public class FilterOptions implements Serializable {
     public static final class Option implements Serializable {
         @Serial
         private static final long serialVersionUID = 0L;
+
         private final OPTION_ITEM item;
         private final String title;
         private final List<String> defaultOptions;
@@ -102,8 +106,9 @@ public class FilterOptions implements Serializable {
 
         @Override
         public String toString() {
-            return item + ": " + (any ? "Any of: " : "All of: ") + selectedOptions +
-                    (excludedOptions == null || excludedOptions.isEmpty() ? "" : " - " + excludedOptions);
+            return "> " + item + ": " + (any ? "Any of: " : (multiSelect ? "All of: " : "")) + selectedOptions +
+                    (excludedOptions == null || excludedOptions.isEmpty() ? "" : " - " + excludedOptions) +
+                    " from av: " + availableOptions + " def: " + defaultOptions;
         }
 
         public boolean isMultiSelectionAllowed() {
@@ -138,14 +143,19 @@ public class FilterOptions implements Serializable {
             if (!Objects.equals(item, option.item)) return false;
             if (!Objects.equals(title, option.title)) return false;
             if (any != option.any) return false;
-            if (!compareLists(selectedOptions, option.selectedOptions)) return false;
-            if (!compareLists(excludedOptions, option.excludedOptions)) return false;
+            if (option.item == OPTION_ITEM.DIALECT || option.item == OPTION_ITEM.DESCRIPTION_TYPE) {
+                if (!compareSortedLists(selectedOptions, option.selectedOptions)) return false;
+                if (!compareSortedLists(excludedOptions, option.excludedOptions)) return false;
+            } else {
+                if (!compareLists(selectedOptions, option.selectedOptions)) return false;
+                if (!compareLists(excludedOptions, option.excludedOptions)) return false;
+            }
             return true;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(item, title, selectedOptions, excludedOptions);
+            return Objects.hash(item, title, any, selectedOptions, excludedOptions);
         }
 
         public Option copy() {
@@ -188,7 +198,6 @@ public class FilterOptions implements Serializable {
         public EnumSet<BUTTON> buttonType() {
             return buttonType;
         }
-
     }
 
     private final EnumSet<Option.BUTTON> noneSet = EnumSet.of(Option.BUTTON.NONE);
@@ -196,159 +205,355 @@ public class FilterOptions implements Serializable {
     private final EnumSet<Option.BUTTON> allExcludingSet = EnumSet.of(Option.BUTTON.ALL, Option.BUTTON.EXCLUDING);
     private final EnumSet<Option.BUTTON> allAnyExcludingSet = EnumSet.of(Option.BUTTON.ALL, Option.BUTTON.ANY, Option.BUTTON.EXCLUDING);
 
-    private Option navigator;
-    {
-        List<String> navigatorOptions = Stream.of(
-                        "navigator.option.stated", "navigator.option.inferred")
-                .map(resources::getString)
-                .toList();
-        navigator = new Option(OPTION_ITEM.NAVIGATOR, "navigator.title", new ArrayList<>(),
-                navigatorOptions, new ArrayList<>(), null, false, false, noneSet);
+    public interface Coordinates {}
+
+    public class MainCoordinates implements Coordinates {
+
+        // MainCoordinates
+
+        private Option navigator;
+
+        {
+            List<String> navigatorOptions = Stream.of(
+                            "navigator.option.stated", "navigator.option.inferred")
+                    .map(resources::getString)
+                    .toList();
+            navigator = new Option(OPTION_ITEM.NAVIGATOR, "navigator.title", new ArrayList<>(List.of(navigatorOptions.getFirst())),
+                    new ArrayList<>(navigatorOptions), new ArrayList<>(List.of(navigatorOptions.getFirst())), null, false, false, noneSet);
+        }
+
+        private Option type;
+        {
+            List<String> typeOptions = Stream.of(
+                            "type.option.concepts", "type.option.semantics")
+                    .map(resources::getString)
+                    .toList();
+            type = new Option(OPTION_ITEM.TYPE, "type.title", new ArrayList<>(typeOptions),
+                    new ArrayList<>(typeOptions), new ArrayList<>(typeOptions), null, true, false, allSet);
+        }
+
+        private Option header = new Option(OPTION_ITEM.HEADER, "header.title", new ArrayList<>(),
+                new ArrayList<>(), new ArrayList<>(), null, false, false, allSet);
+
+        private Option status = new Option(OPTION_ITEM.STATUS, "status.title", new ArrayList<>(),
+                new ArrayList<>(), new ArrayList<>(), null, true, false, allSet);
+
+        private Option time;
+        {
+            List<String> dateOptions = Stream.of("time.item1", "time.item2", "time.item3")
+                    .map(resources::getString)
+                    .toList();
+            time = new Option(OPTION_ITEM.TIME, "time.title", new ArrayList<>(List.of(dateOptions.getFirst())),
+                    new ArrayList<>(dateOptions), new ArrayList<>(List.of(dateOptions.getFirst())), new ArrayList<>(), false, false, noneSet);
+        }
+
+        private Option module = new Option(OPTION_ITEM.MODULE, "module.title", new ArrayList<>(),
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), true, false, allAnyExcludingSet);
+
+        private Option path = new Option(OPTION_ITEM.PATH, "path.title", new ArrayList<>(),
+                new ArrayList<>(), new ArrayList<>(), null, false, false, noneSet);
+
+        private Option kindOf;
+        {
+            List<String> kindOfOptions = Stream.of(
+                            "kindof.option.item1", "kindof.option.item2", "kindof.option.item3", "kindof.option.item4",
+                            "kindof.option.item5", "kindof.option.item6", "kindof.option.item7", "kindof.option.item8",
+                            "kindof.option.item9", "kindof.option.item10", "kindof.option.item11")
+                    .map(resources::getString)
+                    .toList();
+            kindOf = new Option(OPTION_ITEM.KIND_OF, "kindof.title", new ArrayList<>(kindOfOptions),
+                    new ArrayList<>(kindOfOptions), new ArrayList<>(kindOfOptions), new ArrayList<>(), true, false, allExcludingSet);
+        }
+
+        private Option membership;
+        {
+            List<String> membershipOptions = Stream.of(
+                            "membership.option.member1", "membership.option.member2", "membership.option.member3",
+                            "membership.option.member4", "membership.option.member5")
+                    .map(resources::getString)
+                    .toList();
+            membership = new Option(OPTION_ITEM.MEMBERSHIP, "membership.title", new ArrayList<>(membershipOptions),
+                    new ArrayList<>(membershipOptions), new ArrayList<>(membershipOptions), null, true, false, allSet);
+        }
+
+        private Option sortBy;
+        {
+            List<String> sortByOptions = Stream.of(
+                            "sortby.option.relevant", "sortby.option.alphabetical", "sortby.option.groupedby")
+                    .map(resources::getString)
+                    .toList();
+            sortBy = new Option(OPTION_ITEM.SORT_BY, "sortby.title", new ArrayList<>(List.of(sortByOptions.getFirst())),
+                    new ArrayList<>(sortByOptions), new ArrayList<>(List.of(sortByOptions.getFirst())), null, false, false, allSet);
+        }
+
+        private final List<Option> options;
+
+        MainCoordinates() {
+            options = new ArrayList<>(List.of(
+                    navigator, type, header, status, time, module, path, kindOf, membership, sortBy
+            ));
+        }
+
+        public Option getNavigator() {
+            return navigator;
+        }
+
+        public Option getType() {
+            return type;
+        }
+
+        public Option getHeader() {
+            return header;
+        }
+
+        public Option getStatus() {
+            return status;
+        }
+
+        public Option getTime() {
+            return time;
+        }
+
+        public Option getModule() {
+            return module;
+        }
+
+        public Option getPath() {
+            return path;
+        }
+
+        public Option getKindOf() {
+            return kindOf;
+        }
+
+        public Option getMembership() {
+            return membership;
+        }
+
+        public Option getSortBy() {
+            return sortBy;
+        }
+
+        public List<Option> getOptions() {
+            return options;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MainCoordinates that = (MainCoordinates) o;
+            return Objects.equals(navigator, that.navigator) &&
+                    Objects.equals(type, that.type) &&
+                    Objects.equals(header, that.header) &&
+                    Objects.equals(status, that.status) &&
+                    Objects.equals(time, that.time) &&
+                    Objects.equals(module, that.module) &&
+                    Objects.equals(path, that.path) &&
+                    Objects.equals(kindOf, that.kindOf) &&
+                    Objects.equals(membership, that.membership) &&
+                    Objects.equals(sortBy, that.sortBy) &&
+                    Objects.equals(options, that.options);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(
+                    navigator, type, header, status, time, module, path, kindOf, membership, sortBy,
+                    options);
+        }
+
+        @Override
+        public String toString() {
+            return "MainOptions{\n" +
+                    options.stream()
+                            .map(Object::toString)
+                            .collect(Collectors.joining("\n")) +
+                    "\n}";
+        }
     }
 
-    private Option type;
-    {
-        List<String> typeOptions = Stream.of(
-                "type.option.concepts", "type.option.semantics")
-                .map(resources::getString)
-                .toList();
-        type = new Option(OPTION_ITEM.TYPE, "type.title", new ArrayList<>(),
-            typeOptions, new ArrayList<>(), null, true, false, allSet);
+    public class LanguageCoordinates implements Coordinates, Comparable {
+
+        // Language Coordinates
+        private Option language = new Option(OPTION_ITEM.LANGUAGE, "language.option.title", new ArrayList<>(),
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), false, false, noneSet);
+
+        private Option dialect;
+        {
+            List<String> dialectOptions = Stream.of(
+                            "dialect.option.item1", "dialect.option.item2",
+                            "dialect.option.item3", "dialect.option.item4", "dialect.option.item5")
+                    .map(resources::getString)
+                    .toList();
+            dialect = new Option(OPTION_ITEM.DIALECT, "dialect.option.title", new ArrayList<>(dialectOptions),
+                    new ArrayList<>(dialectOptions), new ArrayList<>(dialectOptions), null, true, false, noneSet);
+        }
+
+        private Option pattern;
+        {
+            List<String> patternOptions = Stream.of(
+                            "pattern.option.item1", "pattern.option.item2",
+                            "pattern.option.item3", "pattern.option.item4")
+                    .map(resources::getString)
+                    .toList();
+            pattern = new Option(OPTION_ITEM.PATTERN, "pattern.option.title", new ArrayList<>(List.of(patternOptions.getFirst())),
+                    new ArrayList<>(patternOptions), new ArrayList<>(List.of(patternOptions.getFirst())), null, false, false, noneSet);
+        }
+
+        private Option descriptionType;
+        {
+            List<String> descriptionTypeOptions = Stream.of(
+                            //FIXME, the parent/classic menu uses FxGET::allowedDescriptionTypeOrder and hard codes FQN
+                            // and Regular Name as options... as new designs for Language+Dialect get implemented
+                            // we will additionally need to address this setting as well
+                            "description.option.fqn", "description.option.preferred", "description.option.regular",
+                            "description.option.preferredfqn", "description.option.regularfqn")
+                    .map(resources::getString)
+                    .toList();
+            descriptionType = new Option(OPTION_ITEM.DESCRIPTION_TYPE, "description.option.title", new ArrayList<>(descriptionTypeOptions),
+                    new ArrayList<>(descriptionTypeOptions), new ArrayList<>(descriptionTypeOptions), null, true, false, noneSet);
+        }
+
+        private final List<Option> options;
+        private final int ordinal;
+
+        LanguageCoordinates(int ordinal) {
+            this.ordinal = ordinal;
+            options = new ArrayList<>(List.of(
+                    language, dialect, pattern, descriptionType
+            ));
+        }
+
+        public Option getLanguage() {
+            return language;
+        }
+
+        public Option getDialect() {
+            return dialect;
+        }
+
+        public Option getPattern() {
+            return pattern;
+        }
+
+        public Option getDescriptionType() {
+            return descriptionType;
+        }
+
+        public List<Option> getOptions() {
+            return options;
+        }
+
+        public int getOrdinal() {
+            return ordinal;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            LanguageCoordinates that = (LanguageCoordinates) o;
+            if (ordinal != that.ordinal) {
+                return false;
+            }
+            if (!Objects.equals(language, that.language)) {
+                return false;
+            }
+            if (!Objects.equals(dialect, that.dialect)) {
+                return false;
+            }
+            if (!Objects.equals(pattern, that.pattern)) {
+                return false;
+            }
+            if (!Objects.equals(descriptionType, that.descriptionType)) {
+                return false;
+            }
+            if (!Objects.equals(options, that.options)) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(
+                    language, dialect, pattern, descriptionType, ordinal,
+                    options);
+        }
+
+        @Override
+        public String toString() {
+            return "LangOptions[" + ordinal + "] {\n" +
+                    options.stream()
+                            .map(option -> "> " + option.toString())
+                            .collect(Collectors.joining("\n")) +
+                    "\n}";
+        }
+
+        public LanguageCoordinates copy() {
+            LanguageCoordinates languageCoordinates = new LanguageCoordinates(ordinal);
+            languageCoordinates.language = language.copy();
+            languageCoordinates.dialect = dialect.copy();
+            languageCoordinates.pattern = pattern.copy();
+            languageCoordinates.descriptionType = descriptionType.copy();
+            languageCoordinates.options.clear();
+            languageCoordinates.options.addAll(List.of(
+                    languageCoordinates.language, languageCoordinates.dialect,
+                    languageCoordinates.pattern, languageCoordinates.descriptionType
+            ));
+            return languageCoordinates;
+        }
+
+        @Override
+        public int compareTo(Object o) {
+            if (o instanceof LanguageCoordinates lang) {
+                return this.ordinal - lang.ordinal;
+            }
+            return 1;
+        }
     }
 
-    private Option header = new Option(OPTION_ITEM.HEADER, "header.title", new ArrayList<>(),
-            new ArrayList<>(), new ArrayList<>(), null, false, false, allSet);
-
-    private Option status = new Option(OPTION_ITEM.STATUS, "status.title", new ArrayList<>(),
-            new ArrayList<>(), new ArrayList<>(), null, true, false, allSet);
-
-    private Option module = new Option(OPTION_ITEM.MODULE, "module.title", new ArrayList<>(Arrays.asList("Any")),
-            new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), true, false, allAnyExcludingSet);
-
-    private Option path = new Option(OPTION_ITEM.PATH, "path.title", new ArrayList<>(),
-            new ArrayList<>(), new ArrayList<>(), null, false, false, noneSet);
-
-    private Option language = new Option(OPTION_ITEM.LANGUAGE, "language.title", new ArrayList<>(),
-            new ArrayList<>(), new ArrayList<>(), null, false, false, allSet);
-
-    private Option descriptionType;
-    {
-        List<String> descriptionTypeOptions = Stream.of(
-                        //FIXME, the parent/classic menu uses FxGET::allowedDescriptionTypeOrder and hard codes FQN
-                        // and Regular Name as options... as new designs for Language+Dialect get implemented
-                        // we will additionally need to address this setting as well
-                "description.option.fqn", "description.option.preferred", "description.option.regular",
-                "description.option.preferredfqn", "description.option.regularfqn")
-                .map(resources::getString)
-                .toList();
-        descriptionType = new Option(OPTION_ITEM.DESCRIPTION_TYPE, "description.title", new ArrayList<>(Arrays.asList("All")),
-                descriptionTypeOptions, new ArrayList<>(), null, true, false, allSet);
-    }
-
-    private Option kindOf;
-    {
-        List<String> kindOfOptions = Stream.of(
-                "kindof.option.item1", "kindof.option.item2", "kindof.option.item3", "kindof.option.item4",
-                        "kindof.option.item5", "kindof.option.item6", "kindof.option.item7", "kindof.option.item8",
-                        "kindof.option.item9", "kindof.option.item10", "kindof.option.item11")
-                .map(resources::getString)
-                .toList();
-        kindOf = new Option(OPTION_ITEM.KIND_OF, "kindof.title", new ArrayList<>(Arrays.asList("All")),
-                kindOfOptions, new ArrayList<>(), new ArrayList<>(), true, false, allExcludingSet);
-    }
-
-    private Option membership;
-    {
-        List<String> membershipOptions = Stream.of(
-                "membership.option.member1", "membership.option.member2", "membership.option.member3",
-                        "membership.option.member4", "membership.option.member5")
-                .map(resources::getString)
-                .toList();
-        membership = new Option(OPTION_ITEM.MEMBERSHIP, "membership.title", new ArrayList<>(Arrays.asList("All")),
-                membershipOptions, new ArrayList<>(), null, true, false, allSet);
-    }
-
-    private Option sortBy;
-    {
-        List<String> typeOptions = Stream.of(
-                        "sortby.option.relevant", "sortby.option.alphabetical", "sortby.option.groupedby")
-                .map(resources::getString)
-                .toList();
-        sortBy = new Option(OPTION_ITEM.SORT_BY, "sortby.title", new ArrayList<>(),
-                typeOptions, new ArrayList<>(), null, false, false, allSet);
-    }
-
-    private Option date;
-    {
-        List<String> dateOptions = Stream.of("date.item1", "date.item2", "date.item3")
-                .map(resources::getString)
-                .toList();
-        date = new Option(OPTION_ITEM.DATE, "date.title", new ArrayList<>(Arrays.asList("Latest")),
-                dateOptions, new ArrayList<>(), new ArrayList<>(), true, false, noneSet);
-    }
-
-    private final List<Option> options;
+    private final MainCoordinates mainCoordinates;
+    private final List<LanguageCoordinates> languageCoordinatesList;
 
     public FilterOptions() {
-        options = new ArrayList<>(List.of(
-                navigator, type, header, status, module, path, language,
-                descriptionType, kindOf, membership, sortBy, date));
+        mainCoordinates = new MainCoordinates();
+
+        languageCoordinatesList = new ArrayList<>(); // at least one
+        languageCoordinatesList.add(new LanguageCoordinates(0));
     }
 
-    public Option getNavigator() {
-        return navigator;
+    public MainCoordinates getMainCoordinates() {
+        return mainCoordinates;
     }
 
-    public Option getType() {
-        return type;
+    public List<LanguageCoordinates> getLanguageCoordinatesList() {
+        return languageCoordinatesList;
     }
 
-    public Option getHeader() {
-        return header;
+    public LanguageCoordinates getLanguageCoordinates(int ordinal) {
+        if (ordinal < 0 || ordinal >= languageCoordinatesList.size()) {
+            Thread.dumpStack();
+        }
+        return getLanguageCoordinatesList().get(ordinal);
     }
 
-    public Option getStatus() {
-        return status;
-    }
-
-    public Option getModule() {
-        return module;
-    }
-
-    public Option getPath() {
-        return path;
-    }
-
-    public Option getLanguage() {
-        return language;
-    }
-
-    public Option getDescription() {
-        return descriptionType;
-    }
-
-    public Option getKindOf() {
-        return kindOf;
-    }
-
-    public Option getMembership() {
-        return membership;
-    }
-
-    public Option getSortBy() {
-        return sortBy;
-    }
-
-    public Option getDate() {
-        return date;
-    }
-
-    public List<Option> getOptions() {
-        return options;
+    public LanguageCoordinates addLanguageCoordinates() {
+        LanguageCoordinates languageCoordinates = new LanguageCoordinates(languageCoordinatesList.size());
+        languageCoordinatesList.add(languageCoordinates);
+        return languageCoordinates;
     }
 
     public Option getOptionForItem(OPTION_ITEM item) {
-        return options.stream()
+        return mainCoordinates.options.stream()
+                .filter(o -> o.item() == item)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    public Option getLangOptionForItem(int ordinal, OPTION_ITEM item) {
+        return languageCoordinatesList.get(ordinal).options.stream()
                 .filter(o -> o.item() == item)
                 .findFirst()
                 .orElseThrow();
@@ -356,23 +561,34 @@ public class FilterOptions implements Serializable {
 
     public void setOptionForItem(OPTION_ITEM item, Option option) {
         switch (item) {
-            case NAVIGATOR -> navigator = option;
-            case TYPE -> type = option;
-            case HEADER -> header = option;
-            case STATUS -> status = option;
-            case MODULE -> module = option;
-            case PATH -> path = option;
-            case LANGUAGE -> language = option;
-            case DESCRIPTION_TYPE -> descriptionType = option;
-            case KIND_OF -> kindOf = option;
-            case MEMBERSHIP -> membership = option;
-            case SORT_BY -> sortBy = option;
-            case DATE -> date = option;
+            case NAVIGATOR -> mainCoordinates.navigator = option;
+            case TYPE -> mainCoordinates.type = option;
+            case HEADER -> mainCoordinates.header = option;
+            case STATUS -> mainCoordinates.status = option;
+            case TIME -> mainCoordinates.time = option;
+            case MODULE -> mainCoordinates.module = option;
+            case PATH -> mainCoordinates.path = option;
+            case KIND_OF -> mainCoordinates.kindOf = option;
+            case MEMBERSHIP -> mainCoordinates.membership = option;
+            case SORT_BY -> mainCoordinates.sortBy = option;
         }
-        options.clear();
-        options.addAll(List.of(
-                navigator, type, header, status, module, path, language,
-                descriptionType, kindOf, membership, sortBy, date));
+        mainCoordinates.options.clear();
+        mainCoordinates.options.addAll(List.of(mainCoordinates.navigator, mainCoordinates.type,
+                mainCoordinates.header, mainCoordinates.status,
+                mainCoordinates.time, mainCoordinates.module,
+                mainCoordinates.path, mainCoordinates.kindOf,
+                mainCoordinates.membership, mainCoordinates.sortBy));
+    }
+
+    public void setLangCoordinates(int ordinal, LanguageCoordinates value) {
+        LanguageCoordinates languageCoordinates = languageCoordinatesList.get(ordinal);
+        languageCoordinates.language = value.language;
+        languageCoordinates.dialect = value.dialect;
+        languageCoordinates.pattern = value.pattern;
+        languageCoordinates.descriptionType = value.descriptionType;
+        languageCoordinates.options.clear();
+        languageCoordinates.options.addAll(List.of(languageCoordinates.language, languageCoordinates.dialect,
+                        languageCoordinates.pattern, languageCoordinates.descriptionType));
     }
 
     @Override
@@ -380,44 +596,43 @@ public class FilterOptions implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         FilterOptions that = (FilterOptions) o;
-        return Objects.equals(navigator, that.navigator) &&
-                Objects.equals(type, that.type) &&
-                Objects.equals(header, that.header) &&
-                Objects.equals(status, that.status) &&
-                Objects.equals(module, that.module) &&
-                Objects.equals(path, that.path) &&
-                Objects.equals(language, that.language) &&
-                Objects.equals(descriptionType, that.descriptionType) &&
-                Objects.equals(kindOf, that.kindOf) &&
-                Objects.equals(membership, that.membership) &&
-                Objects.equals(sortBy, that.sortBy) &&
-                Objects.equals(date, that.date) &&
-                Objects.equals(options, that.options);
+        if (!Objects.equals(mainCoordinates, that.mainCoordinates)) {
+            return false;
+        }
+        if (!compareLists(languageCoordinatesList, that.languageCoordinatesList)) {
+            return false;
+        }
+        return true;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(
-                navigator, type, header, status, module, path, language,
-                descriptionType, kindOf, membership, sortBy, date,
-                options);
+        return Objects.hash(mainCoordinates, languageCoordinatesList);
     }
 
     @Override
     public String toString() {
-        return "FilterOptions{" +
-                options.stream()
+        return "FilterOptions{ " +
+                mainCoordinates + "\n" + languageCoordinatesList.stream()
                         .map(Object::toString)
-                        .collect(Collectors.joining(", ")) +
+                        .collect(Collectors.joining(",\n")) +
                 "}";
     }
 
-    static boolean compareLists(List<String> list1, List<String> list2) {
+    static boolean compareLists(List<?> list1, List<?> list2) {
         if (list1 == null && list2 != null) return false;
         if (list1 != null && list2 == null) return false;
         if (list1 != null && list1.size() != list2.size()) return false;
         return list1 == null ||
                 list1.stream().sorted().toList().equals(list2.stream().sorted().toList());
+    }
+
+    static boolean compareSortedLists(List<?> list1, List<?> list2) {
+        if (list1 == null && list2 != null) return false;
+        if (list1 != null && list2 == null) return false;
+        if (list1 != null && list1.size() != list2.size()) return false;
+        return list1 == null ||
+                list1.stream().toList().equals(list2.stream().toList());
     }
 
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/FilterOptionsUtils.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/FilterOptionsUtils.java
@@ -1,0 +1,133 @@
+package dev.ikm.komet.kview.controls;
+
+import dev.ikm.komet.framework.view.ObservableCoordinate;
+import dev.ikm.komet.framework.view.ObservableLanguageCoordinate;
+import dev.ikm.komet.framework.view.ObservableStampCoordinate;
+import dev.ikm.komet.navigator.graph.Navigator;
+import dev.ikm.tinkar.coordinate.navigation.calculator.Edge;
+import dev.ikm.tinkar.coordinate.stamp.StateSet;
+import dev.ikm.tinkar.coordinate.view.ViewCoordinateRecord;
+import dev.ikm.tinkar.coordinate.view.calculator.ViewCalculator;
+import dev.ikm.tinkar.entity.Entity;
+import dev.ikm.tinkar.terms.ConceptFacade;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static dev.ikm.tinkar.common.service.PrimitiveData.PREMUNDANE_TIME;
+
+public class FilterOptionsUtils {
+
+    public static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("MM/dd/yyyy");
+
+    public static FilterOptions loadFilterOptions(ObservableCoordinate<ViewCoordinateRecord> parentView, ViewCalculator calculator) {
+        FilterOptions filterOptions = new FilterOptions();
+
+        // get parent menu settings
+        for (ObservableCoordinate<?> observableCoordinate : parentView.getCompositeCoordinates()) {
+            if (observableCoordinate instanceof ObservableStampCoordinate observableStampCoordinate) {
+
+                // populate the TYPE; this isn't in the parent view coordinate
+                // it is all set in FilterOptions
+
+                // populate the STATUS
+                StateSet currentStates = observableStampCoordinate.allowedStatesProperty().getValue();
+                List<String> currentStatesStr = currentStates.toEnumSet().stream().map(Enum::name).toList();
+
+                FilterOptions.Option statusOption = filterOptions.getMainCoordinates().getStatus();
+                statusOption.selectedOptions().clear();
+                statusOption.selectedOptions().addAll(currentStatesStr);
+
+                statusOption.defaultOptions().clear();
+                statusOption.defaultOptions().addAll(currentStatesStr);
+
+                // MODULE
+                if (!observableStampCoordinate.moduleNids().isEmpty()) {
+                    FilterOptions.Option moduleOption = filterOptions.getMainCoordinates().getModule();
+                    moduleOption.defaultOptions().clear();
+                    observableStampCoordinate.moduleNids().intStream().forEach(moduleNid -> {
+                        String moduleStr = calculator.getPreferredDescriptionStringOrNid(moduleNid);
+                        System.out.println("moduleStr = " + moduleStr);
+                        moduleOption.defaultOptions().add(moduleStr);
+                    });
+                }
+
+                // populate the PATH
+                ConceptFacade currentPath = observableStampCoordinate.pathConceptProperty().getValue();
+                String currentPathStr = currentPath.description();
+
+                List<String> defaultSelectedPaths = new ArrayList<>(List.of(currentPathStr));
+                FilterOptions.Option pathOption = filterOptions.getMainCoordinates().getPath();
+                pathOption.defaultOptions().clear();
+                pathOption.defaultOptions().addAll(defaultSelectedPaths);
+
+                pathOption.selectedOptions().clear();
+                pathOption.selectedOptions().addAll(defaultSelectedPaths);
+
+                // TIME
+                FilterOptions.Option timeOption = filterOptions.getMainCoordinates().getTime();
+
+                Long time = observableStampCoordinate.timeProperty().getValue();
+                if (!time.equals(Long.MAX_VALUE) && !time.equals(PREMUNDANE_TIME)) {
+                    //FIXME the custom control doesn't support premundane yet
+                    Date date = new Date(time);
+                    timeOption.defaultOptions().clear();
+                    timeOption.selectedOptions().clear();
+                    timeOption.selectedOptions().add(SIMPLE_DATE_FORMAT.format(date));
+                    timeOption.defaultOptions().addAll(timeOption.selectedOptions());
+                }
+            } else if (observableCoordinate instanceof ObservableLanguageCoordinate observableLanguageCoordinate) {
+                // populate the LANGUAGE
+                FilterOptions.Option language = filterOptions.getLanguageCoordinates(0).getLanguage();
+                language.defaultOptions().clear();
+                String languageStr = calculator.languageCalculator().getPreferredDescriptionTextWithFallbackOrNid(
+                        observableLanguageCoordinate.languageConceptProperty().get().nid());
+                language.defaultOptions().add(languageStr);
+                language.selectedOptions().clear();
+                language.selectedOptions().addAll(language.defaultOptions());
+
+                //FIXME description choices don't yet align with parent/classic menu, more discussion needs to happen on
+                // how we want to fix this.
+                // all set in FilterOptions
+            }
+        }
+        return filterOptions;
+    }
+
+    public static long getMillis(FilterOptions filterOptions) {
+        FilterOptions.Option time = filterOptions.getMainCoordinates().getTime();
+        if (time == null || time.selectedOptions().isEmpty()) {
+            return -1;
+        }
+
+        Date date;
+        try {
+            date = SIMPLE_DATE_FORMAT.parse(time.selectedOptions().getFirst());
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+        return date.getTime();
+    }
+
+    private static int findNidForDescription(Navigator navigator, int nid, String description) {
+        return navigator.getChildEdges(nid).stream()
+                .filter(edge -> Entity.getFast(edge.destinationNid()).description().equals(description))
+                .findFirst()
+                .map(Edge::destinationNid)
+                .orElseThrow();
+    }
+
+    public static List<String> getDescendentsList(Navigator navigator, int parentNid, String description) {
+        int nid = parentNid;
+        for (String s : description.split(", ")) {
+            nid = findNidForDescription(navigator, nid, s);
+        }
+        return navigator.getViewCalculator().descendentsOf(nid).intStream().boxed()
+                .map(i -> Entity.getFast(i).description())
+                .sorted()
+                .toList();
+    }
+}

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/FilterTitledPane.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/FilterTitledPane.java
@@ -11,7 +11,7 @@ import javafx.scene.control.TitledPane;
 public class FilterTitledPane extends TitledPane {
 
     public FilterTitledPane() {
-
+        getStyleClass().add("filter-titled-pane");
     }
 
     // titleProperty
@@ -24,6 +24,18 @@ public class FilterTitledPane extends TitledPane {
     }
     public final void setTitle(String value) {
         titleProperty.set(value);
+    }
+
+    // defaultOptionProperty
+    private final ObjectProperty<FilterOptions.Option> defaultOptionProperty = new SimpleObjectProperty<>(this, "defaultOption");
+    public final ObjectProperty<FilterOptions.Option> defaultOptionProperty() {
+       return defaultOptionProperty;
+    }
+    public final FilterOptions.Option getDefaultOption() {
+       return defaultOptionProperty.get();
+    }
+    public final void setDefaultOption(FilterOptions.Option value) {
+        defaultOptionProperty.set(value);
     }
 
     // optionProperty

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/LangFilterTitledPane.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/LangFilterTitledPane.java
@@ -1,0 +1,56 @@
+package dev.ikm.komet.kview.controls;
+
+import dev.ikm.komet.kview.controls.skin.LangFilterTitledPaneSkin;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.control.Skin;
+
+public class LangFilterTitledPane extends FilterTitledPane {
+
+    public LangFilterTitledPane() {
+        getStyleClass().add("lang-filter-titled-pane");
+    }
+
+    // ordinalProperty
+    private final IntegerProperty ordinalProperty = new SimpleIntegerProperty(this, "ordinal");
+    public final IntegerProperty ordinalProperty() {
+       return ordinalProperty;
+    }
+    public final int getOrdinal() {
+       return ordinalProperty.get();
+    }
+    public final void setOrdinal(int value) {
+        ordinalProperty.set(value);
+    }
+
+    // defaultLangCoordinatesProperty
+    private final ObjectProperty<FilterOptions.LanguageCoordinates> defaultLangCoordinatesProperty = new SimpleObjectProperty<>(this, "defaultLangCoordinates");
+    public final ObjectProperty<FilterOptions.LanguageCoordinates> defaultLangCoordinatesProperty() {
+       return defaultLangCoordinatesProperty;
+    }
+    public final FilterOptions.LanguageCoordinates getDefaultLangCoordinates() {
+       return defaultLangCoordinatesProperty.get();
+    }
+    public final void setDefaultLangCoordinates(FilterOptions.LanguageCoordinates value) {
+        defaultLangCoordinatesProperty.set(value);
+    }
+
+    // langCoordinatesProperty
+    private final ObjectProperty<FilterOptions.LanguageCoordinates> langCoordinatesProperty = new SimpleObjectProperty<>(this, "langCoordinates");
+    public final ObjectProperty<FilterOptions.LanguageCoordinates> langCoordinatesProperty() {
+       return langCoordinatesProperty;
+    }
+    public final FilterOptions.LanguageCoordinates getLangCoordinates() {
+       return langCoordinatesProperty.get();
+    }
+    public final void setLangCoordinates(FilterOptions.LanguageCoordinates value) {
+        langCoordinatesProperty.set(value);
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new LangFilterTitledPaneSkin(this);
+    }
+}

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/DateFilterTitledPaneSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/DateFilterTitledPaneSkin.java
@@ -11,7 +11,6 @@ import dev.ikm.komet.kview.controls.TruncatedTextFlow;
 import javafx.collections.FXCollections;
 import javafx.css.PseudoClass;
 import javafx.scene.Parent;
-import javafx.scene.control.Accordion;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
@@ -62,7 +61,6 @@ public class DateFilterTitledPaneSkin extends TitledPaneSkin {
 
         selectedOption = new TruncatedTextFlow();
         selectedOption.setMaxContentHeight(44); // 2 lines
-        selectedOption.setMaxWidth(240);
         selectedOption.getStyleClass().add("option");
 
         comboBox = new ComboBox<>();
@@ -92,14 +90,12 @@ public class DateFilterTitledPaneSkin extends TitledPaneSkin {
             }
         });
 
-        if (control.getParent() instanceof Accordion accordion) {
-            Parent parent = accordion.getParent();
-            while (!(parent instanceof ScrollPane)) {
-                parent = parent.getParent();
-            }
-
-            scrollPane = (ScrollPane) parent;
+        Parent parent = control.getParent();
+        while (!(parent instanceof ScrollPane)) {
+            parent = parent.getParent();
         }
+
+        scrollPane = (ScrollPane) parent;
 
         setupTitledPane();
     }
@@ -126,10 +122,10 @@ public class DateFilterTitledPaneSkin extends TitledPaneSkin {
             if (defaultOptions.isEmpty()) {
                 defaultOptions.add(currentOption.availableOptions().getFirst());
             }
-            pseudoClassStateChanged(MODIFIED_TITLED_PANE, !text.isEmpty() && !text.equals(String.join(", ", defaultOptions)));
+            pseudoClassStateChanged(MODIFIED_TITLED_PANE, !Objects.equals(currentOption, control.getDefaultOption()));
         }));
 
-        if (control.getParent() instanceof Accordion accordion) {
+        if (control.getParent() instanceof FilterOptionsPopupSkin.AccordionBox accordion) {
             subscription = subscription.and(accordion.expandedPaneProperty().subscribe(pane -> {
                 if (!(pane instanceof DateFilterTitledPane)) {
                     control.pseudoClassStateChanged(SELECTED_PSEUDO_CLASS, false);
@@ -139,7 +135,7 @@ public class DateFilterTitledPaneSkin extends TitledPaneSkin {
 
         subscription = subscription.and(control.heightProperty().subscribe(_ -> {
             if (control.isExpanded()) {
-                scrollPane.setVvalue(scrollPane.getVmax());
+                scrollPane.setVvalue(scrollPane.getVmin());
             }
         }));
 
@@ -153,7 +149,7 @@ public class DateFilterTitledPaneSkin extends TitledPaneSkin {
         subscription = subscription.and(comboBox.getSelectionModel().selectedIndexProperty().subscribe((_, value) -> {
             if (comboBox.isShowing()) {
                 // reset
-                currentOption = new FilterOptions().getDate();
+                currentOption = new FilterOptions().getMainCoordinates().getTime();
             }
 
             if (value.intValue() == 0) {
@@ -201,12 +197,13 @@ public class DateFilterTitledPaneSkin extends TitledPaneSkin {
 
         List<String> selectedOptions = control.getOption().selectedOptions();
         List<String> excludedOptions = control.getOption().excludedOptions();
-        if (containsDateRange(selectedOptions) || containsDateRange(excludedOptions)) {
+        if (selectedOptions.isEmpty() || (selectedOptions.size() == 1 &&
+                resources.getString("time.item1").equals(selectedOptions.getFirst()))) {
+            control.setMode(DateFilterTitledPane.MODE.LATEST);
+        } else if (containsDateRange(selectedOptions) || containsDateRange(excludedOptions)) {
             control.setMode(DateFilterTitledPane.MODE.DATE_RANGE_LIST);
         } else if (containsDate(selectedOptions) && (excludedOptions == null || excludedOptions.isEmpty())) {
             control.setMode(DateFilterTitledPane.MODE.SINGLE_DATE);
-        } else {
-            control.setMode(DateFilterTitledPane.MODE.LATEST);
         }
 
         subscription = subscription.and(control.modeProperty().subscribe(mode ->
@@ -234,12 +231,10 @@ public class DateFilterTitledPaneSkin extends TitledPaneSkin {
 
         if (containsDate(option.selectedOptions())) {
             try {
-                if (!option.selectedOptions().getFirst().equals("Latest")) {
-                    LocalDate date = LocalDate.parse(option.selectedOptions().getFirst(), DateTimeFormatter.ofPattern(DEFAULT_DATE_PATTERN));
-                    calendarControl.setDate(date);
-                }
+                LocalDate date = LocalDate.parse(option.selectedOptions().getFirst(), DateTimeFormatter.ofPattern(DEFAULT_DATE_PATTERN));
+                calendarControl.setDate(date);
             } catch (DateTimeParseException e) {
-                e.printStackTrace();
+                // ignore
             }
         }
         control.setMode(DateFilterTitledPane.MODE.SINGLE_DATE);
@@ -251,11 +246,11 @@ public class DateFilterTitledPaneSkin extends TitledPaneSkin {
 
         calendarControl = new RangeCalendarControl();
         calendarControl.setMode(RangeCalendarControl.MODE.RANGE);
-        Button additionButton = new Button(resources.getString("date.range.additional.button"));
+        Button additionButton = new Button(resources.getString("time.range.additional.button"));
         additionButton.getStyleClass().add("additional");
         additionButton.setOnAction(_ -> calendarControl.addRange(false));
 
-        Button excludeButton = new Button(resources.getString("date.range.exclude.button"));
+        Button excludeButton = new Button(resources.getString("time.range.exclude.button"));
         excludeButton.getStyleClass().add("exclude");
         excludeButton.setOnAction(_ -> calendarControl.addRange(true));
 
@@ -290,21 +285,21 @@ public class DateFilterTitledPaneSkin extends TitledPaneSkin {
             return null;
         }
         if (calendarControl != null && calendarControl.getDate() != null) {
-            return MessageFormat.format(resources.getString("date.option.specific"),
+            return MessageFormat.format(resources.getString("time.option.specific"),
                     DATE_FORMATTER.format(calendarControl.getDate()));
         } else if (calendarControl != null && !calendarControl.dateRangeList().isEmpty()) {
             String including = calendarControl.dateRangeList().stream()
                     .filter(r -> !r.exclude())
-                    .map(dr -> MessageFormat.format(resources.getString("date.range.text"), dr.startDate(), dr.endDate()))
+                    .map(dr -> MessageFormat.format(resources.getString("time.range.text"), dr.startDate(), dr.endDate()))
                     .collect(Collectors.joining(", "));
             String excluding = calendarControl.dateRangeList().stream()
                     .filter(DateRange::exclude)
-                    .map(dr -> MessageFormat.format(resources.getString("date.range.text"), dr.startDate(), dr.endDate()))
+                    .map(dr -> MessageFormat.format(resources.getString("time.range.text"), dr.startDate(), dr.endDate()))
                     .collect(Collectors.joining(", "));
             if (excluding.isEmpty()) {
-                return MessageFormat.format(resources.getString("date.option.range"), including);
+                return MessageFormat.format(resources.getString("time.option.range"), including);
             } else {
-                return MessageFormat.format(resources.getString("date.option.range.excluding"), including, excluding);
+                return MessageFormat.format(resources.getString("time.option.range.excluding"), including, excluding);
             }
         } else {
             return String.join(", ", option.defaultOptions());

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterOptionsPopupSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterOptionsPopupSkin.java
@@ -1,20 +1,27 @@
 package dev.ikm.komet.kview.controls.skin;
 
 import static dev.ikm.komet.kview.controls.FilterOptions.OPTION_ITEM.MODULE;
+
 import dev.ikm.komet.kview.controls.DateFilterTitledPane;
 import dev.ikm.komet.kview.controls.FilterOptions;
 import dev.ikm.komet.kview.controls.FilterOptionsPopup;
+import dev.ikm.komet.kview.controls.FilterOptionsUtils;
 import dev.ikm.komet.kview.controls.FilterTitledPane;
 import dev.ikm.komet.kview.controls.IconRegion;
+import dev.ikm.komet.kview.controls.LangFilterTitledPane;
 import dev.ikm.komet.kview.controls.SavedFiltersPopup;
 import dev.ikm.komet.navigator.graph.Navigator;
 import dev.ikm.komet.preferences.KometPreferences;
 import dev.ikm.komet.preferences.Preferences;
-import dev.ikm.tinkar.coordinate.navigation.calculator.Edge;
 import dev.ikm.tinkar.coordinate.stamp.StateSet;
 import dev.ikm.tinkar.entity.Entity;
+import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
 import javafx.geometry.Bounds;
 import javafx.scene.Node;
 import javafx.scene.control.Accordion;
@@ -22,7 +29,9 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Skin;
+import javafx.scene.control.TitledPane;
 import javafx.scene.control.ToggleButton;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
@@ -36,8 +45,11 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.function.Consumer;
 
 public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
 
@@ -49,7 +61,8 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
     private final FilterOptionsPopup control;
     private final VBox root;
 
-    private final Accordion accordion;
+    private final AccordionBox accordionBox;
+    private final ScrollPane scrollPane;
     private final Button revertButton;
     private final Button applyButton;
     private final SavedFiltersPopup savedFiltersPopup;
@@ -57,11 +70,11 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
 
     private Subscription subscription;
     private Subscription filterSubscription;
-    private boolean updating;
+    private boolean updating, skipUpdateFilterOptions;
 
     private static final List<String> ALL_STATES = StateSet.ACTIVE_INACTIVE_AND_WITHDRAWN.toEnumSet().stream().map(s -> s.name()).toList();
 
-    private final FilterOptions inheritedFilterOptions = new FilterOptions();
+    private FilterOptions defaultFilterOptions = new FilterOptions();
     private final ObjectProperty<FilterOptions> currentFilterOptionsProperty = new SimpleObjectProperty<>() {
         @Override
         protected void invalidated() {
@@ -72,7 +85,10 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
                 }
                 // Keep button always enabled, though it won't do anything, since filterOptions are already passed to the control
 //                applyButton.setDisable(control.getFilterOptions().equals(filterOptions));
-                revertButton.setDisable(inheritedFilterOptions.equals(filterOptions));
+                revertButton.setDisable(defaultFilterOptions.equals(filterOptions));
+
+                accordionBox.disableAddButton(filterOptions.getLanguageCoordinatesList().stream()
+                        .anyMatch(l -> l.getLanguage().selectedOptions().isEmpty()));
             }
         }
     };
@@ -97,8 +113,8 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
         HBox headerBox = new HBox(closePane, title, filterPane);
         headerBox.getStyleClass().add("header-box");
 
-        accordion = new Accordion();
-        ScrollPane scrollPane = new ScrollPane(accordion);
+        accordionBox = new AccordionBox();
+        scrollPane = new ScrollPane(accordionBox);
 
         Region spacer = new Region();
         VBox.setVgrow(spacer, Priority.ALWAYS);
@@ -106,7 +122,7 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
         applyButton = new Button(resources.getString("button.apply"));
         applyButton.getStyleClass().add("apply");
         applyButton.setOnAction(_ -> {
-            accordion.setExpandedPane(null);
+            accordionBox.setExpandedPane(null);
             // copy options from titledPanes into control
             control.setFilterOptions(currentFilterOptionsProperty.get());
         });
@@ -119,7 +135,7 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
         saveButton.setDisable(true);
         saveButton.setOnAction(_ -> {
             // close all titled panes to update the current filter options
-            accordion.setExpandedPane(null);
+            accordionBox.setExpandedPane(null);
             List<String> savedFilters = kometPreferences.getList(SAVED_FILTERS_KEY, new ArrayList<>());
             try {
                 String key = "" + (savedFilters.isEmpty() ? 1 : Integer.parseInt(savedFilters.getLast()) + 1);
@@ -142,8 +158,11 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
         root.getStyleClass().add("filter-options-popup");
         root.getStylesheets().add(FilterOptionsPopup.class.getResource("filter-options-popup.css").toExternalForm());
 
+        // create panes, without any filter option yet
+        createAccordionBoxPanes();
+
         subscription = control.filterOptionsProperty().subscribe(this::setupFilter);
-        subscription = subscription.and(control.navigatorProperty().subscribe(this::setOptionsFromNavigator));
+        subscription = subscription.and(control.navigatorProperty().subscribe(this::setupDefaultFilterOptions));
 
         subscription = subscription.and(savedFiltersPopup.showingProperty().subscribe((_, showing) -> {
             if (!showing) {
@@ -151,8 +170,10 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
             }
         }));
         //experimental... trying to listen to changes when the inherited options change to change what is selected
-        subscription = subscription.and(control.inheritedFilterOptionsProperty().subscribe((oldVal, newVal) -> {
-            currentFilterOptionsProperty.setValue(control.getInheritedFilterOptions());
+        subscription = subscription.and(control.inheritedFilterOptionsProperty().subscribe((_, _) -> {
+            if (control.getNavigator() != null) {
+                setupDefaultFilterOptions(control.getNavigator());
+            }
         }));
         subscription = subscription.and(filterPane.selectedProperty().subscribe((_, selected) -> {
             if (selected) {
@@ -163,6 +184,8 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
                 savedFiltersPopup.hide();
             }
         }));
+
+        control.setOnShown(_ -> scrollPane.setVvalue(scrollPane.getVmin()));
     }
 
     private void setupFilter(FilterOptions filterOptions) {
@@ -172,30 +195,41 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
         if (filterOptions == null) {
             return;
         }
-        // changes from titledPane control:
+
         updating = true;
         filterSubscription = Subscription.EMPTY;
-        accordion.getPanes().stream()
-                .filter(FilterTitledPane.class::isInstance)
-                .map(FilterTitledPane.class::cast)
-                .forEach(pane -> {
-                    filterSubscription = filterSubscription.and(pane.optionProperty().subscribe((_, _) ->
-                            updateCurrentFilterOptions()));
-                });
+
+        // changes from titledPane controls:
+        accordionBox.updateMainPanes(pane ->
+            filterSubscription = filterSubscription.and(pane.optionProperty().subscribe((_, _) ->
+                    updateCurrentFilterOptions())));
+        accordionBox.updateLangPanes(pane ->
+            filterSubscription = filterSubscription.and(pane.langCoordinatesProperty().subscribe((_, _) ->
+                    updateCurrentFilterOptions())));
 
         // pass filter options to titledPane controls
-        accordion.getPanes().stream()
-                .filter(FilterTitledPane.class::isInstance)
-                .map(FilterTitledPane.class::cast)
-                .forEach(pane -> {
-                    FilterOptions.Option optionForItem = filterOptions.getOptionForItem(pane.getOption().item());
-                    if (optionForItem.availableOptions().isEmpty()) {
-                        optionForItem.availableOptions().addAll(pane.getOption().availableOptions());
+        skipUpdateFilterOptions = true;
+        accordionBox.updateMainPanes(pane -> {
+                FilterOptions.Option optionForItem = filterOptions.getOptionForItem(pane.getOption().item());
+                if (optionForItem.availableOptions().isEmpty()) {
+                    optionForItem.availableOptions().addAll(pane.getOption().availableOptions());
+                }
+                pane.setOption(optionForItem);
+            });
+        accordionBox.updateLangPanes(pane -> {
+                int ordinal = pane.getOrdinal();
+                FilterOptions.LanguageCoordinates languageCoordinates = filterOptions.getLanguageCoordinates(ordinal);
+                for (int i = 0; i < languageCoordinates.getOptions().size(); i++) {
+                    FilterOptions.Option option = languageCoordinates.getOptions().get(i);
+                    if (option.availableOptions().isEmpty()) {
+                        option.availableOptions().addAll(pane.getLangCoordinates().getOptions().get(i).availableOptions());
                     }
-                    pane.setOption(optionForItem);
-                });
+                }
+                pane.setLangCoordinates(languageCoordinates);
+            });
+        skipUpdateFilterOptions = false;
         updateCurrentFilterOptions();
-        control.getProperties().put(DEFAULT_OPTIONS_KEY, inheritedFilterOptions.equals(control.getFilterOptions()));
+        control.getProperties().put(DEFAULT_OPTIONS_KEY, defaultFilterOptions.equals(control.getFilterOptions()));
         updating = false;
     }
 
@@ -220,135 +254,164 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
     }
 
     private void revertFilterOptions() {
-        accordion.setExpandedPane(null);
+        accordionBox.setExpandedPane(null);
+        accordionBox.getLangAccordion().getPanes().removeIf(t -> t instanceof LangFilterTitledPane langFilterTitledPane
+                && langFilterTitledPane.getOrdinal() > 0);
         updating = true;
         currentFilterOptionsProperty.set(null);
         setupFilter(null);
-        setOptionsFromNavigator(control.getNavigator());
+        setupFilter(defaultFilterOptions);
         updating = false;
         updateCurrentFilterOptions();
     }
 
     private void updateCurrentFilterOptions() {
+        if (skipUpdateFilterOptions) {
+            return;
+        }
         FilterOptions currentFilterOptions = new FilterOptions();
-        accordion.getPanes().stream()
-                .filter(FilterTitledPane.class::isInstance)
-                .map(FilterTitledPane.class::cast)
-                .forEach(pane -> {
-                    FilterOptions.Option optionForItem = pane.getOption();
-                    currentFilterOptions.setOptionForItem(pane.getOption().item(), optionForItem);
-                });
+        accordionBox.updateMainPanes(pane -> {
+            FilterOptions.Option optionForItem = pane.getOption();
+            currentFilterOptions.setOptionForItem(pane.getOption().item(), optionForItem);
+        });
+        accordionBox.updateLangPanes(pane -> {
+            FilterOptions.LanguageCoordinates languageCoordinates = pane.getLangCoordinates();
+            if (pane.getOrdinal() > 0) {
+                currentFilterOptions.addLanguageCoordinates();
+            }
+            currentFilterOptions.setLangCoordinates(pane.getOrdinal(), languageCoordinates);
+        });
         currentFilterOptionsProperty.set(currentFilterOptions);
     }
 
-    private void setOptionsFromNavigator(Navigator navigator) {
+    private void createAccordionBoxPanes() {
         FilterOptions filterOptions = new FilterOptions();
+
+        // Main Coordinates
+
+        FilterOptions.Option option = filterOptions.getMainCoordinates().getType();
+        FilterTitledPane typeFilterTitledPane = setupTitledPane(option);
+
+        option = filterOptions.getMainCoordinates().getNavigator();
+        FilterTitledPane navigatorFilterTitledPane = setupTitledPane(option);
+
+        // status: all descendants of Status
+        option = filterOptions.getMainCoordinates().getStatus();
+        FilterTitledPane statusFilterTitledPane = setupTitledPane(option);
+
+        option = filterOptions.getMainCoordinates().getTime();
+        FilterTitledPane timeFilterTitledPane = setupTitledPane(option);
+
+        // module: all descendants of Module
+        option = filterOptions.getMainCoordinates().getModule();
+        FilterTitledPane moduleFilterTitledPane = setupTitledPane(option);
+
+        // path: all descendants of Path
+        option = filterOptions.getMainCoordinates().getPath();
+        FilterTitledPane pathFilterTitledPane = setupTitledPane(option);
+
+        option = filterOptions.getMainCoordinates().getKindOf();
+        FilterTitledPane kindOfFilterTitledPane = setupTitledPane(option);
+
+        option = filterOptions.getMainCoordinates().getMembership();
+        FilterTitledPane membershipFilterTitledPane = setupTitledPane(option);
+
+        if (control.getFilterType() == FilterOptionsPopup.FILTER_TYPE.NAVIGATOR) {
+            // header: All first children of root
+            option = filterOptions.getMainCoordinates().getHeader();
+            FilterTitledPane headerFilterTitledPane = setupTitledPane(option);
+
+            accordionBox.getPanes().setAll(
+                    navigatorFilterTitledPane,
+                    headerFilterTitledPane,
+                    statusFilterTitledPane,
+                    timeFilterTitledPane,
+                    moduleFilterTitledPane,
+                    pathFilterTitledPane,
+                    kindOfFilterTitledPane,
+                    membershipFilterTitledPane);
+        } else {
+            option = filterOptions.getMainCoordinates().getSortBy();
+            FilterTitledPane sortByFilterTitledPane = setupTitledPane(option);
+
+            accordionBox.getPanes().setAll(
+                    typeFilterTitledPane,
+                    statusFilterTitledPane,
+                    timeFilterTitledPane,
+                    moduleFilterTitledPane,
+                    pathFilterTitledPane,
+                    kindOfFilterTitledPane,
+                    membershipFilterTitledPane,
+                    sortByFilterTitledPane);
+        }
+
+        // Language Coordinates
+
+        FilterOptions.LanguageCoordinates languageCoordinates = filterOptions.getLanguageCoordinates(0);
+        LangFilterTitledPane langFilterTitledPane = setupLangTitledPane(languageCoordinates);
+        accordionBox.getLangAccordion().getPanes().add(langFilterTitledPane);
+    }
+
+    private void setupDefaultFilterOptions(Navigator navigator) {
+        // reset default filter options
+        defaultFilterOptions = new FilterOptions();
+        // once we have navigator, update pending options with av/def/sel default options
+        setAvailableOptionsFromNavigator(defaultFilterOptions, navigator);
+        // then pass the inherited options, to override av/def/sel default options where set
+        setDefaultOptions(control.getInheritedFilterOptions());
+        // pass default options to panes
+        accordionBox.updateMainPanes(pane ->
+                pane.setDefaultOption(defaultFilterOptions.getOptionForItem(pane.getOption().item())));
+        accordionBox.updateLangPanes(pane ->
+                pane.setDefaultLangCoordinates(defaultFilterOptions.getLanguageCoordinates(pane.getOrdinal())));
+        // finally, setup filter with default options
+        setupFilter(defaultFilterOptions);
+    }
+
+    private void setDefaultOptions(FilterOptions filterOptions) {
+        filterOptions.getMainCoordinates().getOptions().forEach(sourceOption ->
+                setInheritedOptions(sourceOption, defaultFilterOptions.getOptionForItem(sourceOption.item())));
+        filterOptions.getLanguageCoordinates(0).getOptions().forEach(sourceOption ->
+                setInheritedOptions(sourceOption, defaultFilterOptions.getLangOptionForItem(0, sourceOption.item())));
+    }
+
+    private void setAvailableOptionsFromNavigator(FilterOptions options, Navigator navigator) {
         if (navigator == null || navigator.getRootNids() == null || navigator.getRootNids().length == 0) {
             return;
         }
         int rootNid = navigator.getRootNids()[0];
 
-        FilterOptions.Option option = control.getInheritedFilterOptions().getNavigator();
-        FilterTitledPane navigatorFilterTitledPane = setupTitledPane(option);
-        setInheritedOptions(option);
-
-        option = control.getInheritedFilterOptions().getType();
-        FilterTitledPane typeFilterTitledPane = setupTitledPane(option);
-        if (control.getFilterType() == FilterOptionsPopup.FILTER_TYPE.SEARCH) {
-            setInheritedOptions(option);
-        }
-
-        // header: All first children of root
-        List<String> headerList = navigator.getChildEdges(rootNid).stream()
-                .map(edge -> Entity.getFast(edge.destinationNid()).description())
-                .toList();
-        option = filterOptions.getHeader();
-        setAvailableOptions(option, headerList);
-        FilterTitledPane headerFilterTitledPane = setupTitledPane(option);
         if (control.getFilterType() == FilterOptionsPopup.FILTER_TYPE.NAVIGATOR) {
-            setInheritedOptions(option);
+            // header: All first children of root
+            List<String> headerList = navigator.getChildEdges(rootNid).stream()
+                    .map(edge -> Entity.getFast(edge.destinationNid()).description())
+                    .toList();
+            FilterOptions.Option option = options.getMainCoordinates().getHeader();
+            setAvailableOptions(option, headerList);
         }
 
         // status: all descendants of Status
-        option = control.getInheritedFilterOptions().getStatus();
+        FilterOptions.Option option = options.getMainCoordinates().getStatus();
         setAvailableOptions(option, ALL_STATES); //ACTIVE, INACTIVE, WITHDRAWN
-        FilterTitledPane statusFilterTitledPane = setupTitledPane(option);
-        setInheritedOptions(option);
 
         // module: all descendants of Module
-        option = control.getInheritedFilterOptions().getModule();
-        setAvailableOptions(option, getDescendentsList(navigator, rootNid, MODULE.getPath()));
-        FilterTitledPane moduleFilterTitledPane = setupTitledPane(option);
-        setInheritedOptions(option);
+        option = options.getMainCoordinates().getModule();
+        setAvailableOptions(option, FilterOptionsUtils.getDescendentsList(navigator, rootNid, MODULE.getPath()));
 
         // path: all descendants of Path
-        option = control.getInheritedFilterOptions().getPath();
-        setAvailableOptions(option, getDescendentsList(navigator, rootNid, FilterOptions.OPTION_ITEM.PATH.getPath()));
-        FilterTitledPane pathFilterTitledPane = setupTitledPane(option);
-        setInheritedOptions(option);
+        option = options.getMainCoordinates().getPath();
+        setAvailableOptions(option, FilterOptionsUtils.getDescendentsList(navigator, rootNid, FilterOptions.OPTION_ITEM.PATH.getPath()));
 
         // language: all descendants of Model concept->Tinkar Model concept->Language
-        option = control.getInheritedFilterOptions().getLanguage();
-        setAvailableOptions(option, getDescendentsList(navigator, rootNid, FilterOptions.OPTION_ITEM.LANGUAGE.getPath()));
-        FilterTitledPane languageFilterTitledPane = setupTitledPane(option);
-        setInheritedOptions(option);
-
-        option = control.getInheritedFilterOptions().getDescription();
-        FilterTitledPane descriptionFilterTitledPane = setupTitledPane(option);
-        setInheritedOptions(option);
-
-        option = control.getInheritedFilterOptions().getKindOf();
-        FilterTitledPane kindOfFilterTitledPane = setupTitledPane(option);
-        setInheritedOptions(option);
-
-        option = control.getInheritedFilterOptions().getMembership();
-        FilterTitledPane membershipFilterTitledPane = setupTitledPane(option);
-        setInheritedOptions(option);
-
-        option = control.getInheritedFilterOptions().getSortBy();
-        FilterTitledPane sortByFilterTitledPane = setupTitledPane(option);
-        if (control.getFilterType() == FilterOptionsPopup.FILTER_TYPE.SEARCH) {
-            setInheritedOptions(option);
+        List<String> descendentsList = FilterOptionsUtils.getDescendentsList(navigator, rootNid, FilterOptions.OPTION_ITEM.LANGUAGE.getPath());
+        for (int i = 0; i < options.getLanguageCoordinatesList().size(); i++) {
+            option = options.getLanguageCoordinates(i).getLanguage();
+            setAvailableOptions(option, descendentsList);
         }
-
-        option = filterOptions.getDate();
-        FilterTitledPane dateFilterTitledPane = setupTitledPane(option);
-        inheritedFilterOptions.getOptionForItem(option.item()).selectedOptions().clear(); // latest has no selected options
-
-        if (control.getFilterType() == FilterOptionsPopup.FILTER_TYPE.NAVIGATOR) {
-            accordion.getPanes().setAll(
-                    navigatorFilterTitledPane,
-                    headerFilterTitledPane,
-                    statusFilterTitledPane,
-                    moduleFilterTitledPane,
-                    pathFilterTitledPane,
-                    languageFilterTitledPane,
-                    descriptionFilterTitledPane,
-                    kindOfFilterTitledPane,
-                    membershipFilterTitledPane,
-                    dateFilterTitledPane);
-        } else {
-            accordion.getPanes().setAll(
-                    typeFilterTitledPane,
-                    statusFilterTitledPane,
-                    moduleFilterTitledPane,
-                    pathFilterTitledPane,
-                    languageFilterTitledPane,
-                    descriptionFilterTitledPane,
-                    kindOfFilterTitledPane,
-                    membershipFilterTitledPane,
-                    sortByFilterTitledPane,
-                    dateFilterTitledPane);
-        }
-
-        // initially, set default options
-        currentFilterOptionsProperty.set(inheritedFilterOptions);
-        setupFilter(inheritedFilterOptions);
-        updateCurrentFilterOptions();
     }
 
     private FilterTitledPane setupTitledPane(FilterOptions.Option option) {
-        FilterTitledPane titledPane = option.item() == FilterOptions.OPTION_ITEM.DATE ?
+        FilterTitledPane titledPane = option.item() == FilterOptions.OPTION_ITEM.TIME ?
                 new DateFilterTitledPane() : new FilterTitledPane();
         titledPane.setTitle(option.title());
         titledPane.setOption(option);
@@ -356,28 +419,40 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
         return titledPane;
     }
 
+    private LangFilterTitledPane setupLangTitledPane(FilterOptions.LanguageCoordinates languageCoordinates) {
+        LangFilterTitledPane titledPane = new LangFilterTitledPane();
+        titledPane.setOrdinal(languageCoordinates.getOrdinal());
+        titledPane.setTitle(resources.getString("language.coordinates.ordinal" + (languageCoordinates.getOrdinal() + 1)));
+        titledPane.setLangCoordinates(languageCoordinates);
+        titledPane.setExpanded(false);
+        return titledPane;
+    }
+
     private void setAvailableOptions(FilterOptions.Option option, List<String> options) {
         option.availableOptions().clear();
         option.availableOptions().addAll(options);
+        option.defaultOptions().clear();
+        option.defaultOptions().addAll(option.isMultiSelectionAllowed() ? options : List.of(options.getFirst()));
+        option.selectedOptions().clear();
+        option.selectedOptions().addAll(option.isMultiSelectionAllowed() ? options : List.of(options.getFirst()));
     }
 
-    private void setInheritedOptions(FilterOptions.Option option) {
-        inheritedFilterOptions.getOptionForItem(option.item()).selectedOptions().clear();
-        inheritedFilterOptions.getOptionForItem(option.item()).defaultOptions().clear();
-        if (option.isMultiSelectionAllowed()) {
-            if (!option.selectedOptions().isEmpty()) {
-                inheritedFilterOptions.getOptionForItem(option.item()).selectedOptions().addAll(option.selectedOptions());
-            } else if (inheritedFilterOptions.getOptionForItem(option.item()).hasAny()) {
-                inheritedFilterOptions.getOptionForItem(option.item()).setAny(true);
-            } else {
-                inheritedFilterOptions.getOptionForItem(option.item()).selectedOptions().addAll(option.availableOptions());
-            }
-        } else {
-            if (!option.selectedOptions().isEmpty()) {
-                inheritedFilterOptions.getOptionForItem(option.item()).selectedOptions().add(option.selectedOptions().getFirst());
-            }
+    private void setInheritedOptions(FilterOptions.Option sourceOption, FilterOptions.Option targetOption) {
+        targetOption.selectedOptions().clear();
+        targetOption.defaultOptions().clear();
+        if (targetOption.hasAny()) {
+            targetOption.setAny(sourceOption.any());
         }
-        inheritedFilterOptions.getOptionForItem(option.item()).defaultOptions().addAll(option.selectedOptions());
+        if (sourceOption.isMultiSelectionAllowed()) {
+            if (!sourceOption.selectedOptions().isEmpty()) {
+                targetOption.selectedOptions().addAll(sourceOption.selectedOptions());
+            } else {
+                targetOption.selectedOptions().addAll(targetOption.availableOptions());
+            }
+        } else if (!(sourceOption.selectedOptions().isEmpty() || sourceOption.selectedOptions().getFirst() == null)) {
+            targetOption.selectedOptions().add(sourceOption.selectedOptions().getFirst());
+        }
+        targetOption.defaultOptions().addAll(sourceOption.selectedOptions());
     }
 
     private void applyFilter(String i) {
@@ -406,25 +481,6 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
         savedFiltersPopup.getSavedFiltersList().setAll(savedFilters);
     }
 
-    private static int findNidForDescription(Navigator navigator, int nid, String description) {
-        return navigator.getChildEdges(nid).stream()
-                .filter(edge -> navigator.getViewCalculator().languageCalculator().getPreferredDescriptionTextWithFallbackOrNid(edge.destinationNid()).equals(description))
-                .findFirst()
-                .map(Edge::destinationNid)
-                .orElseThrow();
-    }
-
-    private static List<String> getDescendentsList(Navigator navigator, int parentNid, String description) {
-        int nid = parentNid;
-        for (String s : description.split(", ")) {
-            nid = findNidForDescription(navigator, nid, s);
-        }
-        return navigator.getViewCalculator().descendentsOf(nid).intStream().boxed()
-                .map(i -> navigator.getViewCalculator().languageCalculator().getPreferredDescriptionTextWithFallbackOrNid(i))
-                .sorted()
-                .toList();
-    }
-
     private static byte[] serialize(FilterOptions filterOptions) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
@@ -438,6 +494,172 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
     private FilterOptions deserialize(byte[] data) throws IOException, ClassNotFoundException {
         try (ByteArrayInputStream bis = new ByteArrayInputStream(data)) {
             return (FilterOptions) new ObjectInputStream(bis).readObject();
+        }
+    }
+
+    class AccordionBox extends VBox {
+
+        private final ObservableList<FilterTitledPane> panes = FXCollections.observableArrayList();
+        private final Accordion langAccordion;
+        private TitledPane expandedPane = null;
+        private final Map<TitledPane, ChangeListener<Boolean>> listeners = new HashMap<>();
+        private final StackPane addButton;
+
+        public AccordionBox() {
+            getStyleClass().add("accordion");
+
+            langAccordion = new Accordion();
+            langAccordion.getPanes().addListener((ListChangeListener<TitledPane>) c -> {
+                while (c.next()) {
+                    if (c.wasRemoved()) {
+                        c.getRemoved().stream()
+                                .filter(LangFilterTitledPane.class::isInstance)
+                                .map(LangFilterTitledPane.class::cast)
+                                .map(LangFilterTitledPane::getOrdinal)
+                                .findFirst()
+                                .ifPresent(i -> {
+                                    updateLangPanes(pane -> {
+                                        if (pane.getOrdinal() > i) {
+                                            pane.setOrdinal(pane.getOrdinal() - 1);
+                                            pane.setTitle(resources.getString("language.coordinates.ordinal" + (pane.getOrdinal() + 1)));
+                                        }
+                                    });
+                                });
+                        updateCurrentFilterOptions();
+                        Platform.runLater(() -> {
+                            langAccordion.requestLayout();
+                            scrollPane.requestLayout();
+                            scrollPane.setVvalue(scrollPane.getVmax());
+                        });
+                    }
+                }
+            });
+
+            Label titleLabel = new Label(resources.getString("language.title"));
+            titleLabel.getStyleClass().add("title-label");
+
+            Region spacer = new Region();
+            HBox.setHgrow(spacer, Priority.ALWAYS);
+
+            addButton = new StackPane(new IconRegion("icon", "add"));
+            addButton.getStyleClass().add("add-pane");
+            addButton.addEventFilter(MouseEvent.MOUSE_RELEASED, e -> {
+                e.consume();
+                langAccordion.setExpandedPane(null);
+                addButton.setDisable(true);
+                List<String> list = currentFilterOptionsProperty.get().getLanguageCoordinatesList().stream()
+                        .map(l -> l.getLanguage().selectedOptions().getFirst())
+                        .toList();
+                FilterOptions.LanguageCoordinates languageCoordinates = currentFilterOptionsProperty.get().addLanguageCoordinates();
+                languageCoordinates.getLanguage().excludedOptions().addAll(list);
+                languageCoordinates.getLanguage().availableOptions().addAll(
+                        currentFilterOptionsProperty.get().getLanguageCoordinatesList().getFirst().getLanguage().availableOptions());
+                languageCoordinates.getOptions().forEach(sourceOption ->
+                        setInheritedOptions(sourceOption, defaultFilterOptions.getLangOptionForItem(0, sourceOption.item())));
+                LangFilterTitledPane langFilterTitledPane = setupLangTitledPane(languageCoordinates);
+                langAccordion.getPanes().add(langFilterTitledPane);
+                updateCurrentFilterOptions();
+            });
+
+            HBox titleBox = new HBox(titleLabel, spacer, addButton);
+            titleBox.getStyleClass().add("title-box");
+
+            TitledPane languageTitledPane = new TitledPane();
+            languageTitledPane.getStyleClass().add("lang-titled-pane");
+            languageTitledPane.setGraphic(titleBox);
+            languageTitledPane.setContent(langAccordion);
+            languageTitledPane.heightProperty().subscribe(_ -> {
+                if (languageTitledPane.isExpanded() && scrollPane != null) {
+                    scrollPane.setVvalue(scrollPane.getVmax());
+                }
+            });
+
+            getChildren().add(languageTitledPane);
+            panes.addListener((ListChangeListener<FilterTitledPane>) c -> {
+                getChildren().setAll(panes);
+                getChildren().add(languageTitledPane);
+                while (c.next()) {
+                    if (c.wasRemoved()) {
+                        removeTitledPaneListeners(c.getRemoved());
+                    }
+                    if (c.wasAdded()) {
+                        initTitledPaneListeners(c.getAddedSubList());
+                    }
+                }
+            });
+        }
+
+        // expandedPane
+        private final ObjectProperty<FilterTitledPane> expandedPaneProperty = new SimpleObjectProperty<>(this, "expandedPane");
+        public final ObjectProperty<FilterTitledPane> expandedPaneProperty() {
+           return expandedPaneProperty;
+        }
+        public final FilterTitledPane getExpandedPane() {
+           return expandedPaneProperty.get();
+        }
+        public final void setExpandedPane(FilterTitledPane value) {
+            expandedPaneProperty.set(value);
+        }
+
+        public ObservableList<FilterTitledPane> getPanes() {
+            return panes;
+        }
+
+        public Accordion getLangAccordion() {
+            return langAccordion;
+        }
+
+        public void disableAddButton(boolean disable) {
+            addButton.setDisable(disable);
+        }
+
+        public void updateMainPanes(Consumer<FilterTitledPane> onAccept) {
+            getPanes().forEach(onAccept);
+        }
+
+        public void updateLangPanes(Consumer<LangFilterTitledPane> onAccept) {
+            getLangAccordion().getPanes().stream()
+                    .filter(LangFilterTitledPane.class::isInstance)
+                    .map(LangFilterTitledPane.class::cast)
+                    .forEach(onAccept);
+        }
+
+        private void initTitledPaneListeners(List<? extends FilterTitledPane> list) {
+            for (final FilterTitledPane tp: list) {
+                tp.setExpanded(tp == getExpandedPane());
+                if (tp.isExpanded()) {
+                    expandedPane = tp;
+                }
+                ChangeListener<Boolean> changeListener = expandedPropertyListener(tp);
+                tp.expandedProperty().addListener(changeListener);
+                listeners.put(tp, changeListener);
+            }
+        }
+
+        private void removeTitledPaneListeners(List<? extends FilterTitledPane> list) {
+            for (final FilterTitledPane tp: list) {
+                if (listeners.containsKey(tp)) {
+                    tp.expandedProperty().removeListener(listeners.get(tp));
+                    listeners.remove(tp);
+                }
+            }
+        }
+
+        private ChangeListener<Boolean> expandedPropertyListener(final FilterTitledPane tp) {
+            return (_, _, expanded) -> {
+                if (expanded) {
+                    if (expandedPane != null) {
+                        expandedPane.setExpanded(false);
+                    }
+                    if (tp != null) {
+                        setExpandedPane(tp);
+                    }
+                    expandedPane = getExpandedPane();
+                } else {
+                    expandedPane = null;
+                    setExpandedPane(null);
+                }
+            };
         }
     }
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterTitledPaneSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterTitledPaneSkin.java
@@ -69,7 +69,6 @@ public class FilterTitledPaneSkin extends TitledPaneSkin {
 
         selectedOption = new TruncatedTextFlow();
         selectedOption.setMaxContentHeight(44); // 2 lines
-        selectedOption.setMaxWidth(240);
         selectedOption.getStyleClass().add("option");
 
         buttonToggleGroup = new ToggleGroup();
@@ -109,14 +108,12 @@ public class FilterTitledPaneSkin extends TitledPaneSkin {
 
         control.setContent(contentBox);
 
-        if (control.getParent() instanceof Accordion accordion) {
-            Parent parent = accordion.getParent();
-            while (!(parent instanceof ScrollPane)) {
-                parent = parent.getParent();
-            }
-
-            scrollPane = (ScrollPane) parent;
+        Parent parent = control.getParent();
+        while (!(parent instanceof ScrollPane)) {
+            parent = parent.getParent();
         }
+
+        scrollPane = (ScrollPane) parent;
 
         setupTitledPane();
     }
@@ -127,15 +124,19 @@ public class FilterTitledPaneSkin extends TitledPaneSkin {
             subscription = Subscription.EMPTY;
         }
 
-        boolean multiSelectionAllowed = control.getOption().isMultiSelectionAllowed();
+        FilterOptions.Option option = control.getOption();
+        if (option == null) {
+            return;
+        }
+        boolean multiSelectionAllowed = option.isMultiSelectionAllowed();
         control.pseudoClassStateChanged(SINGLE_SELECT_OPTION, !multiSelectionAllowed);
 
-        FilterOptions.Option currentOption = control.getOption().copy();
+        FilterOptions.Option currentOption = option.copy();
         selectedOption.setText(getOptionText(currentOption));
 
         // add toggles only once
         if (contentBox.getChildren().size() == 1) {
-            control.getOption().availableOptions().forEach(text ->
+            option.availableOptions().forEach(text ->
                     contentBox.getChildren().add(new OptionToggle(text)));
         }
         setupToggleBox(currentOption);
@@ -145,7 +146,7 @@ public class FilterTitledPaneSkin extends TitledPaneSkin {
 
         subscription = subscription.and(selectedOption.textProperty().subscribe(_ -> {
             pseudoClassStateChanged(MODIFIED_TITLED_PANE,
-                    !Objects.equals(currentOption.selectedOptions(), currentOption.defaultOptions()));
+                    !Objects.equals(currentOption, control.getDefaultOption()));
         }));
 
         if (control.getParent() instanceof Accordion accordion) {

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLSearchControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLSearchControlSkin.java
@@ -1,13 +1,10 @@
 package dev.ikm.komet.kview.controls.skin;
 
-import static dev.ikm.tinkar.common.service.PrimitiveData.PREMUNDANE_TIME;
 import static dev.ikm.tinkar.events.FrameworkTopics.CALCULATOR_CACHE_TOPIC;
 import dev.ikm.komet.framework.events.appevents.RefreshCalculatorCacheEvent;
-import dev.ikm.komet.framework.view.ObservableCoordinate;
-import dev.ikm.komet.framework.view.ObservableLanguageCoordinate;
-import dev.ikm.komet.framework.view.ObservableStampCoordinate;
 import dev.ikm.komet.kview.controls.FilterOptions;
 import dev.ikm.komet.kview.controls.FilterOptionsPopup;
+import dev.ikm.komet.kview.controls.FilterOptionsUtils;
 import dev.ikm.komet.kview.controls.IconRegion;
 import dev.ikm.komet.kview.controls.InvertedTree;
 import dev.ikm.komet.kview.controls.KLSearchControl;
@@ -48,11 +45,7 @@ import javafx.scene.text.Text;
 import javafx.util.Duration;
 import javafx.util.Subscription;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
@@ -84,9 +77,6 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
 
     private final ListView<KLSearchControl.SearchResult> resultsPane;
     private final FilterOptionsPopup filterOptionsPopup;
-
-    private static final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MM/dd/yyyy");
-    private static final List<String> ALL_STATES = StateSet.ACTIVE_INACTIVE_AND_WITHDRAWN.toEnumSet().stream().map(s -> s.name()).toList();
 
     /**
      * <p>Creates a {@link KLSearchControlSkin} instance.
@@ -176,7 +166,7 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
         filterOptionsPopup = new FilterOptionsPopup(FilterOptionsPopup.FILTER_TYPE.NAVIGATOR);
 
         // initialize the filter options
-        filterOptionsPopup.inheritedFilterOptionsProperty().setValue(loadFilterOptions(control));
+        filterOptionsPopup.inheritedFilterOptionsProperty().setValue(FilterOptionsUtils.loadFilterOptions(control.getViewProperties().parentView(), control.getViewProperties().calculator()));
 
         filterOptionsPopup.navigatorProperty().bind(control.navigatorProperty());
         getSkinnable().parentProperty().subscribe(parent -> {
@@ -259,16 +249,16 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
         // listen for changes to the filter options
         ChangeListener<FilterOptions> changeListener = ((obs, oldFilterOptions, newFilterOptions) -> {
             if (newFilterOptions != null) {
-                if (!newFilterOptions.getStatus().selectedOptions().isEmpty()) {
+                if (!newFilterOptions.getMainCoordinates().getStatus().selectedOptions().isEmpty()) {
                     StateSet stateSet = StateSet.make(
-                            newFilterOptions.getStatus().selectedOptions().stream().map(
+                            newFilterOptions.getMainCoordinates().getStatus().selectedOptions().stream().map(
                                     s -> State.valueOf(s.toUpperCase())).toList());
                     // update the STATUS
                     control.getViewProperties().nodeView().stampCoordinate().allowedStatesProperty().setValue(stateSet);
                 }
-                if (!newFilterOptions.getPath().selectedOptions().isEmpty()) {
+                if (!newFilterOptions.getMainCoordinates().getPath().selectedOptions().isEmpty()) {
                     //NOTE: there is no known way to set multiple paths
-                    String pathStr = newFilterOptions.getPath().selectedOptions().stream().findFirst().get();
+                    String pathStr = newFilterOptions.getMainCoordinates().getPath().selectedOptions().stream().findFirst().get();
 
                     ConceptFacade conceptPath = switch(pathStr) {
                         case "Master path" -> TinkarTerm.MASTER_PATH;
@@ -279,9 +269,10 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
                     // update the Path
                     control.getViewProperties().nodeView().stampCoordinate().pathConceptProperty().setValue(conceptPath);
                 }
-                if (!newFilterOptions.getDate().selectedOptions().isEmpty() &&
-                        !oldFilterOptions.getDate().selectedOptions().equals(newFilterOptions.getDate().selectedOptions())) {
-                    long millis = getMillis(newFilterOptions);
+                if (!newFilterOptions.getMainCoordinates().getTime().selectedOptions().isEmpty() &&
+                        oldFilterOptions != null &&
+                        !oldFilterOptions.getMainCoordinates().getTime().selectedOptions().equals(newFilterOptions.getMainCoordinates().getTime().selectedOptions())) {
+                    long millis = FilterOptionsUtils.getMillis(newFilterOptions);
                     // update the time
                     control.getViewProperties().nodeView().stampCoordinate().timeProperty().set(millis);
                 } else {
@@ -302,7 +293,7 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
         // listen to changes to the parent of the current overrideable view
         parentSubscription = control.getViewProperties().parentView().subscribe((oldValue, newValue) -> {
             filterOptionsPopup.filterOptionsProperty().removeListener(changeListener);
-            filterOptionsPopup.inheritedFilterOptionsProperty().setValue(loadFilterOptions(control));
+            filterOptionsPopup.inheritedFilterOptionsProperty().setValue(FilterOptionsUtils.loadFilterOptions(control.getViewProperties().parentView(), control.getViewProperties().calculator()));
             filterOptionsPopup.filterOptionsProperty().addListener(changeListener);
 
             // publish event to refresh the navigator
@@ -311,113 +302,8 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
         });
     }
 
-    private FilterOptions loadFilterOptions(KLSearchControl control) {
-        FilterOptions filterOptions = new FilterOptions();
 
-        // get parent menu settings
-        ObservableCoordinate parentView = control.getViewProperties().parentView();
-        for (ObservableCoordinate<?> observableCoordinate : parentView.getCompositeCoordinates()) {
-            if (observableCoordinate instanceof ObservableStampCoordinate observableStampCoordinate) {
 
-                // populate the TYPE; this isn't in the parent view coordinate
-                // it is All | Concepts | Semantics
-                filterOptions.getType().selectedOptions().clear();
-                filterOptions.getType().selectedOptions().addAll(new ArrayList<>(List.of("Concepts", "Semantics")));
-                filterOptions.getType().defaultOptions().clear();
-                filterOptions.getType().defaultOptions().addAll(filterOptions.getType().selectedOptions());
-
-                // populate the STATUS
-                StateSet currentStates = observableStampCoordinate.allowedStatesProperty().getValue();
-                List<String> currentStatesStr = currentStates.toEnumSet().stream().map(s -> s.name()).toList();
-
-                filterOptions.getStatus().selectedOptions().clear();
-                filterOptions.getStatus().selectedOptions().addAll(currentStatesStr);
-
-                filterOptions.getStatus().availableOptions().clear();
-                filterOptions.getStatus().availableOptions().addAll(ALL_STATES);
-
-                filterOptions.getStatus().defaultOptions().clear();
-                filterOptions.getStatus().defaultOptions().addAll(currentStatesStr);
-
-                // MODULE
-                filterOptions.getModule().defaultOptions().clear();
-                observableStampCoordinate.moduleNids().intStream().forEach(moduleNid -> {
-                    String moduleStr = control.getViewProperties().calculator().getPreferredDescriptionStringOrNid(moduleNid);
-                    filterOptions.getModule().defaultOptions().add(moduleStr);
-                });
-
-                // populate the PATH
-                ConceptFacade currentPath = observableStampCoordinate.pathConceptProperty().getValue();
-                String currentPathStr = currentPath.description();
-
-                List<String> defaultSelectedPaths = new ArrayList(List.of(currentPathStr));
-                filterOptions.getPath().defaultOptions().clear();
-                filterOptions.getPath().defaultOptions().addAll(defaultSelectedPaths);
-
-                filterOptions.getPath().selectedOptions().clear();
-                filterOptions.getPath().selectedOptions().addAll(defaultSelectedPaths);
-
-                // TIME
-                filterOptions.getDate().defaultOptions().clear();
-                filterOptions.getDate().selectedOptions().clear();
-
-                Long time = observableStampCoordinate.timeProperty().getValue();
-                if (time.equals(Long.MAX_VALUE)) {
-                    filterOptions.getDate().selectedOptions().add("Latest");
-                } else if (time.equals(PREMUNDANE_TIME)) {
-                    //FIXME the custom control doesn't support premundane yet
-                    filterOptions.getDate().selectedOptions().add("Latest");
-                } else {
-                    Date date = new Date(time);
-                    filterOptions.getDate().selectedOptions().add(simpleDateFormat.format(date));
-                }
-                filterOptions.getDate().defaultOptions().addAll(filterOptions.getDate().selectedOptions());
-            } else if (observableCoordinate instanceof ObservableLanguageCoordinate observableLanguageCoordinate) {
-                // populate the LANGUAGE
-                filterOptions.getLanguage().defaultOptions().clear();
-                String languageStr = control.getViewProperties().calculator().languageCalculator().getPreferredDescriptionTextWithFallbackOrNid(
-                        observableLanguageCoordinate.languageConceptProperty().get().nid());
-                filterOptions.getLanguage().defaultOptions().add(languageStr);
-                filterOptions.getLanguage().selectedOptions().clear();
-                filterOptions.getLanguage().selectedOptions().addAll(filterOptions.getLanguage().defaultOptions());
-
-                filterOptions.getDescription().selectedOptions().add("All");
-                filterOptions.getDescription().defaultOptions().addAll(filterOptions.getDescription().selectedOptions());
-            }
-        }
-
-        // set values for 'Kind Of'
-        filterOptions.getKindOf().defaultOptions().clear();
-        filterOptions.getKindOf().defaultOptions().add("All");
-        filterOptions.getKindOf().selectedOptions().addAll(filterOptions.getKindOf().defaultOptions());
-
-        // membership
-        filterOptions.getMembership().defaultOptions().clear();
-        filterOptions.getMembership().defaultOptions().add("All");
-        filterOptions.getMembership().selectedOptions().addAll(filterOptions.getMembership().defaultOptions());
-
-        // sort by
-        filterOptions.getSortBy().defaultOptions().clear();
-
-        //TODO Description Type
-
-        return filterOptions;
-    }
-
-    private long getMillis(FilterOptions newFilterOptions) {
-        int lastElementIndex = newFilterOptions.getDate().selectedOptions().size() - 1;
-        String newDate = newFilterOptions.getDate().selectedOptions().get(lastElementIndex);
-
-        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy");
-        Date date;
-        try {
-            date = sdf.parse(newDate);
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
-        long millis = date.getTime();
-        return millis;
-    }
 
     /** {@inheritDoc} **/
     @Override

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/LangFilterTitledPaneSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/LangFilterTitledPaneSkin.java
@@ -1,0 +1,735 @@
+package dev.ikm.komet.kview.controls.skin;
+
+import dev.ikm.komet.kview.controls.FilterOptionsPopup;
+import dev.ikm.komet.kview.controls.LangFilterTitledPane;
+import dev.ikm.komet.kview.controls.FilterOptions;
+import dev.ikm.komet.kview.controls.IconRegion;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.css.PseudoClass;
+import javafx.geometry.Bounds;
+import javafx.scene.Parent;
+import javafx.scene.control.Accordion;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.control.skin.TitledPaneSkin;
+import javafx.scene.image.Image;
+import javafx.scene.image.WritableImage;
+import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.input.TransferMode;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.RowConstraints;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.shape.Line;
+import javafx.stage.Window;
+import javafx.util.Subscription;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.ResourceBundle;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+public class LangFilterTitledPaneSkin extends TitledPaneSkin {
+
+    private static final ResourceBundle resources = ResourceBundle.getBundle("dev.ikm.komet.kview.controls.filter-options");
+    private static final String STYLE_SHEETS = FilterOptionsPopup.class.getResource("filter-options-popup.css").toExternalForm();
+    private static final PseudoClass MODIFIED_TITLED_PANE = PseudoClass.getPseudoClass("modified");
+
+    private final Region arrow;
+    private final VBox titleVBox;
+    private final StackPane revertButton;
+    private final LangGridPane selectedOptionPane;
+    private final LangContentBox contentBox;
+    private final LangFilterTitledPane control;
+    private Subscription subscription;
+    private ScrollPane scrollPane;
+    private FilterOptions.LanguageCoordinates currentLangCoordinates;
+
+    public LangFilterTitledPaneSkin(LangFilterTitledPane control) {
+        super(control);
+        this.control = control;
+
+        Label titleLabel = new Label(control.getText(), new IconRegion("circle"));
+        titleLabel.textProperty().bind(control.titleProperty());
+        titleLabel.getStyleClass().add("title-label");
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        revertButton = new StackPane(new IconRegion("icon", "revert"));
+        revertButton.setDisable(true);
+        revertButton.addEventFilter(MouseEvent.MOUSE_RELEASED, e -> {
+            if (!revertButton.isDisable()) {
+                control.setLangCoordinates(control.getDefaultLangCoordinates().copy());
+                e.consume();
+            }
+        });
+        revertButton.getStyleClass().add("revert-pane");
+
+        HBox titleHBox = new HBox(titleLabel, spacer, revertButton);
+        titleHBox.getStyleClass().add("title-hbox");
+
+        selectedOptionPane = new LangGridPane();
+        selectedOptionPane.getStyleClass().add("grid-option");
+
+        titleVBox = new VBox(titleHBox, selectedOptionPane);
+        titleVBox.getStyleClass().add("title-box");
+        control.setGraphic(titleVBox);
+
+        Region titleRegion = (Region) control.lookup(".title");
+        arrow = (Region) titleRegion.lookup(".arrow-button");
+
+        arrow.translateXProperty().bind(titleRegion.widthProperty().subtract(arrow.widthProperty().add(arrow.layoutXProperty())));
+        arrow.translateYProperty().bind(titleVBox.layoutYProperty().subtract(arrow.layoutYProperty()));
+        titleVBox.translateXProperty().bind(arrow.widthProperty().multiply(-1));
+
+        contentBox = new LangContentBox();
+        control.setContent(contentBox);
+
+        if (control.getParent() instanceof Accordion accordion) {
+            Parent parent = accordion.getParent();
+            while (!(parent instanceof ScrollPane)) {
+                parent = parent.getParent();
+            }
+
+            scrollPane = (ScrollPane) parent;
+        }
+
+        control.setOnContextMenuRequested(_ -> {
+            if (currentLangCoordinates.getOrdinal() == 0) {
+                return;
+            }
+            DeleteContextMenu contextMenu = new DeleteContextMenu(() -> {
+                if (control.getParent() instanceof Accordion accordion) {
+                    accordion.getPanes().remove(control);
+                }
+            });
+            Bounds bounds = control.localToScreen(control.getLayoutBounds());
+            contextMenu.show(control.getScene().getWindow(), bounds.getMaxX(), bounds.getMinY());
+        });
+
+        setupTitledPane();
+    }
+
+    private void setupTitledPane() {
+        if (subscription != null) {
+            subscription.unsubscribe();
+        }
+
+        FilterOptions.LanguageCoordinates langCoordinates = control.getLangCoordinates();
+
+        currentLangCoordinates = langCoordinates == null ? null : langCoordinates.copy();
+        selectedOptionPane.setLangOption(currentLangCoordinates);
+        contentBox.setLangOption(currentLangCoordinates);
+
+        subscription = Subscription.EMPTY;
+
+        subscription = subscription.and(control.heightProperty().subscribe(_ -> {
+            if (control.isExpanded()) {
+                scrollPane.setVvalue(scrollPane.getVmax()); // TODO: make sure this titlePane is visible
+            }
+        }));
+
+        // confirm changes
+        subscription = subscription.and(control.expandedProperty().subscribe((_, expanded) -> {
+            if (!expanded) {
+                currentLangCoordinates = contentBox.getLangCoordinates().copy();
+                control.setLangCoordinates(currentLangCoordinates.copy());
+                boolean modified = !Objects.equals(currentLangCoordinates, control.getDefaultLangCoordinates());
+                pseudoClassStateChanged(MODIFIED_TITLED_PANE, modified);
+                revertButton.setDisable(!modified);
+            }
+        }));
+
+        subscription = subscription.and(control.langCoordinatesProperty().subscribe((_, _) -> setupTitledPane()));
+    }
+
+    @Override
+    public void dispose() {
+        arrow.translateXProperty().unbind();
+        arrow.translateYProperty().unbind();
+        titleVBox.translateXProperty().unbind();
+        if (subscription != null) {
+            subscription.unsubscribe();
+        }
+        super.dispose();
+    }
+
+    private static class LangGridPane extends GridPane {
+
+        private final Label langOption;
+        private final Label dialectOption;
+        private final Label patternOption;
+        private final Label descriptionOption;
+        private final BooleanProperty initialized = new SimpleBooleanProperty();
+
+        public LangGridPane() {
+            Label langLabel = new Label(resources.getString("language.option.title"));
+            langLabel.getStyleClass().add("title-label");
+            add(langLabel, 0, 0);
+
+            Region line1 = new Region();
+            line1.getStyleClass().add("line");
+            add(line1, 0, 1, 2, 1);
+
+            Label dialectLabel = new Label(resources.getString("dialect.option.title"));
+            dialectLabel.getStyleClass().add("title-label");
+            add(dialectLabel, 0, 2);
+
+            Region line2 = new Region();
+            line2.getStyleClass().add("line");
+            add(line2, 0, 3, 2, 1);
+
+            Label patternLabel = new Label(resources.getString("pattern.option.title"));
+            patternLabel.getStyleClass().add("title-label");
+            add(patternLabel, 0, 4);
+
+            Region line3 = new Region();
+            line3.getStyleClass().add("line");
+            add(line3, 0, 5, 2, 1);
+
+            Label descriptionLabel = new Label(resources.getString("description.option.title"));
+            descriptionLabel.getStyleClass().add("title-label");
+            add(descriptionLabel, 0, 6);
+
+            Region line4 = new Region();
+            line4.getStyleClass().add("line");
+            add(line4, 0, 7, 2, 1);
+
+            langOption = new Label();
+            langOption.getStyleClass().add("option-label");
+            add(langOption, 1, 0);
+
+            dialectOption = new Label();
+            dialectOption.getStyleClass().add("option-label");
+            add(dialectOption, 1, 2);
+
+            patternOption = new Label();
+            patternOption.getStyleClass().add("option-label");
+            add(patternOption, 1, 4);
+
+            descriptionOption = new Label();
+            descriptionOption.getStyleClass().add("option-label");
+            add(descriptionOption, 1, 6);
+
+            initialized.subscribe(v -> {
+                dialectOption.setVisible(v);
+                dialectOption.setManaged(v);
+                patternOption.setVisible(v);
+                patternOption.setManaged(v);
+                descriptionOption.setVisible(v);
+                descriptionOption.setManaged(v);
+            });
+            ColumnConstraints columnConstraints1 = new ColumnConstraints();
+            columnConstraints1.setMinWidth(80);
+            columnConstraints1.setPrefWidth(80);
+            columnConstraints1.setMaxWidth(80);
+            getColumnConstraints().add(columnConstraints1);
+            ColumnConstraints columnConstraints2 = new ColumnConstraints();
+            columnConstraints2.setFillWidth(true);
+            columnConstraints2.setHgrow(Priority.ALWAYS);
+            getColumnConstraints().add(columnConstraints2);
+
+            RowConstraints rowConstraints1 = new RowConstraints();
+            rowConstraints1.setMinHeight(20);
+            rowConstraints1.setVgrow(Priority.SOMETIMES);
+            RowConstraints rowConstraints2 = new RowConstraints();
+            rowConstraints2.setPrefHeight(9);
+            rowConstraints2.setVgrow(Priority.NEVER);
+            RowConstraints rowConstraints3 = new RowConstraints();
+            rowConstraints3.setMinHeight(20);
+            rowConstraints3.setVgrow(Priority.SOMETIMES);
+            RowConstraints rowConstraints4 = new RowConstraints();
+            rowConstraints4.setPrefHeight(9);
+            rowConstraints4.setVgrow(Priority.NEVER);
+            RowConstraints rowConstraints5 = new RowConstraints();
+            rowConstraints5.setMinHeight(20);
+            rowConstraints5.setVgrow(Priority.SOMETIMES);
+            RowConstraints rowConstraints6 = new RowConstraints();
+            rowConstraints6.setPrefHeight(9);
+            rowConstraints6.setVgrow(Priority.NEVER);
+            RowConstraints rowConstraints7 = new RowConstraints();
+            rowConstraints7.setMinHeight(20);
+            rowConstraints7.setVgrow(Priority.SOMETIMES);
+            RowConstraints rowConstraints8 = new RowConstraints();
+            rowConstraints8.setPrefHeight(9);
+            rowConstraints8.setVgrow(Priority.NEVER);
+
+            getRowConstraints().addAll(
+                    rowConstraints1, rowConstraints2,
+                    rowConstraints3, rowConstraints4,
+                    rowConstraints5, rowConstraints6,
+                    rowConstraints7, rowConstraints8
+            );
+
+        }
+
+        // langOptionProperty
+        private final ObjectProperty<FilterOptions.LanguageCoordinates> langOptionProperty = new SimpleObjectProperty<>(this, "langOption") {
+            @Override
+            protected void invalidated() {
+                FilterOptions.LanguageCoordinates languageOptions = get();
+                if (languageOptions != null) {
+                    List<String> selectedOptions = languageOptions.getLanguage().selectedOptions();
+                    langOption.setText(selectedOptions.isEmpty() || selectedOptions.getFirst() == null ?
+                        resources.getString("language.option.empty") : selectedOptions.getFirst());
+                    dialectOption.setText(String.join(", ", languageOptions.getDialect().selectedOptions()));
+                    patternOption.setText(languageOptions.getPattern().selectedOptions().isEmpty() ? "" : languageOptions.getPattern().selectedOptions().getFirst());
+                    descriptionOption.setText(String.join(", ", languageOptions.getDescriptionType().selectedOptions()));
+                    initialized.set(!(selectedOptions.isEmpty() || selectedOptions.getFirst() == null));
+                } else {
+                    initialized.set(false);
+                    langOption.setText(null);
+                    dialectOption.setText(null);
+                    patternOption.setText(null);
+                    descriptionOption.setText(null);
+                }
+            }
+        };
+        public final ObjectProperty<FilterOptions.LanguageCoordinates> langOptionProperty() {
+            return langOptionProperty;
+        }
+        public final FilterOptions.LanguageCoordinates getLangOption() {
+            return langOptionProperty.get();
+        }
+        public final void setLangOption(FilterOptions.LanguageCoordinates value) {
+            langOptionProperty.set(value);
+        }
+
+    }
+
+    private static class LangContentBox extends VBox {
+
+        private static final int MAX_ORDER = 5;
+        private static final PseudoClass PROMPT_PSEUDO_CLASS = PseudoClass.getPseudoClass("prompt");
+
+        private final ComboBox<String> comboBox;
+
+        private final SortedBox dialectBox;
+        private final VBox patternBox;
+        private final ToggleGroup patternGroup;
+        private final SortedBox descriptionBox;
+        private List<String> disabledLanguages;
+        private final BooleanProperty initialized = new SimpleBooleanProperty();
+
+        public LangContentBox() {
+            Label langLabel = new Label(resources.getString("language.option.title"));
+            langLabel.getStyleClass().add("title-label");
+
+            comboBox = new ComboBox<>();
+            comboBox.getStyleClass().add("lang-combo-box");
+            comboBox.setPromptText(resources.getString("language.option.prompt"));
+            comboBox.valueProperty().subscribe(v -> {
+                comboBox.pseudoClassStateChanged(PROMPT_PSEUDO_CLASS, v == null);
+                initialized.set(v != null);
+            });
+            comboBox.setCellFactory(_ -> new ListCell<>() {
+                private final Label label;
+                private final HBox box;
+                {
+                    label = new Label();
+                    Region spacer = new Region();
+                    HBox.setHgrow(spacer, Priority.ALWAYS);
+                    StackPane region = new StackPane(new IconRegion("icon", "check"));
+                    region.getStyleClass().add("region");
+                    box = new HBox(label, spacer, region);
+                    box.getStyleClass().add("box");
+                    setText(null);
+                }
+
+                @Override
+                protected void updateItem(String item, boolean empty) {
+                    super.updateItem(item, empty);
+                    if (item != null && !empty) {
+                        label.setText(item);
+                        setGraphic(box);
+                        if (disabledLanguages != null) {
+                            setDisable(disabledLanguages.contains(item));
+                        } else {
+                            setDisable(false);
+                        }
+                    } else {
+                        setGraphic(null);
+                    }
+                }
+            });
+
+            Region line1 = new Region();
+            line1.getStyleClass().add("line");
+
+            Label dialectLabel = new Label(resources.getString("dialect.option.title"));
+            dialectLabel.getStyleClass().add("title-label");
+
+            dialectBox = new SortedBox();
+            dialectBox.getStyleClass().add("sorted-toggle-box");
+
+            Region line2 = new Region();
+            line2.getStyleClass().add("line");
+
+            Label patternLabel = new Label(resources.getString("pattern.option.title"));
+            patternLabel.getStyleClass().add("title-label");
+
+            patternBox = new VBox();
+            patternBox.getStyleClass().add("option-toggle-box");
+            patternGroup = new ToggleGroup();
+
+            Region line3 = new Region();
+            line3.getStyleClass().add("line");
+
+            Label descriptionLabel = new Label(resources.getString("description.option.title"));
+            descriptionLabel.getStyleClass().add("title-label");
+
+            descriptionBox = new SortedBox();
+            descriptionBox.getStyleClass().add("sorted-toggle-box");
+
+            getChildren().addAll(
+                    langLabel, comboBox, line1,
+                    dialectLabel, dialectBox, line2,
+                    patternLabel, patternBox, line3,
+                    descriptionLabel, descriptionBox);
+            getStyleClass().add("content-box");
+
+            initialized.subscribe(v -> {
+                dialectBox.setVisible(v);
+                dialectBox.setManaged(v);
+                patternBox.setVisible(v);
+                patternBox.setManaged(v);
+                descriptionBox.setVisible(v);
+                descriptionBox.setManaged(v);
+            });
+        }
+
+        // langOptionProperty
+        private final ObjectProperty<FilterOptions.LanguageCoordinates> langOptionProperty = new SimpleObjectProperty<>(this, "langOption") {
+            @Override
+            protected void invalidated() {
+                FilterOptions.LanguageCoordinates languageOptions = get();
+                if (languageOptions != null) {
+                    comboBox.setItems(FXCollections.observableArrayList(languageOptions.getLanguage().availableOptions()));
+                    disabledLanguages = new ArrayList<>(languageOptions.getLanguage().excludedOptions());
+                    comboBox.setValue(languageOptions.getLanguage().selectedOptions().isEmpty() ?
+                            null : languageOptions.getLanguage().selectedOptions().getFirst());
+
+                    dialectBox.setOption(languageOptions.getDialect());
+                    patternBox.getChildren().clear();
+                    patternBox.getChildren().addAll(languageOptions.getPattern().availableOptions().stream()
+                            .map(s -> {
+                                ToggleButton tb = new ToggleButton(s, new IconRegion("check"));
+                                tb.selectedProperty().subscribe((_, selected) -> {
+                                    if (selected) {
+                                        patternGroup.getToggles().stream()
+                                                .filter(t -> t != tb)
+                                                .forEach(t -> t.setSelected(false));
+                                    }
+                                });
+                                tb.getStyleClass().add("option-toggle");
+                                tb.setToggleGroup(patternGroup);
+                                tb.setSelected(!languageOptions.getPattern().selectedOptions().isEmpty() &&
+                                        s.equals(languageOptions.getPattern().selectedOptions().getFirst()));
+                                return tb;
+                            })
+                            .toList());
+                    descriptionBox.setOption(languageOptions.getDescriptionType());
+                } else {
+                    comboBox.setValue(null);
+                    disabledLanguages = null;
+                    comboBox.getItems().clear();
+                    dialectBox.setOption(null);
+                    patternBox.getChildren().clear();
+                    descriptionBox.setOption(null);
+                }
+            }
+        };
+        public final ObjectProperty<FilterOptions.LanguageCoordinates> langOptionProperty() {
+            return langOptionProperty;
+        }
+        public final FilterOptions.LanguageCoordinates getLangOption() {
+            return langOptionProperty.get();
+        }
+        public final void setLangOption(FilterOptions.LanguageCoordinates value) {
+            langOptionProperty.set(value);
+        }
+
+        public FilterOptions.LanguageCoordinates getLangCoordinates() {
+            FilterOptions.LanguageCoordinates languageCoordinates = getLangOption().copy();
+
+            languageCoordinates.getLanguage().selectedOptions().clear();
+            languageCoordinates.getLanguage().selectedOptions().add(comboBox.getSelectionModel().getSelectedItem());
+
+            languageCoordinates.getDialect().selectedOptions().clear();
+            languageCoordinates.getDialect().selectedOptions().addAll(dialectBox.getSelection());
+
+            languageCoordinates.getPattern().selectedOptions().clear();
+            languageCoordinates.getPattern().selectedOptions().add(((ToggleButton) patternGroup.getSelectedToggle()).getText());
+
+            languageCoordinates.getDescriptionType().selectedOptions().clear();
+            languageCoordinates.getDescriptionType().selectedOptions().addAll(descriptionBox.getSelection());
+
+            return languageCoordinates;
+        }
+    }
+
+    private static class SortedBox extends VBox {
+
+        private boolean lock;
+
+        public SortedBox() {
+        }
+
+        // optionProperty
+        private final ObjectProperty<FilterOptions.Option> optionProperty = new SimpleObjectProperty<>(this, "option") {
+            @Override
+            protected void invalidated() {
+                setupBox(get());
+            }
+        };
+        public final ObjectProperty<FilterOptions.Option> optionProperty() {
+           return optionProperty;
+        }
+        public final FilterOptions.Option getOption() {
+           return optionProperty.get();
+        }
+        public final void setOption(FilterOptions.Option value) {
+            optionProperty.set(value);
+        }
+
+        public List<String> getSelection() {
+            return getChildren().stream()
+                    .filter(OrderedToggleBox.class::isInstance)
+                    .map(OrderedToggleBox.class::cast)
+                    .filter(OrderedToggleBox::isSelected)
+                    .map(OrderedToggleBox::getDialect)
+                    .toList();
+        }
+
+        private void setupBox(FilterOptions.Option option) {
+            if (lock) {
+                return;
+            }
+            getChildren().clear();
+            if (option == null) {
+                return;
+            }
+            lock = true;
+            AtomicInteger counter = new AtomicInteger();
+            List<String> selected = option.selectedOptions().stream().toList();
+            List<String> rest = new ArrayList<>(option.availableOptions().stream().toList());
+            rest.removeAll(selected);
+
+            getChildren().addAll(
+                    selected.stream()
+                            .map(name -> {
+                                int index = counter.getAndIncrement();
+                                OrderedToggleBox orderedToggleBox = new OrderedToggleBox(index, name,
+                                        d -> {
+                                            option.selectedOptions().remove(d);
+                                            option.selectedOptions().add(index, d);
+                                            setOption(option.copy());
+                                        });
+                                orderedToggleBox.setSelected(true);
+                                orderedToggleBox.selectedProperty().subscribe((_, s) -> {
+                                   if (!s) {
+                                       option.selectedOptions().remove(name);
+                                       setOption(option.copy());
+                                   }
+                                });
+                                return orderedToggleBox;
+                            })
+                            .toList());
+            if (!selected.isEmpty() && !rest.isEmpty()) {
+                Region line = new Region();
+                HBox.setHgrow(line, Priority.ALWAYS);
+                line.getStyleClass().add("line");
+
+                HBox box = new HBox(line);
+                box.getStyleClass().add("box");
+
+                getChildren().add(box);
+            }
+            if (!rest.isEmpty()) {
+                getChildren().addAll(
+                        rest.stream()
+                                .map(name -> {
+                                    OrderedToggleBox orderedToggleBox = new OrderedToggleBox(-1, name, null);
+                                    orderedToggleBox.selectedProperty().subscribe((_, s) -> {
+                                        if (s) {
+                                            option.selectedOptions().add(name);
+                                            setOption(option.copy());
+                                        }
+                                    });
+                                    return orderedToggleBox;
+                                })
+                                .toList());
+            }
+            lock = false;
+        }
+    }
+
+    private static class OrderedToggleBox extends HBox {
+
+        private static final PseudoClass SELECTED_PSEUDO_CLASS = PseudoClass.getPseudoClass("selected");
+        private static final String DRAG_KEY = "DraggedOrderedToggleBox";
+        private final String dialect;
+        private final Label orderLabel;
+        private boolean dragging;
+
+        public OrderedToggleBox(int order, String dialect, Consumer<String> onDragged) {
+            this.dialect = dialect;
+            orderLabel = new Label();
+            orderLabel.getStyleClass().add("order-label");
+
+            Line dottedLine = new Line(0, 0, 16, 0);
+            dottedLine.getStyleClass().add("dotted-line");
+
+            addEventHandler(MouseEvent.MOUSE_PRESSED, _ -> dragging = false);
+            addEventHandler(MouseEvent.MOUSE_DRAGGED, _ -> dragging = true);
+            addEventHandler(MouseEvent.MOUSE_RELEASED, _ -> {
+                if (!dragging) {
+                    setSelected(!isSelected());
+                }
+            });
+
+            ToggleButton toggleButton = new ToggleButton(dialect, new IconRegion("check"));
+            toggleButton.setMouseTransparent(true);
+            toggleButton.getStyleClass().add("option-toggle");
+            selectedProperty.bindBidirectional(toggleButton.selectedProperty());
+
+            StackPane dragPane = new StackPane(new IconRegion("icon", "drag"));
+            dragPane.getStyleClass().add("drag-pane");
+
+            Region spacer = new Region();
+            HBox.setHgrow(spacer, Priority.ALWAYS);
+            getChildren().addAll(orderLabel, dottedLine, toggleButton, spacer, dragPane);
+            getStyleClass().add("ordered-toggle-box");
+
+            setOnDragOver(e -> {
+                Dragboard dragboard = e.getDragboard();
+                if (dragboard.hasString() && DRAG_KEY.equals(dragboard.getString())) {
+                    e.acceptTransferModes(TransferMode.MOVE);
+                    e.consume();
+                }
+            });
+            setOnDragDropped(e -> {
+                Dragboard dragboard = e.getDragboard();
+                boolean success = false;
+                if (dragboard.hasString() && DRAG_KEY.equals(dragboard.getString())) {
+                    OrderedToggleBox gestureSource = (OrderedToggleBox) e.getGestureSource();
+                    if (onDragged != null) {
+                        onDragged.accept(gestureSource.dialect);
+                    }
+                    success = true;
+                }
+                e.setDropCompleted(success);
+                e.consume();
+            });
+            setOnDragDetected(e -> {
+                if (!isSelected()) {
+                    return;
+                }
+                Dragboard dragboard = startDragAndDrop(TransferMode.MOVE);
+                ClipboardContent content = new ClipboardContent();
+                content.putString(DRAG_KEY);
+                dragboard.setContent(content);
+                Image snapshot = createSnapshot();
+                dragboard.setDragView(snapshot);
+                dragboard.setDragViewOffsetX(e.getX());
+                dragboard.setDragViewOffsetY(e.getY());
+                e.consume();
+            });
+            setOrder(order);
+        }
+
+        // orderProperty
+        private final IntegerProperty orderProperty = new SimpleIntegerProperty(this, "order", -1) {
+            @Override
+            protected void invalidated() {
+                int order = get();
+                if (order >= 0 && order < LangContentBox.MAX_ORDER) {
+                    orderLabel.setText(resources.getString("dialect.order.item" + (order + 1)));
+                } else {
+                    orderLabel.setText(null);
+                }
+            }
+        };
+        public final IntegerProperty orderProperty() {
+           return orderProperty;
+        }
+        public final int getOrder() {
+           return orderProperty.get();
+        }
+        public final void setOrder(int value) {
+            orderProperty.set(value);
+        }
+
+        // selectedProperty
+        private final BooleanProperty selectedProperty = new SimpleBooleanProperty(this, "selected") {
+            @Override
+            protected void invalidated() {
+                pseudoClassStateChanged(SELECTED_PSEUDO_CLASS, get());
+            }
+        };
+        public final BooleanProperty selectedProperty() {
+           return selectedProperty;
+        }
+        public final boolean isSelected() {
+           return selectedProperty.get();
+        }
+        public final void setSelected(boolean value) {
+            selectedProperty.set(value);
+        }
+
+        public String getDialect() {
+            return dialect;
+        }
+
+        private Image createSnapshot() {
+            getStyleClass().add("snapshot");
+            WritableImage snapshot = snapshot(null, null);
+            getStyleClass().remove("snapshot");
+            return snapshot;
+        }
+    }
+
+    private static class DeleteContextMenu extends ContextMenu {
+
+        public DeleteContextMenu(Runnable runnable) {
+            setAutoHide(true);
+
+            MenuItem menuItem = new MenuItem(resources.getString("language.menu.remove"), new IconRegion("icon", "delete"));
+            menuItem.setOnAction(_ -> {
+                if (runnable != null) {
+                    runnable.run();
+                }
+            });
+            getItems().addAll(menuItem);
+        }
+
+        @Override
+        public void show(Window ownerWindow, double anchorX, double anchorY) {
+            super.show(ownerWindow, anchorX, anchorY);
+            if (!getScene().getStylesheets().contains(STYLE_SHEETS)) {
+                getScene().getStylesheets().add(STYLE_SHEETS);
+            }
+        }
+    }
+}

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/filter-options-popup.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/filter-options-popup.css
@@ -220,10 +220,49 @@
 
 /*
  Filter Options Popup - Center
- ScrollPane > Accordion > TitledPane
+ ScrollPane > Accordion > regular TitledPane
 */
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane {
+.filter-options-popup > .scroll-pane .accordion > .titled-pane,
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title {
+    -fx-background-color: transparent;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .text {
+    -fx-fill: #5896F6;
+    -fx-font-family: "Noto Sans";
+    -fx-font-size: 13px;
+    -fx-font-weight: 700;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .arrow-button {
+    -fx-background-color: null;
+    -fx-background-insets: 0;
+    -fx-background-radius: 0;
+    -fx-pref-width: 24;
+    -fx-pref-height: 24;
+    -fx-padding: 4;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .arrow-button > .arrow {
+    -fx-background-color: #5896F6;
+    -fx-background-insets: 0;
+    -fx-scale-shape: false;
+    -fx-shape: "M1.41 0.295078L-2.62268e-07 1.70508L6 7.70508L12 1.70508L10.59 0.295078L6 4.87508L1.41 0.295078Z";
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane:focused > .title > .arrow-button > .arrow {
+    -fx-background-color: #5896F6;
+    -fx-background-insets: 0;
+    -fx-effect: null;
+}
+
+/*
+ Filter Options Popup - Center
+ ScrollPane > Accordion > FilterTitledPane
+*/
+
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane {
     -fx-content-display: graphic-only;
     -fx-background-color: #2E3240, #545D72, #2E3240;
     -fx-background-insets: 0, 0 0 6 0, 1 1 7 1;
@@ -233,20 +272,20 @@
     -fx-padding: 4;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:hover {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:hover {
     -fx-background-color: #2E3240, #4A7AD2, #44495E;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:expanded {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:expanded {
     -fx-padding: 4 4 6 4;
     -fx-background-color: #2E3240, #545D72, #44495E;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:focused {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:focused {
     -fx-color: transparent;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title {
     -fx-background-color: transparent;
     -fx-background-insets: 0;
     -fx-background-radius: 0;
@@ -260,39 +299,39 @@
  ScrollPane > Accordion > TitledPane > TitleBox
 */
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:taller > .title {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:taller > .title {
     -fx-padding: 4 -16 11 8;
     -fx-pref-height: 72;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:taller:expanded > .title,
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:expanded > .title {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:taller:expanded > .title,
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:expanded > .title {
     -fx-padding: 4 -16 0 8;
     -fx-pref-height: 64;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:expanded:single-select > .title {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:expanded:single-select > .title {
     -fx-pref-height: 24;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .title-box {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .title-box {
     -fx-alignment: top-left;
     -fx-spacing: 4;
     -fx-padding: 0;
     -fx-pref-height: 52;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:expanded > .title > .title-box {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:expanded > .title > .title-box {
     -fx-spacing: 6;
     -fx-pref-height: 60;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:expanded:single-select > .title > .title-box {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:expanded:single-select > .title > .title-box {
     -fx-spacing: 6;
     -fx-pref-height: 20;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .title-box > .title-label {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .title-box > .title-label {
     -fx-font-family: "Noto Sans";
     -fx-font-size: 13px;
     -fx-font-style: normal;
@@ -304,11 +343,11 @@
     -fx-alignment: center-left;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:expanded > .title > .title-box > .title-label {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:expanded > .title > .title-box > .title-label {
     -fx-text-fill: #E1E8F1;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .title-box > .title-label > .circle {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .title-box > .title-label > .circle {
     -fx-pref-width: 4;
     -fx-pref-height: 4;
     -fx-background-radius: 4;
@@ -316,41 +355,42 @@
     -fx-translate-y: -6;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:modified > .title > .title-box > .title-label > .circle {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:modified > .title > .title-box > .title-label > .circle {
     -fx-background-color: #F3BE00;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .title-box > .option.truncated-text-flow {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .title-box > .option.truncated-text-flow {
     -fx-managed: true;
     visibility: visible;
+    -fx-max-width: 286;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:expanded > .title > .title-box > .option.truncated-text-flow {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:expanded > .title > .title-box > .option.truncated-text-flow {
     -fx-managed: false;
     visibility: hidden;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .title-box > .option.truncated-text-flow > .text {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .title-box > .option.truncated-text-flow > .text {
     -fx-fill: white;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .title-box > .toggles-box {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .title-box > .toggles-box {
     -fx-managed: false;
     visibility: hidden;
     -fx-spacing: 8;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:expanded > .title > .title-box > .toggles-box {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:expanded > .title > .title-box > .toggles-box {
     -fx-managed: true;
     visibility: visible;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:expanded:single-select > .title > .title-box > .toggles-box {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:expanded:single-select > .title > .title-box > .toggles-box {
     -fx-managed: false;
     visibility: hidden;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .title-box > .toggles-box > .toggle-button {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .title-box > .toggles-box > .toggle-button {
     -fx-background-color: #4A7AD2, white;
     -fx-background-insets: 0, 1;
     -fx-background-radius: 12, 12;
@@ -363,29 +403,29 @@
     -fx-text-fill: #4A7AD2;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .title-box > .toggles-box > .toggle-button:disabled {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .title-box > .toggles-box > .toggle-button:disabled {
     -fx-background-color: #9CAABF, #9CAABF;
     -fx-text-fill: black;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .title-box > .toggles-box > .any-toggle.toggle-button,
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .title-box > .toggles-box > .exclude-toggle.toggle-button {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .title-box > .toggles-box > .any-toggle.toggle-button,
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .title-box > .toggles-box > .exclude-toggle.toggle-button {
     -fx-managed: false;
     visibility: hidden;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .title-box > .toggles-box:any > .any-toggle.toggle-button,
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .title-box > .toggles-box:excluding > .exclude-toggle.toggle-button {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .title-box > .toggles-box:any > .any-toggle.toggle-button,
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .title-box > .toggles-box:excluding > .exclude-toggle.toggle-button {
     -fx-managed: true;
     visibility: visible;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:expanded > .title > .title-box > .toggles-box > .toggle-button:selected {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:expanded > .title > .title-box > .toggles-box > .toggle-button:selected {
     -fx-background-color: #5DCF16, #5DCF16;
     -fx-text-fill: black;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:expanded > .title > .title-box > .toggles-box > .toggle-button > .check {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:expanded > .title > .title-box > .toggles-box > .toggle-button > .check {
     /* 0, 0.08 10x7.83 */
     -fx-pref-width: 10;
     -fx-pref-height: 7.83;
@@ -395,19 +435,19 @@
     visibility: hidden;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:expanded > .title > .title-box > > .toggles-box > .toggle-button:selected > .check {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:expanded > .title > .title-box > > .toggles-box > .toggle-button:selected > .check {
     -fx-managed: true;
     visibility: visible;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .arrow-button {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .arrow-button {
     -fx-padding: 0;
     -fx-rotate: 90;
     -fx-pref-width: 20;
     -fx-pref-height: 20;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .title > .arrow-button > .arrow {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .title > .arrow-button > .arrow {
     -fx-background-color: #5896F6;
     -fx-background-insets: 0;
     -fx-shape: "M8.0876 5L6.9126 6.175L10.7293 10L6.9126 13.825L8.0876 15L13.0876 10L8.0876 5Z";
@@ -420,31 +460,31 @@
  ScrollPane > Accordion > Content
 */
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content {
     -fx-background-color: #44495E;
     -fx-padding: 2;
     -fx-border-color: transparent transparent #545D72 transparent;
     -fx-border-insets: 0;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .content-box {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content > .content-box {
     -fx-spacing: 6;
     -fx-alignment: center-left;
     -fx-padding: 0 6 1 6;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .content-box > .separator-region {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content > .content-box > .separator-region {
     -fx-pref-height: 1;
     -fx-managed: true;
     visibility: visible;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:single-select > .content > .content-box > .separator-region {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:single-select > .content > .content-box > .separator-region {
     -fx-managed: false;
     visibility: hidden;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .content-box > .separator-region > .line {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content > .content-box > .separator-region > .line {
     -fx-background-color: #545D72;
 }
 
@@ -453,13 +493,13 @@
  ScrollPane > Accordion > TitledPane > Content > OptionToggle
 */
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .content-box > .option-toggle-box {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content > .content-box > .option-toggle-box {
     -fx-spacing: 8;
     -fx-alignment: center-left;
     -fx-cursor: hand;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .content-box > .option-toggle-box > .option-toggle {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content > .content-box > .option-toggle-box > .option-toggle {
     -fx-background-color: #4A7AD2, white;
     -fx-background-insets: 0, 1;
     -fx-background-radius: 12, 12;
@@ -472,17 +512,17 @@
     -fx-text-fill: #4A7AD2;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .content-box > .option-toggle-box > .option-toggle:selected {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content > .content-box > .option-toggle-box > .option-toggle:selected {
     -fx-background-color: #5DCF16, #5DCF16;
     -fx-text-fill: black;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .content-box > .option-toggle-box > .option-toggle:disabled {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content > .content-box > .option-toggle-box > .option-toggle:disabled {
     -fx-background-color: #9CAABF, #9CAABF;
     -fx-text-fill: black;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .content-box > .option-toggle-box > .option-toggle > .check {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content > .content-box > .option-toggle-box > .option-toggle > .check {
     /* 0, 0.08 10x7.83 */
     -fx-pref-width: 10;
     -fx-pref-height: 7.83;
@@ -492,12 +532,12 @@
     visibility: hidden;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .content-box > .option-toggle-box > .option-toggle:selected > .check {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content > .content-box > .option-toggle-box > .option-toggle:selected > .check {
     -fx-managed: true;
     visibility: visible;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .content-box > .option-toggle-box > .option-check {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content > .content-box > .option-toggle-box > .option-check {
     -fx-background-color: #F1F3F8, #44495E;
     -fx-background-insets: 0, 2;
     -fx-background-radius: 2, 0;
@@ -511,12 +551,12 @@
     visibility: hidden;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .content-box > .option-toggle-box:excluded > .option-check {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content > .content-box > .option-toggle-box:excluded > .option-check {
     -fx-managed: true;
     visibility: visible;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .content-box > .option-toggle-box > .option-check > .cross {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane > .content > .content-box > .option-toggle-box > .option-check > .cross {
     -fx-background-color: #5DCF16;
     -fx-scale-shape: false;
     -fx-shape: "M10.361 9 14.354 12.993 12.993 14.354 9 10.361 5.007 14.354 3.646 12.993 7.639 9 3.646 5.007 5.007 3.646 9 7.639 12.993 3.646 14.354 5.007 10.361 9Z";
@@ -527,22 +567,22 @@
  ScrollPane > Accordion > DateFilterTitledPane
 */
 
-.filter-options-popup > .scroll-pane .accordion > .titled-pane:selected > .title {
+.filter-options-popup > .scroll-pane .accordion > .filter-titled-pane.titled-pane:selected > .title {
     -fx-padding: 4 -16 8 8;
     -fx-pref-height: 68;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .title > .title-box > .option.truncated-text-flow {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .title > .title-box > .option.truncated-text-flow {
     -fx-managed: true;
     visibility: visible;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane:selected > .title > .title-box > .option.truncated-text-flow {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane:selected > .title > .title-box > .option.truncated-text-flow {
     -fx-managed: false;
     visibility: hidden;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .title > .title-box > .date-combo-box {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .title > .title-box > .date-combo-box {
     -fx-font-size: 14;
     -fx-text-base-color: #2E3240;
     -fx-text-fill: #2E3240;
@@ -560,40 +600,40 @@
     visibility: hidden;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane:selected > .title > .title-box > .date-combo-box {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane:selected > .title > .title-box > .date-combo-box {
     -fx-managed: true;
     visibility: visible;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .title > .title-box > .date-combo-box > .arrow-button {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .title > .title-box > .date-combo-box > .arrow-button {
     -fx-rotate: -90;
     transition-property: -fx-rotate;
     transition-duration: 0.5s;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .title > .title-box > .date-combo-box:showing > .arrow-button {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .title > .title-box > .date-combo-box:showing > .arrow-button {
     -fx-rotate: 0;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .title > .title-box > .date-combo-box > .arrow-button > .arrow {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .title > .title-box > .date-combo-box > .arrow-button > .arrow {
     -fx-shape: "M7.41 8.29508L6 9.70508L12 15.7051L18 9.70508L16.59 8.29508L12 12.8751L7.41 8.29508Z";
     -fx-background-color: #4277D8;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .content {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .content {
     -fx-padding: -6 2 2 2;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .content > .content-box {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .content > .content-box {
     -fx-spacing: 8;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .content > .content-box > .bottom-box {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .content > .content-box > .bottom-box {
     -fx-alignment: center;
     -fx-spacing: 4;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .content > .content-box > .bottom-box > .button {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .content > .content-box > .bottom-box > .button {
     -fx-font-family: "Noto Sans";
     -fx-font-weight: 600;
     -fx-font-size: 12;
@@ -606,27 +646,27 @@
     -fx-min-width: 279;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .content > .content-box > .bottom-box > .button.additional {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .content > .content-box > .bottom-box > .button.additional {
     -fx-text-fill: white;
     -fx-background-color: #4A7AD2, #4A7AD2;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .content > .content-box > .bottom-box > .button:hover {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .content > .content-box > .bottom-box > .button:hover {
     -fx-text-fill: #9DC4FF;
     -fx-background-color: #4A7AD2, #44495E;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .content > .content-box > .bottom-box > .button.additional:hover {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .content > .content-box > .bottom-box > .button.additional:hover {
     -fx-text-fill: white;
     -fx-background-color: #5896F6, #5896F6;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .content > .content-box > .bottom-box > .button:disabled {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .content > .content-box > .bottom-box > .button:disabled {
     -fx-text-fill: #6E7989;
     -fx-background-color: #6E7989, #2E3240;
 }
 
-.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.titled-pane > .content > .content-box > .bottom-box > .button.additional:disabled {
+.filter-options-popup > .scroll-pane .accordion > .date-filter-titled-pane.filter-titled-pane.titled-pane > .content > .content-box > .bottom-box > .button.additional:disabled {
     -fx-text-fill: #CFD8E4;
     -fx-background-color: #6E7989, #6E7989;
 }
@@ -666,6 +706,560 @@
     -fx-text-fill: #9DC4FF;
     -fx-background: #44495E;
     -fx-background-color: #44495E;
+}
+
+/*
+ Filter Options Popup - Center
+ ScrollPane > Accordion > regular TitledPane
+*/
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content {
+    -fx-background-color: #2E3240;
+    -fx-border-width: 0;
+    -fx-padding: 0;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .lang-titled-pane.titled-pane > .title {
+    -fx-padding: 4 0 4 0;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .lang-titled-pane.titled-pane > .title > .title-box {
+    -fx-alignment: center-left;
+    -fx-pref-width: 280;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .lang-titled-pane.titled-pane > .title > .arrow-button {
+    -fx-padding: 0;
+    -fx-rotate: 90;
+    -fx-pref-width: 18;
+    -fx-pref-height: 18;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .lang-titled-pane.titled-pane > .title > .arrow-button > .arrow {
+    -fx-background-color: #5896F6;
+    -fx-background-insets: 0;
+    -fx-shape: "M8.0876 5L6.9126 6.175L10.7293 10L6.9126 13.825L8.0876 15L13.0876 10L8.0876 5Z";
+    -fx-scale-shape: false;
+    -fx-effect: null;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .lang-titled-pane.titled-pane > .title > .title-box > .title-label {
+    -fx-font-family: "Noto Sans";
+    -fx-font-size: 13px;
+    -fx-font-weight: 700;
+    -fx-text-fill: #5896F6;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .lang-titled-pane.titled-pane > .title > .title-box > .add-pane {
+    -fx-pref-width: 18;
+    -fx-pref-height: 18;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .lang-titled-pane.titled-pane > .title > .title-box > .add-pane > .icon.add {
+    -fx-shape: "M9 1.5C4.86675 1.5 1.5 4.86675 1.5 9C1.5 13.1333 4.86675 16.5 9 16.5C13.1333 16.5 16.5 13.1333 16.5 9C16.5 4.86675 13.1333 1.5 9 1.5ZM9 3C12.3226 3 15 5.67741 15 9C15 12.3226 12.3226 15 9 15C5.67741 15 3 12.3226 3 9C3 5.67741 5.67741 3 9 3ZM8.25 5.25V8.25H5.25V9.75H8.25V12.75H9.75V9.75H12.75V8.25H9.75V5.25H8.25Z";
+    -fx-background-color: #5896F6;
+    -fx-scale-shape: false;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .lang-titled-pane.titled-pane > .title > .title-box > .add-pane:disabled > .icon.add {
+    -fx-background-color: #6E7989;
+}
+/*
+ Filter Options Popup - Center
+ ScrollPane > Accordion > TitledPane > Accordion > LangFilterTitledPane
+*/
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane {
+    -fx-content-display: graphic-only;
+    -fx-background-color: #2E3240, #545D72, #2E3240;
+    -fx-background-insets: 0, 0 0 6 0, 1 1 7 1;
+    -fx-background-radius: 0, 4, 4;
+    -fx-min-width: 256;
+    -fx-pref-width: 256;
+    -fx-padding: 0;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane:hover {
+    -fx-background-color: #2E3240, #4A7AD2, #44495E;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane:expanded {
+    -fx-padding: 0 0 6 0;
+    -fx-background-color: #2E3240, #545D72, #44495E;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane:focused {
+    -fx-color: transparent;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title {
+    -fx-background-color: transparent;
+    -fx-background-insets: 0;
+    -fx-background-radius: 0;
+    -fx-padding: 8 0 18 12;
+    -fx-spacing: 2;
+    -fx-pref-height: -1;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane:expanded > .title {
+    -fx-padding: 8 0 4 12;
+    -fx-spacing: 2;
+}
+
+/*
+ Filter Options Popup - Center
+ ScrollPane > Accordion > TitledPane > Accordion > LangFilterTitledPane > TitleBox
+*/
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title > .title-box {
+    -fx-alignment: top-left;
+    -fx-spacing: 4;
+    -fx-padding: 0;
+    -fx-pref-height: -1;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane:expanded > .title > .title-box {
+    -fx-spacing: 4;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title > .title-box > .title-hbox {
+    -fx-alignment: center-left;
+    -fx-pref-width: 298;
+    -fx-padding: 0 10 0 0;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title > .title-box > .title-hbox > .title-label {
+    -fx-font-family: "Noto Sans";
+    -fx-font-size: 12px;
+    -fx-font-style: normal;
+    -fx-font-weight: 600;
+    -fx-text-fill: #4A7AD2;
+    -fx-min-width: 100;
+    -fx-pref-width: 100;
+    -fx-pref-height: 24;
+    -fx-content-display: right;
+    -fx-alignment: center-left;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane:expanded > .title > .title-box > .title-hbox > .title-label {
+    -fx-text-fill: #4A7AD2;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title > .title-box > .title-hbox > .title-label > .circle {
+    -fx-pref-width: 4;
+    -fx-pref-height: 4;
+    -fx-background-radius: 4;
+    -fx-background-color: transparent;
+    -fx-translate-y: -6;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane:modified > .title > .title-box > .title-hbox > .title-label > .circle {
+    -fx-background-color: #F3BE00;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title > .title-box > .title-hbox > .revert-pane {
+    -fx-pref-width: 20;
+    -fx-pref-height: 20;
+    visibility: hidden;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane:expanded > .title > .title-box > .title-hbox > .revert-pane {
+    visibility: visible;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title > .title-box > .title-hbox > .revert-pane > .icon.revert {
+    -fx-shape: "M5.39048 15.4168V13.7502H11.32C12.195 13.7502 12.9553 13.4724 13.6008 12.9168C14.2469 12.3613 14.57 11.6668 14.57 10.8335C14.57 10.0002 14.2469 9.30572 13.6008 8.75016C12.9553 8.19461 12.195 7.91683 11.32 7.91683H6.90334L8.48667 9.50016C8.63945 9.65294 8.71584 9.84738 8.71584 10.0835C8.71584 10.3196 8.63945 10.5141 8.48667 10.6668C8.33389 10.8196 8.13945 10.896 7.90334 10.896C7.66722 10.896 7.47278 10.8196 7.32 10.6668L3.7627 7.07694L7.32 3.50016C7.47278 3.34738 7.66722 3.271 7.90334 3.271C8.13945 3.271 8.33389 3.34738 8.48667 3.50016C8.63945 3.65294 8.71584 3.84738 8.71584 4.0835C8.71584 4.31961 8.63945 4.51405 8.48667 4.66683L6.90334 6.25016H11.32C12.6672 6.25016 13.8236 6.68766 14.7892 7.56266C15.7542 8.43766 16.2367 9.52794 16.2367 10.8335C16.2367 12.1391 15.7542 13.2293 14.7892 14.1043C13.8236 14.9793 12.6672 15.4168 11.32 15.4168H5.39048Z";
+    -fx-background-color: #545D72;
+    -fx-scale-shape: false;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane:modified > .title > .title-box > .title-hbox > .revert-pane > .icon.revert {
+    -fx-background-color: #4A7AD2;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title > .title-box > .grid-option {
+    -fx-managed: true;
+    visibility: visible;
+    -fx-pref-height: 200;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane:expanded > .title > .title-box > .grid-option {
+    -fx-managed: false;
+    visibility: hidden;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title > .title-box > .grid-option > .title-label {
+    -fx-text-fill: #9CAABF;
+    -fx-font-family: "Noto Sans";
+    -fx-font-size: 11px;
+    -fx-font-style: normal;
+    -fx-font-weight: 600;
+    -fx-wrap-text: true;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title > .title-box > .grid-option > .option-label {
+    -fx-text-fill: white;
+    -fx-font-family: "Noto Sans";
+    -fx-font-size: 13px;
+    -fx-font-style: normal;
+    -fx-font-weight: 400;
+    -fx-wrap-text: true;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title > .title-box > .grid-option > .line {
+    -fx-background-color: transparent, #E1E8F1;
+    -fx-background-insets: 0, 4 0 4 0;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title > .arrow-button {
+    -fx-padding: 0;
+    -fx-rotate: 90;
+    -fx-pref-width: 24;
+    -fx-pref-height: 24;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .title > .arrow-button > .arrow {
+    -fx-background-color: #4A7AD2;
+    -fx-background-insets: 0;
+    -fx-shape: "M8.0876 5L6.9126 6.175L10.7293 10L6.9126 13.825L8.0876 15L13.0876 10L8.0876 5Z";
+    -fx-scale-shape: false;
+    -fx-effect: null;
+}
+
+/*
+ Filter Options Popup - Center
+ ScrollPane > Accordion > TitledPane > Accordion > LangFilterTitledPane > Content
+*/
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content {
+    -fx-background-color: transparent;
+    -fx-padding: 8 8 8 12;
+    -fx-border-width: 0;
+    -fx-border-insets: 0;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box {
+    -fx-spacing: 6;
+    -fx-alignment: center-left;
+    -fx-padding: 2;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .title-label {
+    -fx-text-fill: #9CAABF;
+    -fx-font-family: "Noto Sans";
+    -fx-font-size: 13px;
+    -fx-font-weight: 700;
+    -fx-wrap-text: true;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .line {
+    -fx-pref-height: 1;
+    -fx-background-color: #E1E8F1;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .lang-combo-box {
+    -fx-font-size: 14;
+    -fx-text-base-color: #2E3240;
+    -fx-text-fill: #2E3240;
+    -fx-pref-width: 296;
+    -fx-min-height: 28;
+    -fx-pref-height: 28;
+    -fx-font-family: "Noto Sans";
+    -fx-font-style: normal;
+    -fx-font-weight: 500;
+    -fx-background-color: #C3CDDC, #FBFBFC;
+    -fx-background-insets: 0, 1;
+    -fx-background-radius: 4px, 4px;
+    -fx-padding: 0;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .lang-combo-box:prompt {
+    -fx-text-base-color: #6E7989;
+    -fx-text-fill: #6E7989;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .lang-combo-box > .arrow-button {
+    -fx-rotate: -90;
+    transition-property: -fx-rotate;
+    transition-duration: 0.5s;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .lang-combo-box:showing > .arrow-button {
+    -fx-rotate: 0;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .lang-combo-box > .arrow-button > .arrow {
+    -fx-shape: "M7.41 8.29508L6 9.70508L12 15.7051L18 9.70508L16.59 8.29508L12 12.8751L7.41 8.29508Z";
+    -fx-background-color: #4277D8;
+}
+
+.filter-options-popup .lang-combo-box .combo-box-popup > .list-view {
+    -fx-background: #2E3240;
+    -fx-background-color: #2E3240;
+    -fx-background-insets: 0;
+    -fx-background-radius: 8;
+    -fx-border-color: null;
+    -fx-border-width: 0;
+    -fx-translate-y: 5;
+    -fx-padding: 8 0 8 0;
+    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.3), 2, 0.0, 0, 4);
+}
+
+.filter-options-popup .lang-combo-box .combo-box-popup > .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell {
+    -fx-padding: 4 8 4 8;
+    -fx-background: #2E3240;
+    -fx-background-color: #2E3240;
+    -fx-background-insets: 0;
+    -fx-pref-height: 28;
+}
+
+.filter-options-popup .lang-combo-box .combo-box-popup > .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell > .box {
+    -fx-alignment: center-left;
+}
+
+.filter-options-popup .lang-combo-box .combo-box-popup > .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell > .box > .label {
+    -fx-font-size: 13;
+    -fx-text-fill: white;
+    -fx-font-family: "Noto Sans";
+    -fx-font-style: normal;
+    -fx-font-weight: 500;
+}
+
+.filter-options-popup .lang-combo-box .combo-box-popup > .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell > .box > .region {
+    -fx-pref-width: 20;
+    -fx-pref-height: 20;
+    visibility: hidden;
+    -fx-managed: false;
+}
+
+.filter-options-popup .lang-combo-box .combo-box-popup > .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell:selected > .box > .region {
+    visibility: visible;
+    -fx-managed: true;
+}
+
+.filter-options-popup .lang-combo-box .combo-box-popup > .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell > .box > .region > .icon.check {
+    -fx-background-color: #5DCF16;
+    -fx-shape: "M5.49989 9.47487L2.02489 5.99987L0.841553 7.17487L5.49989 11.8332L15.4999 1.8332L14.3249 0.658203L5.49989 9.47487Z";
+    -fx-scale-shape: false;
+}
+
+.filter-options-popup .lang-combo-box .combo-box-popup > .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell:filled:hover {
+    -fx-background: #545D72;
+    -fx-background-color: #545D72;
+}
+
+.filter-options-popup .lang-combo-box .combo-box-popup  > .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell:filled:selected,
+.filter-options-popup .lang-combo-box .combo-box-popup  > .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell:filled:selected:hover {
+    -fx-text-fill: #9DC4FF;
+    -fx-background: #44495E;
+    -fx-background-color: #44495E;
+}
+
+.filter-options-popup .lang-combo-box .combo-box-popup  > .list-view .scroll-bar {
+    -fx-background-color: transparent;
+    -fx-padding: 2px 0 0 0;
+}
+
+.filter-options-popup .lang-combo-box .combo-box-popup  > .list-view .scroll-bar:vertical .increment-button,
+.filter-options-popup .lang-combo-box .combo-box-popup  > .list-view .scroll-bar:vertical .decrement-button,
+.filter-options-popup .lang-combo-box .combo-box-popup  > .list-view .scroll-bar:vertical .increment-arrow,
+.filter-options-popup .lang-combo-box .combo-box-popup  > .list-view .scroll-bar:vertical .decrement-arrow {
+    -fx-background-color:transparent;
+    -fx-background-radius: 0em;
+    -fx-padding: 0 2 0 2;
+}
+
+.filter-options-popup .lang-combo-box .combo-box-popup  > .list-view .scroll-bar:vertical .thumb {
+    -fx-background-color: #a9aeb8;
+    -fx-background-insets: 3px 5px 3px 1px;
+    -fx-background-radius: 16px;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .dialect-box > .arrow-button > .arrow {
+}
+
+
+/*
+Filter Options Popup - Center
+ScrollPane > Accordion > TitledPane > Accordion > LangFilterTitledPane > Content > OptionToggle
+*/
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .option-toggle-box {
+    -fx-spacing: 8;
+    -fx-alignment: center-left;
+    -fx-cursor: hand;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .option-toggle-box > .option-toggle {
+    -fx-background-color: #4A7AD2, white;
+    -fx-background-insets: 0, 1;
+    -fx-background-radius: 12, 12;
+    -fx-padding: 0 8 0 8;
+    -fx-pref-height: 18;
+    -fx-font-family: "Noto Sans";
+    -fx-font-size: 12px;
+    -fx-font-style: normal;
+    -fx-font-weight: 500;
+    -fx-text-fill: #4A7AD2;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .option-toggle-box > .option-toggle:selected {
+    -fx-background-color: #5DCF16, #5DCF16;
+    -fx-text-fill: black;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .option-toggle-box > .option-toggle:disabled {
+    -fx-background-color: #9CAABF, #9CAABF;
+    -fx-text-fill: black;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .option-toggle-box > .option-toggle > .check {
+    /* 0, 0.08 10x7.83 */
+    -fx-pref-width: 10;
+    -fx-pref-height: 7.83;
+    -fx-shape: "M3.33333 7.91683L0 4.5835L1.16667 3.41683L3.33333 5.5835L8.83333 0.0834961L10 1.25016L3.33333 7.91683Z";
+    -fx-background-color: black;
+    -fx-managed: false;
+    visibility: hidden;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .option-toggle-box > .option-toggle:selected > .check {
+    -fx-managed: true;
+    visibility: visible;
+}
+
+/*
+Filter Options Popup - Center
+ScrollPane > Accordion > TitledPane > Accordion > LangFilterTitledPane > Content > SortedToggleBox
+*/
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box {
+    -fx-spacing: 8;
+    -fx-alignment: center-left;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box {
+    -fx-background-color: transparent, transparent;
+    -fx-background-insets: 0, 2;
+    -fx-alignment: center-left;
+    -fx-spacing: 2;
+    -fx-padding: 0 4 0 2;
+    -fx-cursor: hand;
+    -fx-effect: null;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box:selected:hover {
+    -fx-background-color: #6E7989, #6E7989;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box:selected:pressed {
+    -fx-background-color: #5DCF16, #6E7989;
+    -fx-effect: dropshadow(gaussian, #3EC24499, 4, 0.6, 0, 0);
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .snapshot.ordered-toggle-box:selected:pressed {
+    -fx-background-color: #6E7989, #6E7989;
+    -fx-effect: null;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box > .order-label {
+    -fx-font-family: "Noto Sans";
+    -fx-font-size: 12px;
+    -fx-font-style: normal;
+    -fx-font-weight: 500;
+    -fx-text-fill: #9CAABF;
+    -fx-min-width: 24;
+    -fx-pref-width: 24;
+    visibility: hidden;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box > .dotted-line {
+    -fx-stroke: #B3BDCD;
+    -fx-stroke-width: 1;
+    -fx-stroke-dash-array: 2.0 2.0;
+    -fx-stroke-dash-offset: 0.5;
+    -fx-stroke-line-cap: butt;
+    -fx-pref-height: 1;
+    -fx-pref-width: 16;
+    visibility: hidden;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box:selected > .order-label,
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box:selected > .dotted-line {
+    visibility: visible;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .snapshot.ordered-toggle-box:selected > .order-label,
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .snapshot.ordered-toggle-box:selected > .dotted-line {
+    visibility: hidden;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .box {
+    -fx-padding: 0 0 0 46;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .box > .line {
+    -fx-background-color: #E1E8F1;
+    -fx-min-height: 1;
+    -fx-pref-height: 1;
+    -fx-max-height: 1;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box > .option-toggle {
+    -fx-background-color: #4A7AD2, white;
+    -fx-background-insets: 0, 1;
+    -fx-background-radius: 12, 12;
+    -fx-padding: 0 8 0 8;
+    -fx-pref-height: 18;
+    -fx-font-family: "Noto Sans";
+    -fx-font-size: 12px;
+    -fx-font-style: normal;
+    -fx-font-weight: 500;
+    -fx-text-fill: #4A7AD2;
+    -fx-cursor: hand;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box > .option-toggle:selected {
+    -fx-background-color: #5DCF16, #5DCF16;
+    -fx-text-fill: black;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box > .option-toggle:disabled {
+    -fx-background-color: #9CAABF, #9CAABF;
+    -fx-text-fill: black;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box > .option-toggle > .check {
+    /* 0, 0.08 10x7.83 */
+    -fx-pref-width: 10;
+    -fx-pref-height: 7.83;
+    -fx-shape: "M3.33333 7.91683L0 4.5835L1.16667 3.41683L3.33333 5.5835L8.83333 0.0834961L10 1.25016L3.33333 7.91683Z";
+    -fx-background-color: black;
+    -fx-managed: false;
+    visibility: hidden;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box > .option-toggle:selected > .check {
+    -fx-managed: true;
+    visibility: visible;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box > .drag-pane {
+    -fx-pref-width: 14;
+    -fx-pref-height: 14;
+    visibility: hidden;
+    -fx-managed: false;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box:selected:hover > .drag-pane {
+    visibility: visible;
+    -fx-managed: true;
+}
+
+.filter-options-popup > .scroll-pane .accordion > .titled-pane > .content > .accordion > .lang-filter-titled-pane > .content > .content-box > .sorted-toggle-box > .ordered-toggle-box > .drag-pane > .icon.drag {
+    -fx-shape: "M 2.998 1.398 C 2.998 2.116 2.416 2.698 1.698 2.698 C 0.98 2.698 0.398 2.116 0.398 1.398 C 0.398 0.68 0.98 0.098 1.698 0.098 C 2.416 0.098 2.998 0.68 2.998 1.398 Z M 2.998 5.999 C 2.998 6.717 2.416 7.299 1.698 7.299 C 0.98 7.299 0.398 6.717 0.398 5.999 C 0.398 5.281 0.98 4.699 1.698 4.699 C 2.416 4.699 2.998 5.281 2.998 5.999 Z M 2.998 10.601 C 2.998 11.319 2.416 11.901 1.698 11.901 C 0.98 11.901 0.398 11.319 0.398 10.601 C 0.398 9.883 0.98 9.301 1.698 9.301 C 2.416 9.301 2.998 9.883 2.998 10.601 Z M 7.6 1.398 C 7.6 2.116 7.018 2.698 6.3 2.698 C 5.582 2.698 5 2.116 5 1.398 C 5 0.68 5.582 0.098 6.3 0.098 C 7.018 0.098 7.6 0.68 7.6 1.398 Z M 7.6 5.999 C 7.6 6.717 7.018 7.299 6.3 7.299 C 5.582 7.299 5 6.717 5 5.999 C 5 5.281 5.582 4.699 6.3 4.699 C 7.018 4.699 7.6 5.281 7.6 5.999 Z M 7.6 10.601 C 7.6 11.319 7.018 11.901 6.3 11.901 C 5.582 11.901 5 11.319 5 10.601 C 5 9.883 5.582 9.301 6.3 9.301 C 7.018 9.301 7.6 9.883 7.6 10.601 Z";
+    -fx-background-color: #B3BDCD;
+    -fx-scale-shape: false;
 }
 
 /*

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/filter-options.properties
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/filter-options.properties
@@ -34,6 +34,19 @@ status.label.all=All
 status.label.none=None
 status.button.all=All
 
+#TIME
+time.title=TIME
+time.label=Latest
+time.option.specific=Specific date at {0}
+time.option.range=Date range including {0}
+time.option.range.excluding=Date range including {0}, excluding: {1}
+time.range.text=from {0} to {1}
+time.item1=Latest Date
+time.item2=Specific Date
+time.item3=Date Range
+time.range.additional.button=ADDITIONAL RANGE
+time.range.exclude.button=EXCLUDE RANGE
+
 #MODULE
 module.title=MODULE
 module.label.all=All modules
@@ -48,23 +61,6 @@ module.button.excluding=excluding ...
 #PATH
 path.title=PATH
 path.label.none=None
-
-#LANGUAGE
-language.title=LANGUAGE
-language.label.all=All
-language.label.none=None
-language.button.all=All
-
-#DESCRIPTION
-description.title=DESCRIPTION TYPE
-description.label.all=All
-description.label.none=None
-description.button.all=All
-description.option.fqn=Fully Qualified Name (FQN)
-description.option.preferred=Preferred
-description.option.regular=Regular
-description.option.preferredfqn=Preferred, if unavailable - FQN
-description.option.regularfqn=Regular, if unavailable - FQN
 
 #KINDOF
 kindof.title=KIND OF
@@ -105,21 +101,61 @@ sortby.option.relevant=Most Relevant
 sortby.option.alphabetical=Alphabetical
 sortby.option.groupedby=Grouped by Concept/Pattern
 
-#DATE
-date.title=DATE
-date.label.all=Latest
-date.option.specific=Specific date at {0}
-date.option.range=Date range including {0}
-date.option.range.excluding=Date range including {0}, excluding: {1}
-date.range.text=from {0} to {1}
-date.item1=Latest Date
-date.item2=Specific Date
-date.item3=Date Range
-date.range.additional.button=ADDITIONAL RANGE
-date.range.exclude.button=EXCLUDE RANGE
-
 #SAVED FILTERS
 saved.filters.title=SAVED FILTERS
 saved.filter.name=Filter Name {0}
 saved.filters.empty=There are no saved filters
 saved.filters.delete=Remove saved filter
+
+##LANGUAGE
+
+language.title=LANGUAGE COORDINATES
+
+#ORDER
+language.coordinates.ordinal1=PRIMARY
+language.coordinates.ordinal2=SECONDARY
+language.coordinates.ordinal3=TERTIARY
+language.coordinates.ordinal4=QUATERNARY
+language.coordinates.ordinal5=QUINARY
+language.coordinates.ordinal6=SENARY
+language.coordinates.ordinal7=SEPTENARY
+language.coordinates.ordinal8=OCTONARY
+language.coordinates.ordinal9=NONARY
+language.coordinates.ordinal10=DENARY
+language.coordinates.ordinal11=UNDENARY
+
+#LANGUAGE
+language.option.title=Language:
+language.option.prompt=Select
+language.option.empty=None selected
+
+#DIALECT
+dialect.option.title=Dialect:
+dialect.option.item1=Dialect Name 1
+dialect.option.item2=Dialect Name 2
+dialect.option.item3=Dialect Name 3
+dialect.option.item4=Dialect Name 4
+dialect.option.item5=Dialect Name 5
+dialect.order.item1=1st
+dialect.order.item2=2nd
+dialect.order.item3=3rd
+dialect.order.item4=4th
+dialect.order.item5=5th
+
+#PATTERN
+pattern.option.title=Pattern:
+pattern.option.item1=Pattern 1
+pattern.option.item2=Pattern 2
+pattern.option.item3=Pattern 3
+pattern.option.item4=Pattern 4
+
+#DESCRIPTION
+description.option.title=Description Type:
+description.option.fqn=Fully Qualified Name (FQN)
+description.option.preferred=Preferred
+description.option.regular=Regular
+description.option.preferredfqn=Preferred, if unavailable - FQN
+description.option.regularfqn=Regular, if unavailable - FQN
+
+#Context Menu
+language.menu.remove=Remove

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/range-calendar.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/range-calendar.css
@@ -200,8 +200,8 @@
     -fx-padding: 4 7 4 7;
     -fx-border-width: 0;
     -fx-font-size: 11;
-    -fx-background: white;
-    -fx-background-color: white;
+    -fx-background: transparent;
+    -fx-background-color: transparent;
     -fx-border-color: null;
     -fx-text-fill: #2E3240;
 }
@@ -246,7 +246,8 @@
 }
 
 .range-calendar > .calendar-box > .calendar-node.date-picker-popup > .calendar-grid > .today {
-    -fx-text-fill: #4A7AD2;
+    -fx-text-fill: #212430;
+    -fx-font-weight: bold;
 }
 
 .range-calendar > .calendar-box > .calendar-node.date-picker-popup > .calendar-grid > .previous-month,


### PR DESCRIPTION
This PR adds the LangFilterTitledPane control to display one set of Language Coordinates (for a given language). 

The FilterOptionsControl is basically formed by a root Accordion with the set of FilterTitledPane controls for the regular options (including a DateFilterTitledPane for the Time option), and a regular TitledPane that holds a second Accordion control with one or more LangFilterTitledPane controls.

FilterOptions model has been refactored to have the regular options (under MainCoordinates) plus a list of LanguageCoordinates (with at least one item).

Both NextGen Search and ConceptNavigator controllers have been refactored, extracting the loadFilterOptions method to a convenient FilterOptionsUtils class.

Note that the order in which the default FilterOptions model is filled up is really important. For that, see 
FilterOptionsPopupSkin::setupDefaultFilterOptions. Here the available options are set from either the resource bundle, or from the dataset (via Navigator), and then default/selected options are inherited from the ViewProperties (which in some cases are already set in the FilterOptions directly).

<img width="756" height="952" alt="image" src="https://github.com/user-attachments/assets/debdebd1-7780-458c-ac73-f6552480df32" />

<img width="832" height="948" alt="image" src="https://github.com/user-attachments/assets/19040b1d-8617-439f-869e-c3faf5a54414" />


