### PR TITLE
JPRO-195 change ObjectBinding computeValue to not capitalize the value of KLReadOnlyDataTypeControl

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyDataTypeControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLReadOnlyDataTypeControlSkin.java
@@ -34,10 +34,7 @@ public class KLReadOnlyDataTypeControlSkin<T> extends KLReadOnlyBaseControlSkin<
                 if (control.getValue() == null || (control.getValue() instanceof String string && string.isEmpty())) {
                     return "";
                 } else {
-                    String valueString = String.valueOf(control.getValue());
-                    // We always want the first letter to be upper case
-                    String capitalized = valueString.substring(0, 1).toUpperCase() + valueString.substring(1);
-                    return capitalized;
+                    return String.valueOf(control.getValue());
                 }
             }
         });


### PR DESCRIPTION
I am not sure why this was added that way but it seams wrong to me that this was done in the Skin and not to the data itself?

The related issue suggested that its a problem. The only question that remain is if in other places we have wrong data and henceforth capitalization would be needed.