### PR TITLE
feature/finished/IIA-2884-fix-font-size-inherit-bug-in-public-id-control

### DIFF
--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/public-id-control.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/public-id-control.css
@@ -11,9 +11,6 @@
 
     /* the spacing for the HBoxes in the control, is inherited in child nodes */
     -fx-spacing: 4;
-
-    /* setting font size here, to be inherited in child nodes */
-    -fx-font-size: 10;
 }
 
 .public-id > .public-id-box {
@@ -32,7 +29,7 @@
        The value used must work on the Concept, Pattern, and Semantic windows. */
     -fx-pref-width: 195;
     -fx-font-family: "Noto Sans";
-    -fx-font-size: inherit;
+    -fx-font-size: 10;
     -fx-text-fill: -Grey-10;
 }
 


### PR DESCRIPTION
Jira ticket: https://ikmdev.atlassian.net/browse/IIA-2884

Summary of changes:  replaced the inherit with an actual numeric font size (10), because inherit is not supported for font size

Before change:  ClassCastExceptions were occurring because of the inherit value for the font size

Sep 15, 2025 12:04:17 PM javafx.scene.CssStyleHelper calculateValue
WARNING: Caught 'java.lang.ClassCastException: class java.lang.String cannot be cast to class [Ljavafx.css.ParsedValue; (java.lang.String is in module java.base of loader 'bootstrap'; [Ljavafx.css.ParsedValue; is in module javafx.graphics@24.0.1 of loader 'app')' while converting value for '-fx-font' from rule '*.public-id>*.public-id-box>*.public-id-textfield' in stylesheet file:/C:/projects/komet/kview/target/classes/dev/ikm/komet/kview/controls/public-id-control.css
Sep 15, 2025 12:04:17 PM javafx.scene.CssStyleHelper calculateValue
WARNING: Caught 'java.lang.ClassCastException: class java.lang.String cannot be cast to class [Ljavafx.css.ParsedValue; (java.lang.String is in module java.base of loader 'bootstrap'; [Ljavafx.css.ParsedValue; is in module javafx.graphics@24.0.1 of loader 'app')' while converting value for '-fx-font' from rule '*.public-id>*.public-id-box>*.public-id-textfield' in stylesheet file:/C:/projects/komet/kview/target/classes/dev/ikm/komet/kview/controls/public-id-control.css

After change:  No ClassCastExceptions