### PR TITLE
Feature/finished/iia 2878 child viewcoordinate menu overrides for list and set

### DIFF
--- a/framework/src/main/java/dev/ikm/komet/framework/view/ListPropertyWithOverride.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ListPropertyWithOverride.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
@@ -53,16 +54,19 @@ public class ListPropertyWithOverride<T> extends SimpleEqualityBasedListProperty
         return this.overriddenProperty;
     }
 
+    /// set() is called when the child view coordinate menu item is selected
     @Override
     public void set(ObservableList<T> newValue) {
-        if (!overridden && newValue != null) {
-            overridden = true;
-            this.unbind();
-        }
-        if (newValue == null) {
-            overridden = false;
+        if (newValue == null || Objects.equals(newValue, this.overriddenProperty.get())) {
+            // values equal so not an override.
+            this.overridden = false;
             this.bind(overriddenProperty);
         } else {
+            // values not equal
+            if (!overridden) {
+                this.overridden = true;
+                this.unbind();
+            }
             super.set(newValue);
         }
     }
@@ -72,15 +76,23 @@ public class ListPropertyWithOverride<T> extends SimpleEqualityBasedListProperty
         return setAll(Arrays.asList(elements));
     }
 
+    /// setAll() is called when the parent view coordinate menu item is selected
     @Override
     public boolean setAll(Collection<? extends T> elements) {
-        if (!this.get().equals(elements)) {
+
+        List<T> newValue = elements instanceof ArrayList ? (List) elements : new ArrayList<>(elements);
+
+        if (!Objects.equals(this.get(), newValue)) {
             if (!overridden) {
                 overridden = true;
                 this.unbind();
             }
             return super.setAll(elements);
+        } else {
+            overridden = false;
+            this.bind(overriddenProperty);
         }
+
         return false;
     }
 

--- a/framework/src/main/java/dev/ikm/komet/framework/view/ListPropertyWithOverride.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ListPropertyWithOverride.java
@@ -79,10 +79,7 @@ public class ListPropertyWithOverride<T> extends SimpleEqualityBasedListProperty
     /// setAll() is called when the parent view coordinate menu item is selected
     @Override
     public boolean setAll(Collection<? extends T> elements) {
-
-        List<T> newValue = elements instanceof ArrayList ? (List) elements : new ArrayList<>(elements);
-
-        if (!Objects.equals(this.get(), newValue)) {
+        if (!Objects.equals(this.get(), elements)) {
             if (!overridden) {
                 overridden = true;
                 this.unbind();

--- a/framework/src/main/java/dev/ikm/komet/framework/view/ObservableViewWithOverride.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/ObservableViewWithOverride.java
@@ -43,13 +43,24 @@ public class ObservableViewWithOverride extends ObservableViewBase {
         });
     }
 
+    // TODO when the story is worked to compare the view coordinate change within the child
+    // there will be a lot of work around this method and the setExceptOverrides() to determine
+    // if the change will now match the parent, and to clear any overridden flags that match
     private void overriddenBaseChanged(ObservableValue<? extends ViewCoordinateRecord> observableValue,
                                        ViewCoordinateRecord oldValue,
                                        ViewCoordinateRecord newValue) {
         var name = super.getName();
 
         if (this.hasOverrides()) {
+            // TODO need to check the overrides and compare with the newValue
+            // if the objects are the same, then the child is no longer overridden
             setExceptOverrides(newValue);
+
+            if (!this.hasOverrides()) {
+                // TODO need to remove the override indicator in the view coordinate menu
+
+                LOG.debug("{} view coordinate menu no longer has overrides", getName());
+            }
         } else {
             setValue(newValue);
         }

--- a/framework/src/main/java/dev/ikm/komet/framework/view/SetPropertyWithOverride.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/SetPropertyWithOverride.java
@@ -23,6 +23,8 @@ import javafx.collections.ObservableSet;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 
 public class SetPropertyWithOverride <T> extends SimpleEqualityBasedSetProperty<T>
@@ -53,16 +55,19 @@ public class SetPropertyWithOverride <T> extends SimpleEqualityBasedSetProperty<
         this.set(null);
     }
 
+    /// called by ViewMenuTask when view coordinate Set.setValue() is called
     @Override
     public void set(ObservableSet<T> newValue) {
-        if (!overridden) {
-            overridden = true;
-            this.unbind();
-        }
-        if (newValue == null) {
-            overridden = false;
+        if (newValue == null || Objects.equals(newValue, this.overriddenProperty.get())) {
+            // values equal so not an override.
+            this.overridden = false;
             this.bind(overriddenProperty);
         } else {
+            // values not equal
+            if (!overridden) {
+                this.overridden = true;
+                this.unbind();
+            }
             super.set(newValue);
         }
     }
@@ -74,18 +79,27 @@ public class SetPropertyWithOverride <T> extends SimpleEqualityBasedSetProperty<
 
     @Override
     public boolean setAll(Collection<? extends T> elements) {
-        if (!this.get().equals(elements)) {
+        Set<T> newValue = elements instanceof Set ? (Set) elements : new HashSet<>(elements);
+
+        if (!Objects.equals(this.get(), newValue)) {
             if (!overridden) {
                 overridden = true;
                 this.unbind();
             }
             return super.setAll(elements);
+        } else {
+            overridden = false;
+            this.bind(overriddenProperty);
         }
+
         return false;
     }
 
+    /// called by ViewMenuTask when view coordinate Set is removed from
     @Override
     public boolean remove(Object obj) {
+        boolean returnValue = false;
+
         if (!overridden) {
             overridden = true;
 
@@ -94,14 +108,31 @@ public class SetPropertyWithOverride <T> extends SimpleEqualityBasedSetProperty<
 
             ObservableSet<T> set = FXCollections.observableSet(copiedSet);
             this.unbind();
-            boolean returnValue = set.remove(obj);
+            returnValue = set.remove(obj);
             super.set(set);
             return returnValue;
+        } else {
+            // must make a copy to remove the object from the copied set
+            // to use to compare with the overriddenProperty FIRST
+
+            HashSet<T> copiedSet = new HashSet<>(get());
+            returnValue = copiedSet.remove(obj);
+
+            if (Objects.equals(copiedSet, this.overriddenProperty.get())) {
+                overridden = false;
+                this.bind(overriddenProperty);
+            } else {
+                // remove() calls the Set property listeners, which updates the view coordinate menu
+                returnValue = super.remove(obj);
+            }
         }
-        return super.remove(obj);
+
+        return returnValue;
     }
 
     /**
+     * called by ViewMenuTask when view coordinate Set is added to
+     * <p>
      * Note:  cannot use the parent's overriddenProperty because doing so causes the
      * parent property to be changed when the child property is changed
      *
@@ -109,6 +140,8 @@ public class SetPropertyWithOverride <T> extends SimpleEqualityBasedSetProperty<
      */
     @Override
     public boolean add(T element) {
+        boolean returnValue = false;
+
         if (!overridden) {
             overridden = true;
 
@@ -117,12 +150,27 @@ public class SetPropertyWithOverride <T> extends SimpleEqualityBasedSetProperty<
 
             ObservableSet<T> set = FXCollections.observableSet(copiedSet);
             this.unbind();
-            boolean returnValue = set.add(element);
+            returnValue = set.add(element);
             super.set(set);
 
             return returnValue;
+        } else {
+            // must make a copy to add the object to the copied set
+            // to use to compare with the overriddenProperty FIRST
+
+            HashSet<T> copiedSet = new HashSet<>(get());
+            returnValue = copiedSet.add(element);
+
+            if (Objects.equals(this.get(), this.overriddenProperty.get())) {
+                overridden = false;
+                this.bind(overriddenProperty);
+            } else {
+                // add() calls the Set property listeners, which updates the view coordinate menu
+                returnValue = super.add(element);
+            }
         }
-        return super.add(element);
+
+        return returnValue;
     }
 
     @Override
@@ -176,6 +224,7 @@ public class SetPropertyWithOverride <T> extends SimpleEqualityBasedSetProperty<
         return super.retainAll(objects);
     }
 
+    /// called by ViewMenuTask when view coordinate Set is cleared
     @Override
     public void clear() {
         if (!overridden) {
@@ -184,7 +233,14 @@ public class SetPropertyWithOverride <T> extends SimpleEqualityBasedSetProperty<
             // create a new empty set
             super.set(FXCollections.observableSet(new HashSet<>()));
         } else {
-            super.clear();
+            // FIRST check to see if the overriddenProperty Set is empty
+            if (this.overriddenProperty.get().isEmpty()) {
+                overridden = false;
+                this.bind(overriddenProperty);
+            } else {
+                // clear() calls the Set property listeners, which updates the view coordinate menu
+                super.clear();
+            }
         }
     }
 

--- a/framework/src/main/java/dev/ikm/komet/framework/view/SetPropertyWithOverride.java
+++ b/framework/src/main/java/dev/ikm/komet/framework/view/SetPropertyWithOverride.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Predicate;
 
 public class SetPropertyWithOverride <T> extends SimpleEqualityBasedSetProperty<T>
@@ -79,9 +78,7 @@ public class SetPropertyWithOverride <T> extends SimpleEqualityBasedSetProperty<
 
     @Override
     public boolean setAll(Collection<? extends T> elements) {
-        Set<T> newValue = elements instanceof Set ? (Set) elements : new HashSet<>(elements);
-
-        if (!Objects.equals(this.get(), newValue)) {
+        if (!Objects.equals(this.get(), elements)) {
             if (!overridden) {
                 overridden = true;
                 this.unbind();


### PR DESCRIPTION
Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-2878

Summary of changes:

- ListPropertyWithOverride
    - modified set() and setAll() to check for equality with the overriddenProperty
- SetPropertyWithOverride
    - modified set(), setAll(), add(), remove() and clear() to check for equality with the overriddenProperty
- Note:  only modifications were made to the methods that are called for view coordinate menu changes
    - There are more methods that really need the same changes made.
    - But, will be impossible to test without creating JUnit tests.

How to test these changes:
- Test in a child view coordinate menu, such as Classic Search
    - Change to a selection different than the parent, the override indicator goes orange
    - Change back to matching the parent, the override indicator goes back to grey
- To test the List, use Language settings
    - Language Coordinate - Change description preference
    - or Change dialect preference order
- To test the Set, use Stamp settings
  - Stamp filter - Change included modules
  - or Change excluded modules

<img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/bb25f07d-ff39-4e4d-87ab-8a7b92b347d7" />

<img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/10e7bd12-820c-4387-9d1c-83ea7bf901dc" />


Before changes:  override indicator stays orange when the child is changed back to match the parent

After changes:  override indicator goes back to default grey when the child is changed back to match the parent