### PR TITLE
IIA-2508-semantic-tooltip-space-fix

### DIFF
--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/kview.css
@@ -5696,7 +5696,7 @@ Styling a context menu for kview ui/ux controls
     -fx-text-fill: white;
     -fx-text-alignment: left;
     -fx-font-size: 12px;
-    -fx-padding: 10 0 5 0;
+    -fx-padding: 10 0 25 0;
     -fx-alignment: center-left;
 }
 


### PR DESCRIPTION
Semantic Tooltip space fix - https://ikmdev.atlassian.net/browse/IIA-2508

**Before Change:**
<img width="790" height="482" alt="Semantic ToolTip display 1" src="https://github.com/user-attachments/assets/c603387d-82b6-4a10-b921-8511506c5fad" />

**After Change:**
<img width="719" height="404" alt="Semantic ToolTip display fix" src="https://github.com/user-attachments/assets/29f27a8d-bec9-423d-a903-78a807179f1a" />
