### PR TITLE
JPRO-192 Rework fxml to be more inline with concept details view.

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/PublicIDControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/PublicIDControlSkin.java
@@ -111,17 +111,6 @@ public class PublicIDControlSkin extends SkinBase<PublicIDControl> {
             identifier = publicId;
             publicIdTooltip.setText(identifier);
             publicIdTextField.setText(identifier);
-
-            Platform.runLater(() -> {
-                // set the preferredWidth of the TextField to completely show the identifier text
-
-                Text text = new Text(identifier); // Create a temporary Text node with the new text
-                text.setFont(publicIdTextField.getFont()); // Set the same font as the TextField
-                double width = text.getLayoutBounds().getWidth() +
-                        publicIdTextField.getPadding().getLeft() +
-                        publicIdTextField.getPadding().getRight() + 2d; // Add padding and a small buffer
-                publicIdTextField.setPrefWidth(width);
-            });
         });
     }
 

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingDetailsController.java
@@ -191,10 +191,10 @@ public class GenEditingDetailsController {
     private BorderPane propertiesBorderPane;
 
     @FXML
-    private Text semanticMeaningText;
+    private Label semanticMeaningText;
 
     @FXML
-    private Text semanticPurposeText;
+    private Label semanticPurposeText;
 
     @FXML
     private Button addReferenceButton;

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
@@ -235,7 +235,7 @@
                     
                     
                     <Label styleClass="semantic-banner-label" text="Meaning:" GridPane.rowIndex="2"
-                           GridPane.columnIndex="1" minWidth="50.0" GridPane.valignment="TOP"/>
+                           GridPane.columnIndex="1" minWidth="60.0" GridPane.valignment="TOP"/>
                     
                     <Label fx:id="semanticMeaningText" styleClass="semantic-banner-value" text="[]" wrapText="true"
                            GridPane.rowIndex="2" GridPane.columnIndex="2" GridPane.valignment="TOP"/>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
@@ -2,326 +2,375 @@
 
 <?import dev.ikm.komet.kview.controls.KLReadOnlyComponentControl?>
 <?import dev.ikm.komet.kview.controls.PublicIDControl?>
+<?import dev.ikm.komet.kview.controls.StampViewControl?>
 <?import dev.ikm.komet.kview.mvvm.view.common.SVGConstants?>
-<?import java.lang.String?>
-<?import javafx.geometry.Insets?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
 <?import javafx.scene.Cursor?>
 <?import javafx.scene.Group?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.ContextMenu?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.Menu?>
-<?import javafx.scene.control.MenuButton?>
-<?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.Separator?>
-<?import javafx.scene.control.SeparatorMenuItem?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.control.ToggleButton?>
-<?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.BorderPane?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.FlowPane?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Pane?>
-<?import javafx.scene.layout.Region?>
-<?import javafx.scene.layout.RowConstraints?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.shape.Ellipse?>
-<?import javafx.scene.shape.Rectangle?>
-<?import javafx.scene.shape.SVGPath?>
-<?import javafx.scene.text.Font?>
-<?import javafx.scene.text.Text?>
-<?import javafx.scene.text.TextFlow?>
-
-<?import dev.ikm.komet.kview.controls.StampViewControl?>
-<BorderPane fx:id="detailsOuterBorderPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefWidth="727.0" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/24.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.genediting.GenEditingDetailsController">
-   <center>
-      <BorderPane fx:id="detailsCenterBorderPane" prefWidth="762.0">
-         <top>
-            <VBox BorderPane.alignment="CENTER">
-               <children>
-                  <FlowPane styleClass="rounded-top">
-                     <children>
-                        <HBox fx:id="tabHeader" prefHeight="18.0" spacing="4.0" style="-fx-background-color: -Natural-Grey-Main;">
-                           <styleClass>
-                              <String fx:value="lidr-rounded-tab" />
-                           </styleClass>
-                           <children>
-                              <Region prefHeight="12.0" prefWidth="8.4" styleClass="lidr-tab-icon" />
-                              <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="lidr-tab-text" text="Pattern Semantic" />
-                           </children>
-                           <cursor>
-                              <Cursor fx:constant="CLOSED_HAND" />
-                           </cursor>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.shape.*?>
+<?import javafx.scene.text.*?>
+<?import java.lang.*?>
+<BorderPane xmlns:fx="http://javafx.com/fxml/1" fx:id="detailsOuterBorderPane" maxHeight="1.7976931348623157E308"
+            maxWidth="1.7976931348623157E308" prefWidth="727.0" stylesheets="@../kview.css"
+            xmlns="http://javafx.com/javafx/24.0.1"
+            fx:controller="dev.ikm.komet.kview.mvvm.view.genediting.GenEditingDetailsController">
+    
+    <top>
+        <VBox BorderPane.alignment="CENTER" minWidth="480.0">
+            <children>
+                <FlowPane styleClass="rounded-top">
+                    <children>
+                        <HBox fx:id="tabHeader" prefHeight="18.0" spacing="4.0"
+                              style="-fx-background-color: -Natural-Grey-Main;">
+                            <styleClass>
+                                <String fx:value="lidr-rounded-tab"/>
+                            </styleClass>
+                            <children>
+                                <Region prefHeight="12.0" prefWidth="8.4" styleClass="lidr-tab-icon"/>
+                                <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="lidr-tab-text"
+                                      text="Pattern Semantic"/>
+                            </children>
+                            <cursor>
+                                <Cursor fx:constant="CLOSED_HAND"/>
+                            </cursor>
                         </HBox>
-                     </children>
-                  </FlowPane>
-                  <HBox fx:id="conceptHeaderControlToolBarHbox" prefHeight="100.0" prefWidth="762.0" style="-fx-background-color: -Natural-Grey-Main;">
-                     <children>
+                    </children>
+                </FlowPane>
+                <HBox fx:id="conceptHeaderControlToolBarHbox" prefHeight="100.0" prefWidth="762.0"
+                      style="-fx-background-color: -Natural-Grey-Main;">
+                    <children>
                         <MenuButton fx:id="coordinatesMenuButton" contentDisplay="GRAPHIC_ONLY">
-                           <styleClass>
-                              <String fx:value="icon" />
-                              <String fx:value="coordinate" />
-                           </styleClass>
-                           <tooltip><Tooltip text="Coordinates" /></tooltip>
+                            <styleClass>
+                                <String fx:value="icon"/>
+                                <String fx:value="coordinate"/>
+                            </styleClass>
+                            <tooltip>
+                                <Tooltip text="Coordinates"/>
+                            </tooltip>
                         </MenuButton>
-                        <Rectangle fill="DODGERBLUE" height="26.0" stroke="BLACK" strokeType="INSIDE" styleClass="vertical-divider" width="1.0" />
+                        <Rectangle fill="DODGERBLUE" height="26.0" stroke="BLACK" strokeType="INSIDE"
+                                   styleClass="vertical-divider" width="1.0"/>
                         <HBox fx:id="controlBoxHbox1" alignment="CENTER" spacing="15.0">
-                           <children>
-                              <Button fx:id="savePatternButton" mnemonicParsing="false" onAction="#save" text="Button">
-                                 <graphic>
-                                    <SVGPath fillRule="EVEN_ODD" styleClass="duplicate">
-                                       <content><SVGConstants fx:constant="SAVE_SVG_PATH" /></content>
-                                    </SVGPath>
-                                 </graphic>
-                                 <tooltip><Tooltip text="Publish" /></tooltip>
-                              </Button>
-                              <Button mnemonicParsing="false" text="Button">
-                                 <graphic>
-                                    <SVGPath fillRule="EVEN_ODD" styleClass="duplicate">
-                                       <content><SVGConstants fx:constant="DUPLICATE_SVG_PATH" /></content>
-                                    </SVGPath>
-                                 </graphic>
-                                 <tooltip><Tooltip text="Duplicate Semantic" /></tooltip>
-                              </Button>
-                              <Button mnemonicParsing="false" styleClass="share-concept" text="Button">
-                                 <graphic>
-                                    <Region styleClass="share-icon" />
-                                 </graphic>
-                                 <tooltip><Tooltip text="Share Semantic" /></tooltip>
-                              </Button>
-                              <Button mnemonicParsing="false" styleClass="favorite-concept" text="Button">
-                                 <graphic>
-                                    <Region styleClass="favorite-icon" />
-                                 </graphic>
-                                 <tooltip><Tooltip text="Favorite Semantic" /></tooltip>
-                              </Button>
-                              <ToggleButton fx:id="reasonerToggleButton" mnemonicParsing="false" onAction="#openReasonerSlideout" styleClass="reasoner" text="ToggleButton">
-                                 <graphic>
-                                    <Region prefHeight="200.0" prefWidth="200.0">
-                                       <styleClass>
-                                          <String fx:value="icon" />
-                                          <String fx:value="reasoner-icon" />
-                                       </styleClass>
-                                    </Region>
-                                 </graphic>
-                                 <tooltip><Tooltip text="Reasoner" /></tooltip>
-                              </ToggleButton>
-                           </children>
+                            <children>
+                                <Button fx:id="savePatternButton" mnemonicParsing="false" onAction="#save"
+                                        text="Button">
+                                    <graphic>
+                                        <SVGPath fillRule="EVEN_ODD" styleClass="duplicate">
+                                            <content>
+                                                <SVGConstants fx:constant="SAVE_SVG_PATH"/>
+                                            </content>
+                                        </SVGPath>
+                                    </graphic>
+                                    <tooltip>
+                                        <Tooltip text="Publish"/>
+                                    </tooltip>
+                                </Button>
+                                <Button mnemonicParsing="false" text="Button">
+                                    <graphic>
+                                        <SVGPath fillRule="EVEN_ODD" styleClass="duplicate">
+                                            <content>
+                                                <SVGConstants fx:constant="DUPLICATE_SVG_PATH"/>
+                                            </content>
+                                        </SVGPath>
+                                    </graphic>
+                                    <tooltip>
+                                        <Tooltip text="Duplicate Semantic"/>
+                                    </tooltip>
+                                </Button>
+                                <Button mnemonicParsing="false" styleClass="share-concept" text="Button">
+                                    <graphic>
+                                        <Region styleClass="share-icon"/>
+                                    </graphic>
+                                    <tooltip>
+                                        <Tooltip text="Share Semantic"/>
+                                    </tooltip>
+                                </Button>
+                                <Button mnemonicParsing="false" styleClass="favorite-concept" text="Button">
+                                    <graphic>
+                                        <Region styleClass="favorite-icon"/>
+                                    </graphic>
+                                    <tooltip>
+                                        <Tooltip text="Favorite Semantic"/>
+                                    </tooltip>
+                                </Button>
+                                <ToggleButton fx:id="reasonerToggleButton" mnemonicParsing="false"
+                                              onAction="#openReasonerSlideout" styleClass="reasoner"
+                                              text="ToggleButton">
+                                    <graphic>
+                                        <Region prefHeight="200.0" prefWidth="200.0">
+                                            <styleClass>
+                                                <String fx:value="icon"/>
+                                                <String fx:value="reasoner-icon"/>
+                                            </styleClass>
+                                        </Region>
+                                    </graphic>
+                                    <tooltip>
+                                        <Tooltip text="Reasoner"/>
+                                    </tooltip>
+                                </ToggleButton>
+                            </children>
                         </HBox>
-                        <Rectangle fill="DODGERBLUE" height="26.0" stroke="BLACK" strokeType="INSIDE" styleClass="vertical-divider" width="1.0" />
+                        <Rectangle fill="DODGERBLUE" height="26.0" stroke="BLACK" strokeType="INSIDE"
+                                   styleClass="vertical-divider" width="1.0"/>
                         <Button mnemonicParsing="false" text="Button">
-                           <graphic>
-                              <Region prefHeight="200.0" prefWidth="200.0" styleClass="kview-listview" />
-                           </graphic>
-                           <tooltip><Tooltip text="List View" /></tooltip>
+                            <graphic>
+                                <Region prefHeight="200.0" prefWidth="200.0" styleClass="kview-listview"/>
+                            </graphic>
+                            <tooltip>
+                                <Tooltip text="List View"/>
+                            </tooltip>
                         </Button>
-                        <ToggleButton fx:id="timelineToggleButton" mnemonicParsing="false" onAction="#openTimelinePanel" styleClass="timeline" text="ToggleButton">
-                           <graphic>
-                              <Region prefHeight="200.0" prefWidth="200.0">
-                                 <styleClass>
-                                    <String fx:value="icon" />
-                                    <String fx:value="timeline-icon" />
-                                 </styleClass>
-                              </Region>
-                           </graphic>
-                           <tooltip><Tooltip text="Time Travel" /></tooltip>
+                        <ToggleButton fx:id="timelineToggleButton" mnemonicParsing="false" onAction="#openTimelinePanel"
+                                      styleClass="timeline" text="ToggleButton">
+                            <graphic>
+                                <Region prefHeight="200.0" prefWidth="200.0">
+                                    <styleClass>
+                                        <String fx:value="icon"/>
+                                        <String fx:value="timeline-icon"/>
+                                    </styleClass>
+                                </Region>
+                            </graphic>
+                            <tooltip>
+                                <Tooltip text="Time Travel"/>
+                            </tooltip>
                         </ToggleButton>
-                        <Region fx:id="controlBoxRegion2" minWidth="10.0" prefHeight="200.0" prefWidth="200.0" HBox.hgrow="ALWAYS" />
-                        <Text fill="#FFFFFF" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="properties-toggle" text="PROPERTIES">
-                           <font>
-                              <Font name="Open Sans SemiBold" size="13.0" />
-                           </font>
+                        <Region fx:id="controlBoxRegion2" minWidth="10.0" prefHeight="200.0" prefWidth="200.0"
+                                HBox.hgrow="ALWAYS"/>
+                        <Text fill="#FFFFFF" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="properties-toggle"
+                              text="PROPERTIES">
+                            <font>
+                                <Font name="Open Sans SemiBold" size="13.0"/>
+                            </font>
                         </Text>
-                        <ToggleButton fx:id="propertiesToggleButton" mnemonicParsing="false" onAction="#openPropertiesPanel" text="ToggleButton">
-                           <graphic>
-                              <Group>
-                                 <children>
-                                    <Rectangle arcHeight="5.0" arcWidth="5.0" fill="DODGERBLUE" height="20.0" stroke="BLACK" strokeType="INSIDE" styleClass="toggle-switch-body" width="32.0" />
-                                    <Ellipse centerX="10.0" centerY="10.0" fill="DODGERBLUE" radiusX="8.0" radiusY="8.0" stroke="BLACK" strokeType="INSIDE" styleClass="property-toggle-switch" />
-                                 </children>
-                              </Group>
-                           </graphic>
+                        <ToggleButton fx:id="propertiesToggleButton" mnemonicParsing="false"
+                                      onAction="#openPropertiesPanel" text="ToggleButton">
+                            <graphic>
+                                <Group>
+                                    <children>
+                                        <Rectangle arcHeight="5.0" arcWidth="5.0" fill="DODGERBLUE" height="20.0"
+                                                   stroke="BLACK" strokeType="INSIDE" styleClass="toggle-switch-body"
+                                                   width="32.0"/>
+                                        <Ellipse centerX="10.0" centerY="10.0" fill="DODGERBLUE" radiusX="8.0"
+                                                 radiusY="8.0" stroke="BLACK" strokeType="INSIDE"
+                                                 styleClass="property-toggle-switch"/>
+                                    </children>
+                                </Group>
+                            </graphic>
                         </ToggleButton>
-                        <Rectangle fx:id="controlBoxRectangle1" fill="DODGERBLUE" height="26.0" stroke="BLACK" strokeType="INSIDE" styleClass="vertical-divider" width="1.0" />
-                        <Button fx:id="closeConceptButton" mnemonicParsing="false" onAction="#closeConceptWindow" text="Button">
-                           <graphic>
-                              <Region prefHeight="200.0" prefWidth="200.0" styleClass="close-window" />
-                           </graphic>
+                        <Rectangle fx:id="controlBoxRectangle1" fill="DODGERBLUE" height="26.0" stroke="BLACK"
+                                   strokeType="INSIDE" styleClass="vertical-divider" width="1.0"/>
+                        <Button fx:id="closeConceptButton" mnemonicParsing="false" onAction="#closeConceptWindow"
+                                text="Button">
+                            <graphic>
+                                <Region prefHeight="200.0" prefWidth="200.0" styleClass="close-window"/>
+                            </graphic>
                         </Button>
-                     </children>
-                     <padding>
-                        <Insets left="5.0" right="5.0" />
-                     </padding>
-                     <styleClass>
-                        <String fx:value="concept-header-control" />
-                        <String fx:value="rounded-upper-right-only" />
-                     </styleClass>
-                  </HBox>
-               </children>
-            </VBox>
-         </top>
-         <right>
-            <HBox styleClass="main-right-container" BorderPane.alignment="CENTER">
-               <children>
-                  <Pane fx:id="propertiesSlideoutTrayPane" styleClass="slideout-tray-pane" />
-                  <Pane fx:id="timelineSlideoutTrayPane" styleClass="slideout-tray-pane" />
-               </children>
-            </HBox>
-         </right>
-         <center>
-            <BorderPane prefWidth="762.0" styleClass="main-center-container" BorderPane.alignment="CENTER">
-               <center>
-                  <VBox focusTraversable="true" maxHeight="1.7976931348623157E308" prefWidth="762.0">
-                     <children>
+                    </children>
+                    <padding>
+                        <Insets left="5.0" right="5.0"/>
+                    </padding>
+                    <styleClass>
+                        <String fx:value="concept-header-control"/>
+                        <String fx:value="rounded-upper-right-only"/>
+                    </styleClass>
+                </HBox>
+            </children>
+        </VBox>
+    </top>
+    <right>
+        <HBox styleClass="main-right-container" BorderPane.alignment="CENTER">
+            <children>
+                <Pane fx:id="propertiesSlideoutTrayPane" styleClass="slideout-tray-pane"/>
+                <Pane fx:id="timelineSlideoutTrayPane" styleClass="slideout-tray-pane"/>
+            </children>
+        </HBox>
+    </right>
+    <center>
+        <BorderPane prefWidth="762.0" styleClass="main-center-container" BorderPane.alignment="CENTER">
+            <top>
+                <GridPane hgap="8.0" maxWidth="1.7976931348623157E308"
+                          styleClass="concept-detail-banner-background">
+                    
+                    <padding>
+                        <Insets top="8.0" right="8.0" bottom="4.0" left="8.0"/>
+                    </padding>
+                    
+                    <columnConstraints>
+                        <ColumnConstraints halignment="LEFT" prefWidth="42.0"/>
+                        <ColumnConstraints halignment="LEFT" hgrow="NEVER"/>
+                        <ColumnConstraints halignment="LEFT" hgrow="SOMETIMES"/>
+                        <ColumnConstraints halignment="RIGHT" hgrow="NEVER" prefWidth="210.0" minWidth="210.0"/>
+                    </columnConstraints>
+                    
+                    <rowConstraints>
+                        <RowConstraints fillHeight="false" vgrow="NEVER" valignment="TOP"/>
+                        <RowConstraints vgrow="NEVER"/>
+                        <RowConstraints vgrow="NEVER"/>
+                        <RowConstraints vgrow="NEVER"/>
+                        <RowConstraints vgrow="ALWAYS" valignment="BOTTOM"/>
+                    </rowConstraints>
+                    
+                    <ImageView fx:id="identiconImageView" fitWidth="44.0" pickOnBounds="true" preserveRatio="true"
+                               GridPane.columnIndex="0" GridPane.rowIndex="0" GridPane.rowSpan="3"
+                               GridPane.valignment="TOP">
+                        <Image url="@../images/identicon-placeholder.png"/>
+                    </ImageView>
+                    
+                    <Label fx:id="semanticTitleText" text="SEMANTIC TITLE"
+                           GridPane.columnIndex="1" GridPane.rowIndex="0" GridPane.columnSpan="2" wrapText="true">
+                        <font>
+                            <Font name="Open Sans Regular" size="17.0"/>
+                        </font>
+                        <tooltip>
+                            <Tooltip fx:id="conceptNameTooltip" text="Empty Tooltip"/>
+                        </tooltip>
+                    </Label>
+                    
+                    <Label fx:id="semanticDescriptionLabel" text="Semantic for Test Performed Pattern"
+                           GridPane.rowIndex="1" GridPane.columnIndex="1" GridPane.columnSpan="2" wrapText="true"/>
+                    
+                    
+                    <Label styleClass="semantic-banner-label" text="Meaning:" GridPane.rowIndex="2"
+                           GridPane.columnIndex="1" minWidth="50.0" GridPane.valignment="TOP"/>
+                    
+                    <Label fx:id="semanticMeaningText" styleClass="semantic-banner-value" text="[]" wrapText="true"
+                           GridPane.rowIndex="2" GridPane.columnIndex="2" GridPane.valignment="TOP"/>
+                    
+                    
+                    <Label styleClass="semantic-banner-label" text="Purpose:" GridPane.rowIndex="3"
+                           GridPane.columnIndex="1" GridPane.valignment="TOP"/>
+                    
+                    <Label fx:id="semanticPurposeText" styleClass="semantic-banner-value" text="[]" wrapText="true"
+                           GridPane.rowIndex="3" GridPane.columnIndex="2" GridPane.valignment="TOP"/>
+                    
+                    
+                    <PublicIDControl fx:id="identifierControl" GridPane.columnSpan="3"
+                                     GridPane.rowIndex="4" GridPane.columnIndex="0" GridPane.valignment="BOTTOM"
+                                     GridPane.halignment="LEFT"/>
+                    
+                    
+                    <StackPane GridPane.columnIndex="3" GridPane.rowIndex="0" GridPane.rowSpan="4"
+                               styleClass="stamp-container">
+                        <StampViewControl fx:id="stampViewControl" prefWidth="210"/>
+                    
+                    </StackPane>
+                
+                </GridPane>
+            </top>
+            <center>
+                <VBox focusTraversable="true" maxHeight="1.7976931348623157E308" prefWidth="762.0">
+                    <children>
                         <HBox prefWidth="711.0">
-                           <children>
-                              <TitledPane fx:id="referenceComponentTitledPane" contentDisplay="BOTTOM" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" nodeOrientation="LEFT_TO_RIGHT" prefWidth="5000.0" styleClass="pattern-titled-pane" text="REFERENCE COMPONENT">
-                                 <font>
-                                    <Font name="Noto Sans Batak Regular" size="12.0" />
-                                 </font>
-                                 <content>
-                                    <VBox maxWidth="1.7976931348623157E308" styleClass="semantic-field-container">
-                                       <KLReadOnlyComponentControl fx:id="referenceComponent" />
-                                    </VBox>
-                                 </content>
-                              </TitledPane>
-                              <Pane>
-                                 <children>
-                                    <HBox layoutX="-32.0">
-                                       <children>
-                                          <Separator maxWidth="-Infinity" orientation="VERTICAL" prefHeight="20.0" styleClass="pattern-vertical-separator">
-                                             <HBox.margin>
-                                                <Insets top="4.0" />
-                                             </HBox.margin>
-                                          </Separator>
-                                          <Button fx:id="addReferenceButton" mnemonicParsing="false" onAction="#showAddRefComponentPanel" styleClass="add-pencil-button" text="Button">
-                                             <graphic>
-                                                <Region prefHeight="200.0" prefWidth="200.0" styleClass="add-pencil" stylesheets="@../kview.css" />
-                                             </graphic>
-                                             <tooltip><Tooltip text="Edit Reference Component" /></tooltip>
-                                             <HBox.margin>
-                                                <Insets top="4.0" />
-                                             </HBox.margin>
-                                          </Button>
-                                       </children>
-                                    </HBox>
-                                 </children>
-                              </Pane>
-                           </children>
+                            <children>
+                                <TitledPane fx:id="referenceComponentTitledPane" contentDisplay="BOTTOM"
+                                            maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
+                                            nodeOrientation="LEFT_TO_RIGHT" prefWidth="5000.0"
+                                            styleClass="pattern-titled-pane" text="REFERENCE COMPONENT">
+                                    <font>
+                                        <Font name="Noto Sans Batak Regular" size="12.0"/>
+                                    </font>
+                                    <content>
+                                        <VBox maxWidth="1.7976931348623157E308" styleClass="semantic-field-container">
+                                            <KLReadOnlyComponentControl fx:id="referenceComponent"/>
+                                        </VBox>
+                                    </content>
+                                </TitledPane>
+                                <Pane>
+                                    <children>
+                                        <HBox layoutX="-32.0">
+                                            <children>
+                                                <Separator maxWidth="-Infinity" orientation="VERTICAL" prefHeight="20.0"
+                                                           styleClass="pattern-vertical-separator">
+                                                    <HBox.margin>
+                                                        <Insets top="4.0"/>
+                                                    </HBox.margin>
+                                                </Separator>
+                                                <Button fx:id="addReferenceButton" mnemonicParsing="false"
+                                                        onAction="#showAddRefComponentPanel"
+                                                        styleClass="add-pencil-button" text="Button">
+                                                    <graphic>
+                                                        <Region prefHeight="200.0" prefWidth="200.0"
+                                                                styleClass="add-pencil" stylesheets="@../kview.css"/>
+                                                    </graphic>
+                                                    <tooltip>
+                                                        <Tooltip text="Edit Reference Component"/>
+                                                    </tooltip>
+                                                    <HBox.margin>
+                                                        <Insets top="4.0"/>
+                                                    </HBox.margin>
+                                                </Button>
+                                            </children>
+                                        </HBox>
+                                    </children>
+                                </Pane>
+                            </children>
                         </HBox>
                         <HBox layoutX="14.0" layoutY="135.0" prefWidth="711.0" VBox.vgrow="ALWAYS">
-                           <children>
-                              <TitledPane fx:id="semanticDetailsTitledPane" contentDisplay="BOTTOM" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" nodeOrientation="LEFT_TO_RIGHT" prefWidth="5000.0" styleClass="pattern-titled-pane" text="SEMANTIC DETAILS">
-                                 <font>
-                                    <Font name="Noto Sans Batak Regular" size="12.0" />
-                                 </font>
-                                 <content>
-                                    <ScrollPane styleClass="semantic-details-scroll">
-                                       <content>
-                                          <VBox fx:id="semanticDetailsVBox" maxWidth="1.7976931348623157E308" prefWidth="610.0" styleClass="titled-content-background">
-                                             <styleClass>
-                                                <String fx:value="titled-content-background" />
-                                                <String fx:value="semantic-field-container" />
-                                             </styleClass>
-                                          </VBox>
-                                       </content>
-                                    </ScrollPane>
-                                 </content>
-                              </TitledPane>
-                              <Pane>
-                                 <children>
-                                    <HBox layoutX="-32.0">
-                                       <children>
-                                          <Separator orientation="VERTICAL" prefHeight="20.0" styleClass="pattern-vertical-separator">
-                                             <HBox.margin>
-                                                <Insets top="4.0" />
-                                             </HBox.margin>
-                                          </Separator>
-                                          <Button fx:id="editFieldsButton" mnemonicParsing="false" onAction="#showAndEditSemanticFieldsPanel" styleClass="add-pencil-button" text="Button">
-                                             <graphic>
-                                                <Region prefHeight="200.0" prefWidth="200.0" styleClass="add-pencil" stylesheets="@../kview.css" />
-                                             </graphic>
-                                             <tooltip><Tooltip text="Edit Details" /></tooltip>
-                                             <HBox.margin>
-                                                <Insets top="4.0" />
-                                             </HBox.margin>
-                                          </Button>
-                                       </children>
-                                    </HBox>
-                                 </children>
-                              </Pane>
-                           </children>
+                            <children>
+                                <TitledPane fx:id="semanticDetailsTitledPane" contentDisplay="BOTTOM"
+                                            maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
+                                            nodeOrientation="LEFT_TO_RIGHT" prefWidth="5000.0"
+                                            styleClass="pattern-titled-pane" text="SEMANTIC DETAILS">
+                                    <font>
+                                        <Font name="Noto Sans Batak Regular" size="12.0"/>
+                                    </font>
+                                    <content>
+                                        <ScrollPane styleClass="semantic-details-scroll">
+                                            <content>
+                                                <VBox fx:id="semanticDetailsVBox" maxWidth="1.7976931348623157E308"
+                                                      prefWidth="610.0" styleClass="titled-content-background">
+                                                    <styleClass>
+                                                        <String fx:value="titled-content-background"/>
+                                                        <String fx:value="semantic-field-container"/>
+                                                    </styleClass>
+                                                </VBox>
+                                            </content>
+                                        </ScrollPane>
+                                    </content>
+                                </TitledPane>
+                                <Pane>
+                                    <children>
+                                        <HBox layoutX="-32.0">
+                                            <children>
+                                                <Separator orientation="VERTICAL" prefHeight="20.0"
+                                                           styleClass="pattern-vertical-separator">
+                                                    <HBox.margin>
+                                                        <Insets top="4.0"/>
+                                                    </HBox.margin>
+                                                </Separator>
+                                                <Button fx:id="editFieldsButton" mnemonicParsing="false"
+                                                        onAction="#showAndEditSemanticFieldsPanel"
+                                                        styleClass="add-pencil-button" text="Button">
+                                                    <graphic>
+                                                        <Region prefHeight="200.0" prefWidth="200.0"
+                                                                styleClass="add-pencil" stylesheets="@../kview.css"/>
+                                                    </graphic>
+                                                    <tooltip>
+                                                        <Tooltip text="Edit Details"/>
+                                                    </tooltip>
+                                                    <HBox.margin>
+                                                        <Insets top="4.0"/>
+                                                    </HBox.margin>
+                                                </Button>
+                                            </children>
+                                        </HBox>
+                                    </children>
+                                </Pane>
+                            </children>
                         </HBox>
-                     </children>
-                  </VBox>
-               </center>
-               <top>
-                  <BorderPane prefWidth="894.0" styleClass="concept-detail-banner-background" BorderPane.alignment="CENTER">
-                     <center>
-                        <GridPane hgap="8.0" maxHeight="-Infinity" maxWidth="1.7976931348623157E308" prefWidth="507.0" styleClass="concept-detail-banner-background">
-                           <columnConstraints>
-                              <ColumnConstraints halignment="LEFT" maxWidth="586.0" minWidth="-Infinity" prefWidth="42.0" />
-                              <ColumnConstraints halignment="LEFT" hgrow="ALWAYS" maxWidth="1.7976931348623157E308" minWidth="234.0" prefWidth="416.0" />
-                              <ColumnConstraints />
-                           </columnConstraints>
-                           <rowConstraints>
-                              <RowConstraints minHeight="48.0" />
-                              <RowConstraints minHeight="0.0" />
-                              <RowConstraints maxHeight="-Infinity" minHeight="-Infinity" prefHeight="22.0" vgrow="SOMETIMES" />
-                              <RowConstraints maxHeight="22.0" minHeight="-Infinity" prefHeight="22.0" vgrow="SOMETIMES" />
-                           </rowConstraints>
-                           <children>
-                              <ImageView fx:id="identiconImageView" fitWidth="44.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="0" GridPane.rowIndex="0" GridPane.rowSpan="2" GridPane.valignment="TOP">
-                                 <Image url="@../images/identicon-placeholder.png" />
-                              </ImageView>
-                              <Label fx:id="semanticTitleText" alignment="TOP_LEFT" maxWidth="1.7976931348623157E308" prefWidth="495.0" text="SEMANTIC TITLE" textFill="#212430" wrapText="true" GridPane.columnIndex="1" GridPane.rowIndex="0" GridPane.valignment="TOP">
-                                 <font>
-                                    <Font name="Open Sans Regular" size="17.0" />
-                                 </font>
-                                 <tooltip>
-                                    <Tooltip fx:id="conceptNameTooltip" text="Empty Tooltip" />
-                                 </tooltip>
-                              </Label>
-                              <Label fx:id="semanticDescriptionLabel" text="Semantic for Test Performed Pattern" GridPane.columnSpan="2" GridPane.rowIndex="1" />
-                              <TextFlow GridPane.columnSpan="2" GridPane.rowIndex="2" GridPane.rowSpan="1">
-                                 <children>
-                                    <Text fx:id="semanticMeaningLabelText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="semantic-banner-label" text="Meaning:  " translateY="3.0" />
-                                    <Text fx:id="semanticMeaningText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="semantic-banner-value" text="[]" translateY="3.5" />
-                                    <Region prefHeight="10.0" prefWidth="10.0" />
-                                    <Text strokeType="OUTSIDE" strokeWidth="0.0" styleClass="semantic-banner-label" text="Purpose:  " translateY="3.5" />
-                                    <Text fx:id="semanticPurposeText" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="semantic-banner-value" text="[]" translateY="3.5" />
-                                 </children>
-                              </TextFlow>
-                              <PublicIDControl fx:id="identifierControl" styleClass="concept-definition-title" GridPane.columnSpan="2" GridPane.rowIndex="3" GridPane.rowSpan="1" />
-                           </children>
-                           <padding>
-                              <Insets bottom="2.0" left="12.0" right="8.0" top="8.0" />
-                           </padding>
-                        </GridPane>
-                     </center>
-                     <right>
-                        <AnchorPane prefWidth="210.0" BorderPane.alignment="CENTER">
-                           <BorderPane.margin>
-                              <Insets top="5" bottom="5" right="5"/>
-                           </BorderPane.margin>
-                           <StampViewControl fx:id="stampViewControl" prefWidth="210" />
-                        </AnchorPane>
-                     </right>
-                  </BorderPane>
-               </top>
-            </BorderPane>
-         </center>
-      </BorderPane>
-   </center>
-   <styleClass>
-      <String fx:value="concept-detail-pane" />
-      <String fx:value="lidr-container" />
-      <String fx:value="pattern-window" />
-   </styleClass>
+                    </children>
+                </VBox>
+            </center>
+        
+        </BorderPane>
+    </center>
+    <styleClass>
+        <String fx:value="concept-detail-pane"/>
+        <String fx:value="lidr-container"/>
+        <String fx:value="pattern-window"/>
+    </styleClass>
 </BorderPane>

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
@@ -248,7 +248,7 @@
                            GridPane.rowIndex="3" GridPane.columnIndex="2" GridPane.valignment="TOP"/>
                     
                     
-                    <PublicIDControl fx:id="identifierControl" GridPane.columnSpan="3"
+                    <PublicIDControl fx:id="identifierControl" GridPane.columnSpan="4"
                                      GridPane.rowIndex="4" GridPane.columnIndex="0" GridPane.valignment="BOTTOM"
                                      GridPane.halignment="LEFT"/>
                     


### PR DESCRIPTION
made the design similar to the figma base design by aligning the semantic description directly under the sematic title

implemented correct wraping behaviour and expanding behaviour for the details

changed the stampview part from beeing inside a anchorpane to a stackpane allowing for simpler integration of upcoming changes already applied in concept view

still continue to providing a identifier field, while this element is missing in the figma for Pattern Semantics