### PR TITLE
IIA-2727 Remove Fake Error Alerts

### DIFF
--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -4163,7 +4163,7 @@ Styling a context menu for kview ui/ux controls
     -fx-font-weight: 500;
 }
 .card-info-container .validation-counts {
-    -fx-text-fill: -Accent-color-red;
+    -fx-text-fill: -Grey-12;
     -fx-font-family: Noto Sans;
     -fx-font-size: 25px;
     -fx-font-style: normal;


### PR DESCRIPTION
Removed the Fake error alerts. "You have 25 errors" is replaced with “No New Messages” text. - https://ikmdev.atlassian.net/browse/IIA-2727
Changed the font color to Grey.

Before Change:
<img width="1918" height="1016" alt="image" src="https://github.com/user-attachments/assets/d0c8c95c-0f54-43b4-b441-3af54ee7f673" />


After Change:
<img width="949" height="486" alt="image" src="https://github.com/user-attachments/assets/46519088-a394-4198-8f90-a9aa081f0a33" />

