### PR TITLE
Feature/finished/IIA-2747: When Stamp form closes, unselect Stamp View on left pane AND IIA-2823 AND IIA-2821

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/StampViewControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/StampViewControl.java
@@ -1,14 +1,13 @@
 package dev.ikm.komet.kview.controls;
 
 import dev.ikm.komet.kview.controls.skin.StampViewControlSkin;
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.css.PseudoClass;
-import javafx.scene.Node;
 import javafx.scene.control.Control;
 
 public class StampViewControl extends Control {
@@ -16,6 +15,15 @@ public class StampViewControl extends Control {
 
     public StampViewControl() {
         getStyleClass().add("stamp-view-control");
+        sceneProperty().addListener(new InvalidationListener() {
+            @Override
+            public void invalidated(Observable observable) {
+                if (getScene() != null) {
+                    getScene().getStylesheets().add(getUserAgentStylesheet());
+                }
+                sceneProperty().removeListener(this);
+            }
+        });
     }
 
     @Override

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/concept/ConceptController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/concept/ConceptController.java
@@ -330,15 +330,11 @@ public class ConceptController {
     private static final PseudoClass V_SCROLLBAR_NEEDED = PseudoClass.getPseudoClass("vertical-scroll-needed");
 
     /**
-     * Stamp Edit
-     */
-    private PopOver stampEdit;
-    private StampEditController stampEditController;
-
-    /**
      *  TODO: View Calculator will need to be refreshed.
      */
     private ViewCalculatorWithCache viewCalculatorWithCache;
+
+    private boolean isUpdatingStampSelection = false;
 
     public ConceptController() {
     }
@@ -1424,6 +1420,10 @@ public class ConceptController {
     }
 
     private void onStampSelectionChanged() {
+        if (isUpdatingStampSelection) {
+            return;
+        }
+
         if (stampViewControl.isSelected()) {
             if (CREATE.equals(conceptViewModel.getPropertyValue(MODE))) {
                 eventBus.publish(conceptTopic, new StampEvent(stampViewControl, StampEvent.CREATE_STAMP));
@@ -1464,6 +1464,10 @@ public class ConceptController {
 
             updateDraggableNodesForPropertiesPanel(false);
         }
+
+        isUpdatingStampSelection = true;
+        stampViewControl.setSelected(propertyToggle.isSelected());
+        isUpdatingStampSelection = false;
     }
 
     /**

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingDetailsController.java
@@ -238,6 +238,8 @@ public class GenEditingDetailsController {
 
     private ObservableSemanticSnapshot observableSemanticSnapshot;
 
+    private boolean isUpdatingStampSelection = false;
+
     private Subscriber<ClosePropertiesPanelEvent> closePropertiesPanelEventSubscriber;
 
     public GenEditingDetailsController() {
@@ -310,6 +312,10 @@ public class GenEditingDetailsController {
     }
 
     private void onStampSelectionChanged() {
+        if (isUpdatingStampSelection) {
+            return;
+        }
+
         if (stampViewControl.isSelected()) {
             if (!propertiesToggleButton.isSelected()) {
                 propertiesToggleButton.fire();
@@ -841,6 +847,10 @@ public class GenEditingDetailsController {
         EvtType<PropertyPanelEvent> eventEvtType = propertyToggle.isSelected() ? OPEN_PANEL : CLOSE_PANEL;
 
         updateDraggableNodesForPropertiesPanel(propertyToggle.isSelected());
+
+        isUpdatingStampSelection = true;
+        stampViewControl.setSelected(propertyToggle.isSelected());
+        isUpdatingStampSelection = false;
 
         EvtBusFactory.getDefaultEvtBus().publish(genEditingViewModel.getPropertyValue(WINDOW_TOPIC), new PropertyPanelEvent(propertyToggle, eventEvtType));
     }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PatternDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PatternDetailsController.java
@@ -273,6 +273,8 @@ public class PatternDetailsController {
     @InjectViewModel
     private PatternViewModel patternViewModel;
 
+    private boolean isUpdatingStampSelection = false;
+
     private final Tooltip publishTooltip = new Tooltip();
 
     private Subscriber<PropertyPanelEvent> patternPropertiesEventSubscriber;
@@ -524,6 +526,10 @@ public class PatternDetailsController {
     }
 
     private void onStampSelectionChanged() {
+        if (isUpdatingStampSelection) {
+            return;
+        }
+
         if (stampViewControl.isSelected()) {
             if (!propertiesToggleButton.isSelected()) {
                 propertiesToggleButton.fire();
@@ -1049,6 +1055,10 @@ public class PatternDetailsController {
         EvtType<PropertyPanelEvent> eventEvtType = propertyToggle.isSelected() ? OPEN_PANEL : CLOSE_PANEL;
 
         updateDraggableNodesForPropertiesPanel(propertyToggle.isSelected());
+
+        isUpdatingStampSelection = true;
+        stampViewControl.setSelected(propertyToggle.isSelected());
+        isUpdatingStampSelection = false;
 
         EvtBusFactory.getDefaultEvtBus().publish(patternViewModel.getPropertyValue(PATTERN_TOPIC), new PropertyPanelEvent(propertyToggle, eventEvtType));
     }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/StampAddFormViewModel.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/StampAddFormViewModel.java
@@ -170,9 +170,9 @@ public class StampAddFormViewModel extends StampFormViewModelBase {
         EntityFacade module = getValue(MODULE);
         EntityFacade path = getValue(PATH);
 
-        String statusString = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(status.nid());
-        String moduleString = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(module.nid());
-        String pathString = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(path.nid());
+        String statusString = getViewProperties().calculator().getDescriptionTextOrNid(status.nid());
+        String moduleString = getViewProperties().calculator().getDescriptionTextOrNid(module.nid());
+        String pathString = getViewProperties().calculator().getDescriptionTextOrNid(path.nid());
 
         String submitMessage = "New " + stampType.getTextDescription() + " version created (" + statusString +
                 ", " + moduleString + ", " + pathString + ")";

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/StampAddFormViewModel.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/StampAddFormViewModel.java
@@ -2,8 +2,10 @@ package dev.ikm.komet.kview.mvvm.viewmodel;
 
 import dev.ikm.komet.framework.controls.TimeUtils;
 import dev.ikm.komet.framework.view.ViewProperties;
+import dev.ikm.komet.kview.controls.Toast;
 import dev.ikm.komet.kview.events.ClosePropertiesPanelEvent;
 import dev.ikm.komet.kview.mvvm.view.genediting.ConfirmationDialogController;
+import dev.ikm.komet.kview.mvvm.view.journal.JournalController;
 import dev.ikm.tinkar.component.Stamp;
 import dev.ikm.tinkar.composer.Composer;
 import dev.ikm.tinkar.composer.Session;
@@ -24,6 +26,8 @@ import dev.ikm.tinkar.terms.State;
 import dev.ikm.tinkar.terms.TinkarTerm;
 import javafx.event.ActionEvent;
 import javafx.scene.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.UUID;
@@ -155,7 +159,29 @@ public class StampAddFormViewModel extends StampFormViewModelBase {
     @Override
     public void submitOrConfirm() {
         save();
+        showSucessToast();
         setPropertyValue(IS_CONFIRMED_OR_SUBMITTED, true);
+        EvtBusFactory.getDefaultEvtBus().publish(topic, new ClosePropertiesPanelEvent("StampViewModel2 cancel()",
+                ClosePropertiesPanelEvent.CLOSE_PROPERTIES));
+    }
+
+    private void showSucessToast() {
+        State status = getValue(STATUS);
+        EntityFacade module = getValue(MODULE);
+        EntityFacade path = getValue(PATH);
+
+        String statusString = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(status.nid());
+        String moduleString = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(module.nid());
+        String pathString = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(path.nid());
+
+        String submitMessage = "New " + stampType.getTextDescription() + " version created (" + statusString +
+                ", " + moduleString + ", " + pathString + ")";
+
+        JournalController.toast()
+                .show(
+                        Toast.Status.SUCCESS,
+                        submitMessage
+                );
     }
 
     @Override

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/StampCreateFormViewModel.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/StampCreateFormViewModel.java
@@ -100,9 +100,9 @@ public class StampCreateFormViewModel extends StampFormViewModelBase {
         EntityFacade module = getValue(MODULE);
         EntityFacade path = getValue(PATH);
 
-        String statusString = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(status.nid());
-        String moduleString = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(module.nid());
-        String pathString = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(path.nid());
+        String statusString = getViewProperties().calculator().getDescriptionTextOrNid(status.nid());
+        String moduleString = getViewProperties().calculator().getDescriptionTextOrNid(module.nid());
+        String pathString = getViewProperties().calculator().getDescriptionTextOrNid(path.nid());
 
         String submitMessage = "Stamp definition stored for later use (" + statusString +
                 ", " + moduleString + ", " + pathString + ")";

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/StampCreateFormViewModel.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/StampCreateFormViewModel.java
@@ -1,8 +1,10 @@
 package dev.ikm.komet.kview.mvvm.viewmodel;
 
 import dev.ikm.komet.framework.view.ViewProperties;
+import dev.ikm.komet.kview.controls.Toast;
 import dev.ikm.komet.kview.events.ClosePropertiesPanelEvent;
 import dev.ikm.komet.kview.mvvm.view.genediting.ConfirmationDialogController;
+import dev.ikm.komet.kview.mvvm.view.journal.JournalController;
 import dev.ikm.tinkar.entity.*;
 import dev.ikm.tinkar.events.EvtBusFactory;
 import dev.ikm.tinkar.terms.*;
@@ -87,9 +89,29 @@ public class StampCreateFormViewModel extends StampFormViewModelBase {
     @Override
     public void submitOrConfirm() {
         save();
-
+        showSucessToast();
+        setPropertyValue(IS_CONFIRMED_OR_SUBMITTED, true);
         EvtBusFactory.getDefaultEvtBus().publish(topic, new ClosePropertiesPanelEvent("Stamp From View Model cancel()",
                 ClosePropertiesPanelEvent.CLOSE_PROPERTIES));
+    }
+
+    private void showSucessToast() {
+        State status = getValue(STATUS);
+        EntityFacade module = getValue(MODULE);
+        EntityFacade path = getValue(PATH);
+
+        String statusString = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(status.nid());
+        String moduleString = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(module.nid());
+        String pathString = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(path.nid());
+
+        String submitMessage = "Stamp definition stored for later use (" + statusString +
+                ", " + moduleString + ", " + pathString + ")";
+
+        JournalController.toast()
+                .show(
+                        Toast.Status.SUCCESS,
+                        submitMessage
+                );
     }
 
     @Override
@@ -102,8 +124,6 @@ public class StampCreateFormViewModel extends StampFormViewModelBase {
         }
 
         save(true);
-
-        setPropertyValue(IS_CONFIRMED_OR_SUBMITTED, true);
 
         // We're not going to create a stamp here. Just saving the stamp properties to the view model
         // so that they can be used later to create a new Concept.

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/stamp-view-control.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/stamp-view-control.css
@@ -4,11 +4,27 @@
     -fx-border-radius: 3px;
 
     -fx-padding: 5px;
+
+    highlight-color: #f2faee;
+    highlight-border-color: #9ae281;
 }
 
-.stamp-view-control:selected .stamp-container{
-    -fx-background-color: #f2faee;
+.stamp-view-control:selected .stamp-container {
+    -fx-background-color: highlight-color;
     -fx-background-radius: 3px;
 
-    -fx-border-color: #9ae281;
+    -fx-border-color: highlight-border-color;
+}
+
+.stamp-view-control:hover .stamp-container {
+    -fx-background-color: #f8f8f8;
+    -fx-background-radius: 3px;
+
+    -fx-border-color: #ededed;
+}
+
+.stamp-view-control:selected:hover .stamp-container {
+    -fx-background-color: derive(highlight-color, -1.5%);
+
+    -fx-border-color: derive(highlight-border-color, -5%);
 }


### PR DESCRIPTION
This PR fixes:

1. https://ikmdev.atlassian.net/browse/IIA-2614
2. https://ikmdev.atlassian.net/browse/IIA-2747
3. https://ikmdev.atlassian.net/browse/IIA-2626
4. https://ikmdev.atlassian.net/browse/IIA-2823
5. https://ikmdev.atlassian.net/browse/IIA-2821

-------------------------------------

- This PR fixes Stamp selection getting out of sync.
- Some UI tweaks: hover effects on stamp control
- Shows a success toast when stamp is created or when a stamp is stored (the message indicates whether the stamp was created and stored and the new values)
- Closes the right pane after a new stamp is submitted
