### PR TITLE
IIA-2508 Restyle Semantic Tooltip

### DIFF
--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -5667,7 +5667,7 @@ Styling a context menu for kview ui/ux controls
     -fx-font-family: "Noto Sans";
     -fx-text-fill: white;
     -fx-font-size: 16px;
-    -fx-max-height: 300px;
+    -fx-max-height: 100px;
     -fx-padding: 15 15 10 15;
     -fx-text-alignment: left;
 }
@@ -5743,7 +5743,7 @@ Styling a context menu for kview ui/ux controls
 /* Separator */
 .semantic-tooltip .values-container .grid > .separator .line {
     -fx-border-color: #545D72 transparent transparent transparent,
-                      transparent transparent transparent transparent;
+                       transparent transparent transparent;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Restyle Semantic Tooltip to Align with New Design - https://ikmdev.atlassian.net/browse/IIA-2508

**Before Change:**
<img width="867" height="470" alt="image" src="https://github.com/user-attachments/assets/ffb8c6f7-6381-4f90-9a86-5a1c9eca875e" />

**After Change:**
<img width="790" height="482" alt="image" src="https://github.com/user-attachments/assets/35b528d2-875d-4530-8252-5edce7083eb2" />
