### PR TITLE
feature/finished/IIA-2564-fix-for-edit-fqn

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/properties/PropertiesController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/properties/PropertiesController.java
@@ -15,15 +15,6 @@
  */
 package dev.ikm.komet.kview.mvvm.view.properties;
 
-import static dev.ikm.komet.kview.events.StampEvent.ADD_STAMP;
-import static dev.ikm.komet.kview.events.StampEvent.CREATE_STAMP;
-import static dev.ikm.komet.kview.fxutils.CssHelper.genText;
-import static dev.ikm.komet.kview.mvvm.viewmodel.DescrNameViewModel.*;
-import static dev.ikm.komet.kview.mvvm.viewmodel.OtherNameViewModel.OtherNameProperties.FQN_CASE_SIGNIFICANCE;
-import static dev.ikm.komet.kview.mvvm.viewmodel.OtherNameViewModel.OtherNameProperties.FQN_LANGUAGE;
-import static dev.ikm.komet.kview.mvvm.viewmodel.OtherNameViewModel.OtherNameProperties.HAS_OTHER_NAME;
-import static dev.ikm.komet.kview.mvvm.viewmodel.StampFormViewModelBase.StampType.CONCEPT;
-
 import dev.ikm.komet.framework.view.ViewProperties;
 import dev.ikm.komet.kview.events.*;
 import dev.ikm.komet.kview.mvvm.view.common.StampAddController;
@@ -31,22 +22,38 @@ import dev.ikm.komet.kview.mvvm.viewmodel.StampAddFormViewModel;
 import dev.ikm.komet.kview.mvvm.viewmodel.StampCreateFormViewModel;
 import dev.ikm.komet.kview.mvvm.viewmodel.StampFormViewModelBase;
 import dev.ikm.tinkar.common.id.PublicId;
-import dev.ikm.tinkar.events.*;
+import dev.ikm.tinkar.events.EvtBus;
+import dev.ikm.tinkar.events.EvtBusFactory;
+import dev.ikm.tinkar.events.Subscriber;
 import dev.ikm.tinkar.terms.EntityFacade;
 import dev.ikm.tinkar.terms.TinkarTerm;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
-import javafx.scene.control.*;
-import javafx.scene.layout.*;
+import javafx.scene.control.Toggle;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
 import javafx.scene.shape.SVGPath;
-import org.carlfx.cognitive.loader.*;
+import org.carlfx.cognitive.loader.Config;
+import org.carlfx.cognitive.loader.FXMLMvvmLoader;
+import org.carlfx.cognitive.loader.JFXNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.UUID;
+
+import static dev.ikm.komet.kview.events.StampEvent.ADD_STAMP;
+import static dev.ikm.komet.kview.events.StampEvent.CREATE_STAMP;
+import static dev.ikm.komet.kview.fxutils.CssHelper.genText;
+import static dev.ikm.komet.kview.mvvm.viewmodel.DescrNameViewModel.*;
+import static dev.ikm.komet.kview.mvvm.viewmodel.OtherNameViewModel.OtherNameProperties.*;
+import static dev.ikm.komet.kview.mvvm.viewmodel.StampFormViewModelBase.StampType.CONCEPT;
 
 /**
  * The properties window providing tabs of Edit, Hierarchy, History, and Comments.
@@ -314,13 +321,13 @@ public class PropertiesController implements Serializable {
             if (!contentBorderPane.getCenter().equals(editFqnPane)) {
                 editFullyQualifiedNameController.updateModel(getViewProperties(), null);
                 contentBorderPane.setCenter(editFqnPane);
-                editButton.setSelected(true);
-                editButton.setText("EDIT");
-                if (evt.getPublicId() != null) {
-                    editFullyQualifiedNameController.setConceptAndPopulateForm(evt.getPublicId());
-                }else {
-                    editFullyQualifiedNameController.setConceptAndPopulateForm(evt.getDescrName());
-                }
+            }
+            editButton.setSelected(true);
+            editButton.setText("EDIT");
+            if (evt.getPublicId() != null) {
+                editFullyQualifiedNameController.setConceptAndPopulateForm(evt.getPublicId());
+            }else {
+                editFullyQualifiedNameController.setConceptAndPopulateForm(evt.getDescrName());
             }
         };
         eventBus.subscribe(conceptTopic, EditConceptFullyQualifiedNameEvent.class, editConceptFullyQualifiedNameEventSubscriber);


### PR DESCRIPTION
Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-2564

Summary of changes:  moved the call to setConceptAndPopulateForm() outside of the check for the pane not being the editFqnPane, so the editFullyQualifiedNameController is always set with the publicId

Before change:

Edit the FQN, change the case significance to Case Sensitive, and Submit

<img width="1190" height="732" alt="image" src="https://github.com/user-attachments/assets/49c7b25b-f8f9-4d88-a4dd-e0ad06c7f929" />

Click on the FQN to edit, but the properties are set to blank or default values (not being set)

<img width="1193" height="733" alt="image" src="https://github.com/user-attachments/assets/d174c1c4-8e5d-427e-9178-5eb21e7d580f" />


After change:

Edit the FQN, change the case significance to Case Sensitive, and Submit

<img width="1190" height="732" alt="image" src="https://github.com/user-attachments/assets/49c7b25b-f8f9-4d88-a4dd-e0ad06c7f929" />

Click on the FQN to edit, and now the properties are populated

<img width="1188" height="731" alt="image" src="https://github.com/user-attachments/assets/d4b2243d-fe05-4c71-a96d-a5c2aba81583" />

