### PR TITLE
Allow overriding filterOptions

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/FilterOptions.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/FilterOptions.java
@@ -65,9 +65,10 @@ public class FilterOptions implements Serializable {
         private final boolean multiSelect;
         private boolean any;
         private final EnumSet<BUTTON> buttonType;
+        private boolean inOverride;
 
         public Option(OPTION_ITEM item, String title, List<String> defaultOptions, List<String> availableOptions,
-                      List<String> selectedOptions, List<String> excludedOptions, boolean multiSelect, boolean any, EnumSet<BUTTON> buttonType) {
+                      List<String> selectedOptions, List<String> excludedOptions, boolean multiSelect, boolean any, EnumSet<BUTTON> buttonType, boolean inOverride) {
             this.item = item;
             this.title = title;
             this.defaultOptions = defaultOptions;
@@ -77,6 +78,7 @@ public class FilterOptions implements Serializable {
             this.multiSelect = multiSelect;
             this.any = any;
             this.buttonType = buttonType;
+            this.inOverride = inOverride;
         }
 
         public enum BUTTON {
@@ -108,7 +110,7 @@ public class FilterOptions implements Serializable {
         public String toString() {
             return "> " + item + ": " + (any ? "Any of: " : (multiSelect ? "All of: " : "")) + selectedOptions +
                     (excludedOptions == null || excludedOptions.isEmpty() ? "" : " - " + excludedOptions) +
-                    " from av: " + availableOptions + " def: " + defaultOptions;
+                    " from av: " + availableOptions + " def: " + defaultOptions + (inOverride ? " *OV*" : "");
         }
 
         public boolean isMultiSelectionAllowed() {
@@ -135,6 +137,14 @@ public class FilterOptions implements Serializable {
             return hasExcluding() && excludedOptions() != null && !excludedOptions().isEmpty();
         }
 
+        public boolean isInOverride() {
+            return inOverride;
+        }
+
+        public void setInOverride(boolean override) {
+            this.inOverride = override;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
@@ -143,6 +153,7 @@ public class FilterOptions implements Serializable {
             if (!Objects.equals(item, option.item)) return false;
             if (!Objects.equals(title, option.title)) return false;
             if (any != option.any) return false;
+            if (inOverride != option.inOverride) return false;
             if (option.item == OPTION_ITEM.DIALECT || option.item == OPTION_ITEM.DESCRIPTION_TYPE) {
                 if (!compareSortedLists(selectedOptions, option.selectedOptions)) return false;
                 if (!compareSortedLists(excludedOptions, option.excludedOptions)) return false;
@@ -155,7 +166,7 @@ public class FilterOptions implements Serializable {
 
         @Override
         public int hashCode() {
-            return Objects.hash(item, title, any, selectedOptions, excludedOptions);
+            return Objects.hash(item, title, any, selectedOptions, excludedOptions, inOverride);
         }
 
         public Option copy() {
@@ -164,7 +175,7 @@ public class FilterOptions implements Serializable {
                     new ArrayList<>(availableOptions.stream().toList()),
                     new ArrayList<>(selectedOptions.stream().toList()),
                     excludedOptions != null ? new ArrayList<>(excludedOptions.stream().toList()) : null,
-                    multiSelect, any, buttonType);
+                    multiSelect, any, buttonType, inOverride);
         }
 
         public OPTION_ITEM item() {
@@ -219,7 +230,7 @@ public class FilterOptions implements Serializable {
                     .map(resources::getString)
                     .toList();
             navigator = new Option(OPTION_ITEM.NAVIGATOR, "navigator.title", new ArrayList<>(List.of(navigatorOptions.getFirst())),
-                    new ArrayList<>(navigatorOptions), new ArrayList<>(List.of(navigatorOptions.getFirst())), null, false, false, noneSet);
+                    new ArrayList<>(navigatorOptions), new ArrayList<>(List.of(navigatorOptions.getFirst())), null, false, false, noneSet, false);
         }
 
         private Option type;
@@ -229,14 +240,14 @@ public class FilterOptions implements Serializable {
                     .map(resources::getString)
                     .toList();
             type = new Option(OPTION_ITEM.TYPE, "type.title", new ArrayList<>(typeOptions),
-                    new ArrayList<>(typeOptions), new ArrayList<>(typeOptions), null, true, false, allSet);
+                    new ArrayList<>(typeOptions), new ArrayList<>(typeOptions), null, true, false, allSet, false);
         }
 
         private Option header = new Option(OPTION_ITEM.HEADER, "header.title", new ArrayList<>(),
-                new ArrayList<>(), new ArrayList<>(), null, false, false, allSet);
+                new ArrayList<>(), new ArrayList<>(), null, false, false, allSet, false);
 
         private Option status = new Option(OPTION_ITEM.STATUS, "status.title", new ArrayList<>(),
-                new ArrayList<>(), new ArrayList<>(), null, true, false, allSet);
+                new ArrayList<>(), new ArrayList<>(), null, true, false, allSet, false);
 
         private Option time;
         {
@@ -244,14 +255,14 @@ public class FilterOptions implements Serializable {
                     .map(resources::getString)
                     .toList();
             time = new Option(OPTION_ITEM.TIME, "time.title", new ArrayList<>(List.of(dateOptions.getFirst())),
-                    new ArrayList<>(dateOptions), new ArrayList<>(List.of(dateOptions.getFirst())), new ArrayList<>(), false, false, noneSet);
+                    new ArrayList<>(dateOptions), new ArrayList<>(List.of(dateOptions.getFirst())), new ArrayList<>(), false, false, noneSet, false);
         }
 
         private Option module = new Option(OPTION_ITEM.MODULE, "module.title", new ArrayList<>(),
-                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), true, false, allAnyExcludingSet);
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), true, false, allAnyExcludingSet, false);
 
         private Option path = new Option(OPTION_ITEM.PATH, "path.title", new ArrayList<>(),
-                new ArrayList<>(), new ArrayList<>(), null, false, false, noneSet);
+                new ArrayList<>(), new ArrayList<>(), null, false, false, noneSet, false);
 
         private Option kindOf;
         {
@@ -262,7 +273,7 @@ public class FilterOptions implements Serializable {
                     .map(resources::getString)
                     .toList();
             kindOf = new Option(OPTION_ITEM.KIND_OF, "kindof.title", new ArrayList<>(kindOfOptions),
-                    new ArrayList<>(kindOfOptions), new ArrayList<>(kindOfOptions), new ArrayList<>(), true, false, allExcludingSet);
+                    new ArrayList<>(kindOfOptions), new ArrayList<>(kindOfOptions), new ArrayList<>(), true, false, allExcludingSet, false);
         }
 
         private Option membership;
@@ -273,7 +284,7 @@ public class FilterOptions implements Serializable {
                     .map(resources::getString)
                     .toList();
             membership = new Option(OPTION_ITEM.MEMBERSHIP, "membership.title", new ArrayList<>(membershipOptions),
-                    new ArrayList<>(membershipOptions), new ArrayList<>(membershipOptions), null, true, false, allSet);
+                    new ArrayList<>(membershipOptions), new ArrayList<>(membershipOptions), null, true, false, allSet, false);
         }
 
         private Option sortBy;
@@ -283,7 +294,7 @@ public class FilterOptions implements Serializable {
                     .map(resources::getString)
                     .toList();
             sortBy = new Option(OPTION_ITEM.SORT_BY, "sortby.title", new ArrayList<>(List.of(sortByOptions.getFirst())),
-                    new ArrayList<>(sortByOptions), new ArrayList<>(List.of(sortByOptions.getFirst())), null, false, false, allSet);
+                    new ArrayList<>(sortByOptions), new ArrayList<>(List.of(sortByOptions.getFirst())), null, false, false, allSet, false);
         }
 
         private final List<Option> options;
@@ -377,7 +388,7 @@ public class FilterOptions implements Serializable {
 
         // Language Coordinates
         private Option language = new Option(OPTION_ITEM.LANGUAGE, "language.option.title", new ArrayList<>(),
-                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), false, false, noneSet);
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), false, false, noneSet, false);
 
         private Option dialect;
         {
@@ -387,7 +398,7 @@ public class FilterOptions implements Serializable {
                     .map(resources::getString)
                     .toList();
             dialect = new Option(OPTION_ITEM.DIALECT, "dialect.option.title", new ArrayList<>(dialectOptions),
-                    new ArrayList<>(dialectOptions), new ArrayList<>(dialectOptions), null, true, false, noneSet);
+                    new ArrayList<>(dialectOptions), new ArrayList<>(dialectOptions), null, true, false, noneSet, false);
         }
 
         private Option pattern;
@@ -398,7 +409,7 @@ public class FilterOptions implements Serializable {
                     .map(resources::getString)
                     .toList();
             pattern = new Option(OPTION_ITEM.PATTERN, "pattern.option.title", new ArrayList<>(List.of(patternOptions.getFirst())),
-                    new ArrayList<>(patternOptions), new ArrayList<>(List.of(patternOptions.getFirst())), null, false, false, noneSet);
+                    new ArrayList<>(patternOptions), new ArrayList<>(List.of(patternOptions.getFirst())), null, false, false, noneSet, false);
         }
 
         private Option descriptionType;
@@ -412,7 +423,7 @@ public class FilterOptions implements Serializable {
                     .map(resources::getString)
                     .toList();
             descriptionType = new Option(OPTION_ITEM.DESCRIPTION_TYPE, "description.option.title", new ArrayList<>(descriptionTypeOptions),
-                    new ArrayList<>(descriptionTypeOptions), new ArrayList<>(descriptionTypeOptions), null, true, false, noneSet);
+                    new ArrayList<>(descriptionTypeOptions), new ArrayList<>(descriptionTypeOptions), null, true, false, noneSet, false);
         }
 
         private final List<Option> options;

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterOptionsPopupSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterOptionsPopupSkin.java
@@ -231,7 +231,7 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
                         option.availableOptions().addAll(pane.getLangCoordinates().getOptions().get(i).availableOptions());
                     }
                 }
-                pane.setLangCoordinates(languageCoordinates);
+                pane.setLangCoordinates(languageCoordinates.copy());
             });
         skipUpdateFilterOptions = false;
         updateCurrentFilterOptions();

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterOptionsPopupSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterOptionsPopupSkin.java
@@ -74,7 +74,7 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
 
     private static final List<String> ALL_STATES = StateSet.ACTIVE_INACTIVE_AND_WITHDRAWN.toEnumSet().stream().map(s -> s.name()).toList();
 
-    private FilterOptions defaultFilterOptions = new FilterOptions();
+    private FilterOptions defaultFilterOptions;
     private final ObjectProperty<FilterOptions> currentFilterOptionsProperty = new SimpleObjectProperty<>() {
         @Override
         protected void invalidated() {
@@ -169,7 +169,6 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
                 filterPane.setSelected(false);
             }
         }));
-        //experimental... trying to listen to changes when the inherited options change to change what is selected
         subscription = subscription.and(control.inheritedFilterOptionsProperty().subscribe((_, _) -> {
             if (control.getNavigator() != null) {
                 setupDefaultFilterOptions(control.getNavigator());
@@ -195,6 +194,7 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
         if (filterOptions == null) {
             return;
         }
+        boolean isDefault = control.getFilterOptions() != null && filterOptions.equals(defaultFilterOptions);
 
         updating = true;
         filterSubscription = Subscription.EMPTY;
@@ -214,7 +214,13 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
                 if (optionForItem.availableOptions().isEmpty()) {
                     optionForItem.availableOptions().addAll(pane.getOption().availableOptions());
                 }
-                pane.setOption(optionForItem);
+                if (isDefault && control.getFilterOptions().getOptionForItem(pane.getOption().item()).isInOverride()) {
+                    // when passing default filter options, if the option is inOverride mode,
+                    // keep the one in the control, don't set the default one
+                    pane.setOption(control.getFilterOptions().getOptionForItem(pane.getOption().item()));
+                } else {
+                    pane.setOption(optionForItem);
+                }
             });
         accordionBox.updateLangPanes(pane -> {
                 int ordinal = pane.getOrdinal();
@@ -260,6 +266,7 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
         updating = true;
         currentFilterOptionsProperty.set(null);
         setupFilter(null);
+        control.setFilterOptions(null);
         setupFilter(defaultFilterOptions);
         updating = false;
         updateCurrentFilterOptions();
@@ -353,10 +360,12 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
     }
 
     private void setupDefaultFilterOptions(Navigator navigator) {
-        // reset default filter options
-        defaultFilterOptions = new FilterOptions();
-        // once we have navigator, update pending options with av/def/sel default options
-        setAvailableOptionsFromNavigator(defaultFilterOptions, navigator);
+        if (defaultFilterOptions == null) {
+            // create default filter options
+            defaultFilterOptions = new FilterOptions();
+            // once we have navigator, update pending options with av/def/sel default options
+            setAvailableOptionsFromNavigator(defaultFilterOptions, navigator);
+        }
         // then pass the inherited options, to override av/def/sel default options where set
         setDefaultOptions(control.getInheritedFilterOptions());
         // pass default options to panes

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterOptionsPopupSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterOptionsPopupSkin.java
@@ -217,9 +217,9 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
                 if (isDefault && control.getFilterOptions().getOptionForItem(pane.getOption().item()).isInOverride()) {
                     // when passing default filter options, if the option is inOverride mode,
                     // keep the one in the control, don't set the default one
-                    pane.setOption(control.getFilterOptions().getOptionForItem(pane.getOption().item()));
+                    pane.setOption(control.getFilterOptions().getOptionForItem(pane.getOption().item()).copy());
                 } else {
-                    pane.setOption(optionForItem);
+                    pane.setOption(optionForItem.copy());
                 }
             });
         accordionBox.updateLangPanes(pane -> {

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterTitledPaneSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterTitledPaneSkin.java
@@ -144,11 +144,6 @@ public class FilterTitledPaneSkin extends TitledPaneSkin {
         subscription = selectedOption.boundsInParentProperty().subscribe(b ->
                 pseudoClassStateChanged(TALLER_TITLE_AREA, b.getHeight() > 30));
 
-        subscription = subscription.and(selectedOption.textProperty().subscribe(_ -> {
-            pseudoClassStateChanged(MODIFIED_TITLED_PANE,
-                    !Objects.equals(currentOption, control.getDefaultOption()));
-        }));
-
         if (control.getParent() instanceof Accordion accordion) {
             subscription = subscription.and(accordion.expandedPaneProperty().subscribe(pane -> {
                 if (pane == null) {
@@ -309,11 +304,20 @@ public class FilterTitledPaneSkin extends TitledPaneSkin {
         subscription = subscription.and(control.optionProperty().subscribe((_, _) -> setupTitledPane()));
         subscription = subscription.and(control.expandedProperty().subscribe((_, expanded) -> {
             if (!expanded) {
+                updateModifiedState(currentOption);
                 control.setOption(currentOption.copy());
                 selectedOption.setText(getOptionText(currentOption));
             }
         }));
+        updateModifiedState(currentOption);
+    }
 
+    private void updateModifiedState(FilterOptions.Option currentOption) {
+        boolean modified = !Objects.equals(currentOption, control.getDefaultOption());
+        pseudoClassStateChanged(MODIFIED_TITLED_PANE, currentOption.isInOverride() || modified);
+        if (modified && !currentOption.isInOverride()) {
+            currentOption.setInOverride(true);
+        }
     }
 
     private void setupToggleBox(FilterOptions.Option currentOption) {


### PR DESCRIPTION
This PR allows overriding the filter options of a child view menu, after the user changes them, so changes in the parent view menu are ignored, until the Revert button is pressed.

The scope of this PR is limited to the current options that are set via `FilterOptionsUtils::loadFilterOptions`