### PR TITLE
feature/finished/IIA-2729-dont-allow-deselection-of-include-or-exclude-module-wildcard

### DIFF
--- a/framework/src/main/java/dev/ikm/komet/framework/view/ListPropertyWithOverride.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ListPropertyWithOverride.java
@@ -174,9 +174,11 @@ public class ListPropertyWithOverride<T> extends SimpleEqualityBasedListProperty
         if (!overridden) {
             this.unbind();
             overridden = true;
+            // create a new empty list
             super.set(FXCollections.observableArrayList(new ArrayList<>()));
+        } else {
+            super.clear();
         }
-        super.clear();
     }
 
     @Override

--- a/framework/src/main/java/dev/ikm/komet/framework/view/SetPropertyWithOverride.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/SetPropertyWithOverride.java
@@ -181,9 +181,11 @@ public class SetPropertyWithOverride <T> extends SimpleEqualityBasedSetProperty<
         if (!overridden) {
             overridden = true;
             this.unbind();
+            // create a new empty set
             super.set(FXCollections.observableSet(new HashSet<>()));
+        } else {
+            super.clear();
         }
-        super.clear();
     }
 
     @Override

--- a/framework/src/main/java/dev/ikm/komet/framework/view/ViewMenuTask.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ViewMenuTask.java
@@ -250,7 +250,12 @@ public class ViewMenuTask extends TrackingCallable<List<MenuItem>> {
         addIncludedModulesMenu.getItems().add(allModulesItem);
         allModulesItem.setOnAction(event -> {
             Platform.runLater(() -> {
-                observableCoordinate.moduleSpecificationsProperty().clear();
+                // ensure that the wildcard menu item is never deselected
+                if (allModulesItem.isSelected()) {
+                    observableCoordinate.moduleSpecificationsProperty().clear();
+                } else {
+                    allModulesItem.setSelected(true);
+                }
             });
             event.consume();
         });
@@ -301,7 +306,12 @@ public class ViewMenuTask extends TrackingCallable<List<MenuItem>> {
         excludedModulesMenu.getItems().add(noExclusionsWildcard);
         noExclusionsWildcard.setOnAction(event -> {
             Platform.runLater(() -> {
-                observableCoordinate.excludedModuleSpecificationsProperty().clear();
+                // ensure that the wildcard menu item is never deselected
+                if (noExclusionsWildcard.isSelected()) {
+                    observableCoordinate.excludedModuleSpecificationsProperty().clear();
+                } else {
+                    noExclusionsWildcard.setSelected(true);
+                }
             });
             event.consume();
         });


### PR DESCRIPTION
Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-2729

Summary of changes:

- In ViewMenuTask
    - Added check for selected for the Include wildcard CheckMenuItem
    - Added check for selected for the Exclude wildcard CheckMenuItem
    - If not checked, just rechecks the CheckMenuItem
    - If checked, then clears the Set property
- Set and ListPropertyWithOverride.clear() - put the final clear() call into an else, because no reason to clear a newly created empty Set/List

Before changes:  The wildcard menu item can be deselected

After changes:  The wildcard menu item CANNOT be deselected