### PR TITLE
Feature/finished/iia 2796 child view coordinate menu item text fix

### DIFF
--- a/framework/src/main/java/dev/ikm/komet/framework/view/ObservableViewBase.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ObservableViewBase.java
@@ -50,6 +50,9 @@ public abstract class ObservableViewBase
     protected final ObservableLogicCoordinateBase logicCoordinateObservable;
 
     protected final ObservableEditCoordinateBase editCoordinateObservable;
+
+    public static final String DEFAULT_VIEW_NAME = "View";
+
     /**
      * Note that if you don't declare a listener as final in this way, and just use method references, or
      * a direct lambda expression, you will not be able to remove the listener, since each method reference will create
@@ -80,7 +83,7 @@ public abstract class ObservableViewBase
 
     //~--- constructors --------------------------------------------------------
     public ObservableViewBase(ViewCoordinate viewRecord, String name) {
-        super(viewRecord.toViewCoordinateRecord(), name != null ? name: "View");
+        super(viewRecord.toViewCoordinateRecord(), name != null ? name : DEFAULT_VIEW_NAME);
         this.stampCoordinateObservable = makeStampCoordinateObservable(viewRecord);
         this.navigationCoordinateObservable = makeNavigationCoordinateObservable(viewRecord);
         this.languageCoordinates = makeLanguageCoordinateListProperty(viewRecord);

--- a/framework/src/main/java/dev/ikm/komet/framework/view/ViewMenuModel.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ViewMenuModel.java
@@ -35,12 +35,12 @@ import javafx.scene.shape.Shape;
 import java.util.List;
 
 public class ViewMenuModel {
-    private final ViewProperties viewProperties;
-    private final ViewCalculatorWithCache viewCalculator;
-    private final Control baseControlToShowOverride;
-    private final Shape baseControlGraphic;
-    private final Menu coordinateMenu;
-    private final MenuButton coordinateMenuButton;
+    private ViewProperties viewProperties;
+    private ViewCalculatorWithCache viewCalculator;
+    private Control baseControlToShowOverride;
+    private Shape baseControlGraphic;
+    private Menu coordinateMenu;
+    private MenuButton coordinateMenuButton;
     private String oldFill = null;
     private final ChangeListener<ViewCoordinateRecord> viewChangedListener = this::viewCoordinateChanged;
     // whichMenu added to help with debugging
@@ -52,12 +52,27 @@ public class ViewMenuModel {
 
 
     public ViewMenuModel(ViewProperties viewProperties, Control baseControlToShowOverride, Menu coordinateMenu, String whichMenu) {
-        this.viewProperties = viewProperties;
         this.coordinateMenu = coordinateMenu;
         this.coordinateMenuButton = null;
+
+
+        initialize(viewProperties, baseControlToShowOverride, whichMenu);
+    }
+
+    public ViewMenuModel(ViewProperties viewProperties, MenuButton coordinateMenuButton, String whichMenu) {
+        this.coordinateMenu = null;
+        this.coordinateMenuButton = coordinateMenuButton;
+
+        initialize(viewProperties, coordinateMenuButton, whichMenu);
+    }
+
+    private void initialize(ViewProperties viewProperties, Control baseControlToShowOverride, String whichMenu) {
+        this.viewProperties = viewProperties;
         this.viewProperties.nodeView().addListener(this.viewChangedListener);
         this.viewCalculator = ViewCalculatorWithCache.getCalculator(this.viewProperties.nodeView().getValue());
-        FxGet.pathCoordinates(viewCalculator).addListener((MapChangeListener<PublicIdStringKey, StampPathImmutable>) change -> updateCoordinateMenu());
+        FxGet.pathCoordinates(viewCalculator).addListener((MapChangeListener<PublicIdStringKey, StampPathImmutable>) change ->
+                updateCoordinateMenu()
+        );
 
         this.baseControlToShowOverride = baseControlToShowOverride;
         if (baseControlToShowOverride instanceof Labeled) {
@@ -77,38 +92,6 @@ public class ViewMenuModel {
         }
 
         updateCoordinateMenu();
-
-    }
-
-    public ViewMenuModel(ViewProperties viewProperties, MenuButton coordinateMenuButton, String whichMenu) {
-        this.viewProperties = viewProperties;
-        this.coordinateMenu = null;
-        this.coordinateMenuButton = coordinateMenuButton;
-        this.viewProperties.nodeView().addListener(this.viewChangedListener);
-        viewCalculator = ViewCalculatorWithCache.getCalculator(this.viewProperties.nodeView().getValue());
-        FxGet.pathCoordinates(viewCalculator).addListener((MapChangeListener<PublicIdStringKey, StampPathImmutable>) change ->
-                updateCoordinateMenu()
-        );
-
-        this.baseControlToShowOverride = coordinateMenuButton;
-        if (baseControlToShowOverride instanceof Labeled) {
-            Node graphic = ((Labeled) this.baseControlToShowOverride).getGraphic();
-            if (graphic instanceof AnchorPane) {
-                Node childZero = ((AnchorPane) graphic).getChildren().get(0);
-                this.baseControlGraphic = (Shape) childZero;
-            } else {
-                baseControlGraphic = null;
-            }
-        } else {
-            this.baseControlGraphic = null;
-        }
-
-        if (whichMenu != null) {
-            this.whichMenu = whichMenu;
-        }
-
-        updateCoordinateMenu();
-
     }
 
     public void updateCoordinateMenu() {

--- a/framework/src/main/java/dev/ikm/komet/framework/view/ViewMenuModel.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ViewMenuModel.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 public class ViewMenuModel {
     private final ViewProperties viewProperties;
+    private final ViewCalculatorWithCache viewCalculator;
     private final Control baseControlToShowOverride;
     private final Shape baseControlGraphic;
     private final Menu coordinateMenu;
@@ -55,7 +56,7 @@ public class ViewMenuModel {
         this.coordinateMenu = coordinateMenu;
         this.coordinateMenuButton = null;
         this.viewProperties.nodeView().addListener(this.viewChangedListener);
-        ViewCalculatorWithCache viewCalculator = ViewCalculatorWithCache.getCalculator(this.viewProperties.nodeView().getValue());
+        this.viewCalculator = ViewCalculatorWithCache.getCalculator(this.viewProperties.nodeView().getValue());
         FxGet.pathCoordinates(viewCalculator).addListener((MapChangeListener<PublicIdStringKey, StampPathImmutable>) change -> updateCoordinateMenu());
 
         this.baseControlToShowOverride = baseControlToShowOverride;
@@ -84,7 +85,7 @@ public class ViewMenuModel {
         this.coordinateMenu = null;
         this.coordinateMenuButton = coordinateMenuButton;
         this.viewProperties.nodeView().addListener(this.viewChangedListener);
-        ViewCalculatorWithCache viewCalculator = ViewCalculatorWithCache.getCalculator(this.viewProperties.nodeView().getValue());
+        viewCalculator = ViewCalculatorWithCache.getCalculator(this.viewProperties.nodeView().getValue());
         FxGet.pathCoordinates(viewCalculator).addListener((MapChangeListener<PublicIdStringKey, StampPathImmutable>) change ->
                 updateCoordinateMenu()
         );
@@ -139,7 +140,6 @@ public class ViewMenuModel {
             }
 
             if (menuItems != null) {
-                ViewCalculatorWithCache viewCalculator = ViewCalculatorWithCache.getCalculator(viewProperties.nodeView().getValue());
                 var viewMenuTask = new ViewMenuTask(viewCalculator, viewProperties.nodeView(), whichMenu);
 
                 final List<MenuItem> finalMenuItems = menuItems;

--- a/framework/src/main/java/dev/ikm/komet/framework/view/ViewMenuTask.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ViewMenuTask.java
@@ -739,13 +739,7 @@ public class ViewMenuTask extends TrackingCallable<List<MenuItem>> {
         } else if (value instanceof StateSet) {
             sb.append(((StateSet) value).toUserString());
         } else {
-            try {
-                viewCalculator.toEntityString(value, entityFacade -> getPreferredDescriptionStringOrNid(viewCalculator, entityFacade), sb);
-            } catch (Exception e) {
-                LOG.error("Exception calling getPreferredDescriptionStringOrNid", e);
-
-                sb.append(Integer.MAX_VALUE);
-            }
+            viewCalculator.toEntityString(value, entityFacade -> getPreferredDescriptionStringOrNid(viewCalculator, entityFacade), sb);
         }
         return sb.toString();
     }
@@ -762,8 +756,7 @@ public class ViewMenuTask extends TrackingCallable<List<MenuItem>> {
         List<MenuItem> menuItems = new ArrayList<>();
         try {
             makeCoordinateDisplayMenu(viewCalculator,
-                    menuItems,
-                    observableCoordinate);
+                    menuItems, observableCoordinate, whichMenu);
             updateTitle("Updated View Menu");
             updateMessage("In " + durationString());
             LOG.info("Updated View Menu in " + durationString());
@@ -782,13 +775,17 @@ public class ViewMenuTask extends TrackingCallable<List<MenuItem>> {
      */
     private void makeCoordinateDisplayMenu(ViewCalculator viewCalculator,
                                            List<MenuItem> menuItems,
-                                           ObservableCoordinate observableCoordinate) {
+                                           ObservableCoordinate observableCoordinate,
+                                           String whichMenu) {
 
         makeRecursiveOverrideMenu(viewCalculator, menuItems,
                 observableCoordinate);
 
         for (Property<?> baseProperty : observableCoordinate.getBaseProperties()) {
-            menuItems.add(new MenuItem(getNameAndValueString(viewCalculator, baseProperty)));
+            // variables added for simpler debugging
+            var basePropStr = baseProperty.toString();
+            var nameValStr = getNameAndValueString(viewCalculator, baseProperty);
+            menuItems.add(new MenuItem(nameValStr));
         }
 
         updateMessage("Making composite coordinate menu");
@@ -796,7 +793,7 @@ public class ViewMenuTask extends TrackingCallable<List<MenuItem>> {
             String propertyName = getPropertyNameWithOverride(viewCalculator, compositeCoordinate);
             Menu compositeMenu = new Menu(propertyName);
             menuItems.add(compositeMenu);
-            makeCoordinateDisplayMenu(viewCalculator, compositeMenu.getItems(), compositeCoordinate);
+            makeCoordinateDisplayMenu(viewCalculator, compositeMenu.getItems(), compositeCoordinate, whichMenu);
         }
 
         if (observableCoordinate instanceof ObservableView observableView) {


### PR DESCRIPTION
Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-2796

Summary of changes:

- ViewMenuModel
    - It was discovered that ViewMenuModel used the ViewCalculator differently than the JournalController
    - Modified ViewMenuModel to not create a new ViewCalculator when a view coordinate change event occurs
    - Refactored ViewMenuModel constructors to remove duplicate code
- ViewMenuTask - removed unnecessary try catch, which is coded within the getPreferredDescriptionStringOrNid() method and not necessary in the getNameAndValueString() method
- ObservableViewBase - added new constant DEFAULT_VIEW_NAME rather than hard-coding the "View" string in the constructor

Before changes:  XML text was displayed in the child view coordinate menus

In a child view coordinate menu select INACTIVE or WITHDRAWN

<img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/6f968204-eee9-4a41-8169-53b88ce494d8" />

The view coordinate menu has XML text

<img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/e6706e57-9a44-48ec-bf84-a4ca1223be8b" />


After changes:  Correct text is displayed in the child view coordinate menus

In a child view coordinate menu select INACTIVE or WITHDRAWN

The view coordinate menu no longer has XML text

<img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/1cfb8e4a-ac20-4688-aea3-ffc43f60d288" />

