### PR TITLE
JPRO-200 allow for state changes in FilterMenuPopup to persist

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/timeline/FilterMenuController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/timeline/FilterMenuController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2015 Integrated Knowledge Management (support@ikm.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.ikm.komet.kview.mvvm.view.timeline;
 
 import dev.ikm.komet.framework.view.ViewProperties;
@@ -42,7 +58,7 @@ public class FilterMenuController {
         Map<RadioButton, List<CheckBox>> checkBoxMap = new HashMap<>();
 
 
-        SimpleObjectProperty<Map<String, List<Integer>>> test = timelineViewModel.getProperty(TimelineProperties.AVAILABLE_PATH_MOULES_MAP);
+        SimpleObjectProperty<Map<String, List<Integer>>> pathModulesMapProp = timelineViewModel.getProperty(TimelineProperties.AVAILABLE_PATH_MOULES_MAP);
         SimpleStringProperty pathName =  timelineViewModel.getProperty(TimelineProperties.SELECTED_PATH);
         ObservableList<Integer> moduleIDs = timelineViewModel.getObservableList(TimelineProperties.CHECKED_MODULE_IDS);
 
@@ -51,7 +67,7 @@ public class FilterMenuController {
         // programmatically creating all viable elements
 
         // ViewModel -> View
-        test.subscribe( map -> {
+        pathModulesMapProp.subscribe( map -> {
 
             final boolean[] first = {true};
 
@@ -93,7 +109,6 @@ public class FilterMenuController {
                 checkBoxSubscriptionsList.forEach(Subscription::unsubscribe);
                 checkBoxSubscriptionsList.clear();
 
-
                 // get associated checkboxes
                 List<CheckBox> modulesCheckBoxList = checkBoxMap.get(radioButton);
                 // set up a subscriber to any checkbox in the view
@@ -111,7 +126,7 @@ public class FilterMenuController {
                 });
                 extensionSelectionVBox.getChildren().setAll(modulesCheckBoxList);
 
-                // On path trigger we need to make sure to also update the selectionBox to that path in the ViewModel at the same time
+                // On path trigger we need to make sure to also update the selectionBox **once** to that path in the ViewModel
                 pathName.setValue(radioButton.getText());
                 List<Integer> selectedModules = getSelectedModules(extensionSelectionVBox);
                 moduleIDs.setAll(selectedModules);

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/timeline/FilterMenuController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/timeline/FilterMenuController.java
@@ -1,168 +1,136 @@
-/*
- * Copyright © 2015 Integrated Knowledge Management (support@ikm.dev)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package dev.ikm.komet.kview.mvvm.view.timeline;
 
-import dev.ikm.komet.kview.mvvm.view.BasicController;
 import dev.ikm.komet.framework.view.ViewProperties;
-import javafx.event.ActionEvent;
+import dev.ikm.komet.kview.mvvm.viewmodel.TimelineViewModel;
+import dev.ikm.komet.kview.mvvm.viewmodel.TimelineViewModel.*;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
-import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
+import javafx.util.Subscription;
+import org.carlfx.cognitive.loader.InjectViewModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.function.BiConsumer;
+import java.util.Map;
 
-public class FilterMenuController implements BasicController {
+public class FilterMenuController {
     private static final Logger LOG = LoggerFactory.getLogger(FilterMenuController.class);
 
-    @FXML
-    private VBox filterMenuVbox;
+    @FXML private VBox filterMenuVbox;
+
+    @FXML private VBox pathSelectionVBox;
+    @FXML private VBox extensionSelectionVBox;
+
+    @FXML private ToggleGroup selectedPathToggleGroup;
+
+    @FXML private Button closeFilterMenu;
+
+    @InjectViewModel
+    TimelineViewModel timelineViewModel;
 
     @FXML
-    private VBox pathSelectionVBox;
-
-    @FXML
-    private VBox extensionSelectionVBox;
-
-    @FXML
-    private ToggleGroup selectedPathToggleGroup;
-
-    @FXML
-    private Button saveFilterMenu;
-
-    private ViewProperties viewProperties;
-    private TimelinePathMap pathMap;
-    private BiConsumer<String, List<Integer>> pathAndModuleNids;
-
-    @Override
     public void initialize() {
-        pathSelectionVBox.getChildren().clear();
-        extensionSelectionVBox.getChildren().clear();
-        selectedPathToggleGroup.selectedToggleProperty().addListener(((observableValue, t0, t1) -> {
-            getExtensionSelectionVBox().getChildren().clear();
-            if (t1 != null &&
-                    t1.isSelected() &&
-                    t1 instanceof ToggleButton toggleButton){
 
-                getPathMap().getModuleNids(toggleButton.getText()).forEach(moduleId ->{
-                    // get module name
-                    String moduleName = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(moduleId);
-                    // set user data to be nid
-                    CheckBox checkBox = new CheckBox(moduleName);
-                    checkBox.setSelected(true);
-                    checkBox.setUserData(moduleId);
-                    getExtensionSelectionVBox().getChildren().add(checkBox);
+        // This mini "local state" is a compromise -> otherwise the ViewModel would need to know about CheckBox
+        List<Subscription> checkBoxSubscriptionsList = new ArrayList<>();
+        Map<RadioButton, List<CheckBox>> checkBoxMap = new HashMap<>();
+
+
+        SimpleObjectProperty<Map<String, List<Integer>>> test = timelineViewModel.getProperty(TimelineProperties.AVAILABLE_PATH_MOULES_MAP);
+        SimpleStringProperty pathName =  timelineViewModel.getProperty(TimelineProperties.SELECTED_PATH);
+        ObservableList<Integer> moduleIDs = timelineViewModel.getObservableList(TimelineProperties.CHECKED_MODULE_IDS);
+
+        SimpleObjectProperty<ViewProperties> viewPropertiesProperty = timelineViewModel.getProperty(TimelineProperties.VIEW_PROPERTIES);
+
+        // programmatically creating all viable elements
+
+        // ViewModel -> View
+        test.subscribe( map -> {
+
+            final boolean[] first = {true};
+
+            map.forEach( (path, modules) -> {
+                RadioButton pathRadioButton = new RadioButton(path);
+                pathRadioButton.setToggleGroup(selectedPathToggleGroup);
+
+                pathSelectionVBox.getChildren().add(pathRadioButton);
+
+                List<CheckBox> modulesVBox = new ArrayList<>();
+
+                modules.forEach( module -> {
+                    ViewProperties viewProperties = viewPropertiesProperty.getValue();
+                    String moduleName = viewProperties.calculator().getPreferredDescriptionTextWithFallbackOrNid(module);
+                    CheckBox moduleCheckBox = new CheckBox(moduleName);
+                    moduleCheckBox.setUserData(module);
+                    moduleCheckBox.setSelected(true);
+
+                    modulesVBox.add(moduleCheckBox);
                 });
-            };
-        }));
-    }
 
-    public TimelinePathMap getPathMap() {
-        return pathMap;
-    }
+                checkBoxMap.put(pathRadioButton, modulesVBox);
 
-    public VBox getExtensionSelectionVBox() {
-        return extensionSelectionVBox;
-    }
+                // by default the first pathRadioButton is selected
+                if (first[0]) {
+                    pathRadioButton.setSelected(true);
+                    first[0] = false;
+                }
+            } ) ;
 
-    public void setExtensionSelectionVBox(VBox extensionSelectionVBox) {
-        this.extensionSelectionVBox = extensionSelectionVBox;
-    }
-
-    public ViewProperties getViewProperties() {
-        return viewProperties;
-    }
-
-    public void setViewProperties(ViewProperties viewProperties) {
-        this.viewProperties = viewProperties;
-    }
-
-    public void updateModel(ViewProperties viewProperties, TimelinePathMap pathMap){
-        this.viewProperties = viewProperties;
-        this.pathMap = pathMap;
-    }
-
-    @Override
-    public void updateView() {
-
-        clearView();
-
-        pathMap.keySet().forEach(pathName -> {
-            RadioButton pathRadioButton = new RadioButton(pathName);
-            pathRadioButton.setToggleGroup(selectedPathToggleGroup);
-            pathSelectionVBox.getChildren().add(pathRadioButton);
         });
-        if (pathSelectionVBox.getChildren().size() > 0) {
-            RadioButton defaultPath = (RadioButton) pathSelectionVBox.getChildren().get(0);
-            defaultPath.setSelected(true);
-        }
 
-        // Set the default Path
-        if (!pathSelectionVBox.getChildren().isEmpty()) {
-            getExtensionSelectionVBox().getChildren().clear();
-            RadioButton radioButton = (RadioButton) pathSelectionVBox.getChildren().get(0);
-            radioButton.setToggleGroup(selectedPathToggleGroup);
-            pathMap.getModuleNids(radioButton.getText()).forEach(moduleNid ->{
-                // get module name
-                String moduleName = getViewProperties().calculator().getPreferredDescriptionTextWithFallbackOrNid(moduleNid);
-                // set user data to be nid
-                CheckBox checkBox = new CheckBox(moduleName);
-                checkBox.setSelected(true);
-                checkBox.setUserData(moduleNid);
-                getExtensionSelectionVBox().getChildren().add(checkBox);
-            });
-        }
 
-    }
 
-    @Override
-    public void clearView() {
-        pathSelectionVBox.getChildren().clear();
-        extensionSelectionVBox.getChildren().clear();
-    }
+        selectedPathToggleGroup.selectedToggleProperty().subscribe( (newToggle) -> {
+            if (newToggle instanceof RadioButton radioButton && newToggle.isSelected()) {
+                extensionSelectionVBox.getChildren().clear();
 
-    @Override
-    public void cleanup() {
+                checkBoxSubscriptionsList.forEach(Subscription::unsubscribe);
+                checkBoxSubscriptionsList.clear();
 
-    }
-    @FXML
-    void saveFilterMenu(ActionEvent event) {
-        if (filterMenuVbox.getParent() != null) {
-            Pane journalDesktop = (Pane) filterMenuVbox.getParent();
-            journalDesktop.getChildren().remove(filterMenuVbox);
+                // View -> ViewModel path update
+                pathName.setValue(radioButton.getText());
 
-            RadioButton selected = (RadioButton)selectedPathToggleGroup.getSelectedToggle();
-            if (selected != null) {
-                String pathName = ((RadioButton) selectedPathToggleGroup.getSelectedToggle()).getText();
-                List<Integer> moduleIds = getExtensionSelectionVBox()
-                        .getChildren()
-                        .stream()
-                        .filter(node -> ((CheckBox)node).isSelected())
-                        .map(node -> (Integer)node.getUserData())
-                        .toList();
-                pathAndModuleNids.accept(pathName, moduleIds);
+                // get associated checkboxes
+                List<CheckBox> modulesCheckBoxList = checkBoxMap.get(radioButton);
+                // set up a subscriber to any checkbox in the view
+                // that triggers on any checkBox update
+                modulesCheckBoxList.forEach( checkBox -> {
+                    Subscription sub = checkBox.selectedProperty().subscribe(() -> {
+                        LOG.info("toggled checkBox with number {} with nid {}", checkBox.getText(), checkBox.getUserData());
+                        // calculate a new list and provide it to the ViewModel
+                        List<Integer> selectedModules = getSelectedModules(extensionSelectionVBox);
+                        moduleIDs.setAll(selectedModules);
+                    });
+                    checkBoxSubscriptionsList.add(sub);
+
+
+                });
+                extensionSelectionVBox.getChildren().setAll(modulesCheckBoxList);
+
             }
-
-        }
+        });
     }
 
-    public void onSaveAction(BiConsumer<String, List<Integer>> pathAndModuleNids) {
-        this.pathAndModuleNids = pathAndModuleNids;
+    private List<Integer> getSelectedModules(VBox checkBoxesVBox) {
+        return checkBoxesVBox.getChildren().stream()
+                .filter(node -> node instanceof CheckBox)
+                .map(node -> (CheckBox) node)
+                .filter(CheckBox::isSelected)
+                .map(cb -> (Integer) cb.getUserData())
+                .toList();
     }
+
+    @FXML
+    void onClose() {
+        timelineViewModel.setPropertyValue(TimelineProperties.FILTER_POP_UP_VISIBLE, false);
+        LOG.info("Hide PopUp");
+    }
+
+
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/timeline/FilterMenuController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/timeline/FilterMenuController.java
@@ -93,8 +93,6 @@ public class FilterMenuController {
                 checkBoxSubscriptionsList.forEach(Subscription::unsubscribe);
                 checkBoxSubscriptionsList.clear();
 
-                // View -> ViewModel path update
-                pathName.setValue(radioButton.getText());
 
                 // get associated checkboxes
                 List<CheckBox> modulesCheckBoxList = checkBoxMap.get(radioButton);
@@ -112,6 +110,11 @@ public class FilterMenuController {
 
                 });
                 extensionSelectionVBox.getChildren().setAll(modulesCheckBoxList);
+
+                // On path trigger we need to make sure to also update the selectionBox to that path in the ViewModel at the same time
+                pathName.setValue(radioButton.getText());
+                List<Integer> selectedModules = getSelectedModules(extensionSelectionVBox);
+                moduleIDs.setAll(selectedModules);
 
             }
         });

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/timeline/TimelineController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/timeline/TimelineController.java
@@ -324,16 +324,14 @@ public class TimelineController implements BasicController {
             ObservableList<Integer> modules = vm.getObservableList(TimelineViewModel.TimelineProperties.CHECKED_MODULE_IDS);
             SimpleStringProperty path = vm.getProperty(TimelineViewModel.TimelineProperties.SELECTED_PATH);
 
+
             modules.subscribe( () -> {
                 List<Integer> snapshot = List.copyOf(modules);
                 LOG.info("current selected modules list: {}", snapshot);
-                updateConfigPathAndModules(this.configPath, snapshot);
-                updateModel(getViewProperties(), getMainConcept());
-                updateView();
-            });
-            path.subscribe(currentPath -> {
-                LOG.info("current path: {}", currentPath);
-                updateConfigPathAndModules(currentPath, this.configModuleIds);
+
+                String selectedPath = path.getValue();
+
+                updateConfigPathAndModules(selectedPath, snapshot);
                 updateModel(getViewProperties(), getMainConcept());
                 updateView();
             });

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/timeline/TimelinePathMap.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/timeline/TimelinePathMap.java
@@ -17,6 +17,7 @@ package dev.ikm.komet.kview.mvvm.view.timeline;
 
 import dev.ikm.tinkar.coordinate.stamp.change.VersionChangeRecord;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -27,5 +28,13 @@ import java.util.TreeSet;
 public class TimelinePathMap extends TreeMap<String, TreeMap<Integer, TreeMap<Integer, TreeSet<VersionChangeRecord>>>> {
     public List<Integer> getModuleNids(String pathName) {
         return get(pathName).keySet().stream().toList();
+    }
+
+    public LinkedHashMap<String, List<Integer>> getPathModulesNidOnlyMap() {
+        LinkedHashMap<String, List<Integer>> collection = new LinkedHashMap<>();
+        forEach( (path, moduleMap) -> {
+            collection.put(path, this.getModuleNids(path));
+        });
+        return  collection;
     }
 }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/TimelineViewModel.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/viewmodel/TimelineViewModel.java
@@ -1,0 +1,34 @@
+package dev.ikm.komet.kview.mvvm.viewmodel;
+
+import dev.ikm.komet.framework.view.ViewProperties;
+import dev.ikm.komet.kview.mvvm.view.timeline.TimelinePathMap;
+import org.carlfx.cognitive.viewmodel.SimpleViewModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TimelineViewModel extends SimpleViewModel {
+    private static final Logger LOG = LoggerFactory.getLogger(TimelineViewModel.class);
+
+    public enum TimelineProperties {
+        VIEW_PROPERTIES,
+
+        AVAILABLE_PATH_MOULES_MAP,
+
+        SELECTED_PATH,
+        CHECKED_MODULE_IDS,
+
+        FILTER_POP_UP_VISIBLE
+    }
+
+    public TimelineViewModel() {
+        addProperty(TimelineProperties.AVAILABLE_PATH_MOULES_MAP, new LinkedHashMap<String, List<Integer>>())
+                .addProperty(TimelineProperties.CHECKED_MODULE_IDS, List.<Integer>of())
+                .addProperty(TimelineProperties.SELECTED_PATH, (String) null)
+                .addProperty(TimelineProperties.VIEW_PROPERTIES, (ViewProperties) null)
+                .addProperty(TimelineProperties.FILTER_POP_UP_VISIBLE, false);
+    }
+}

--- a/kview/src/main/java/module-info.java
+++ b/kview/src/main/java/module-info.java
@@ -38,9 +38,10 @@ module dev.ikm.komet.kview {
     requires org.eclipse.collections.api;
     requires org.eclipse.collections.impl;
     requires javafx.graphics;
-    requires org.apache.commons.logging;
-    requires org.slf4j;
+    requires javafx.fxml;
     requires javafx.controls;
+    requires org.slf4j;
+    requires javafx.base;
 
     exports dev.ikm.komet.kview.state;
     exports dev.ikm.komet.kview.state.pattern;

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/timeline/filter-menu.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/timeline/filter-menu.fxml
@@ -13,16 +13,12 @@
 <VBox fx:id="filterMenuVbox" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="314.0" prefWidth="214.0" styleClass="filter-menu-container" stylesheets="@../kview.css" xmlns="http://javafx.com/javafx/23" xmlns:fx="http://javafx.com/fxml/1" fx:controller="dev.ikm.komet.kview.mvvm.view.timeline.FilterMenuController">
    <children>
       <Label styleClass="filter-menu-title" text="PATH" />
-      <VBox fx:id="pathSelectionVBox" prefHeight="52.0" prefWidth="212.0" styleClass="filter-menu-options-container">
-         <children>
-            <RadioButton mnemonicParsing="false" text="Master">
-               <toggleGroup>
-                  <ToggleGroup fx:id="selectedPathToggleGroup" />
-               </toggleGroup>
-            </RadioButton>
-            <RadioButton mnemonicParsing="false" text="Development" toggleGroup="$selectedPathToggleGroup" />
-         </children>
-      </VBox>
+       <VBox fx:id="pathSelectionVBox" prefHeight="52.0" prefWidth="212.0" styleClass="filter-menu-options-container" >
+           <fx:define>
+               <ToggleGroup fx:id="selectedPathToggleGroup" />
+           </fx:define>
+       </VBox>
+
       <HBox alignment="CENTER">
          <children>
             <Line endX="190.0" styleClass="divider" />
@@ -30,10 +26,7 @@
       </HBox>
       <Label styleClass="filter-menu-title" text="EXTENSIONS" />
       <VBox fx:id="extensionSelectionVBox" prefHeight="52.0" prefWidth="212.0" styleClass="filter-menu-options-container">
-         <children>
-            <CheckBox mnemonicParsing="false" text="SNOMED CT International" />
-            <CheckBox mnemonicParsing="false" text="SNOMED CT US" />
-         </children>
+  
       </VBox>
       <HBox alignment="CENTER">
          <children>
@@ -42,7 +35,7 @@
       </HBox>
       <HBox alignment="CENTER" prefHeight="100.0" prefWidth="200.0">
          <children>
-            <Button fx:id="saveFilterMenu" mnemonicParsing="false" onAction="#saveFilterMenu" text="SAVE" />
+            <Button fx:id="closeFilterMenu" mnemonicParsing="false" onAction="#onClose" text="CLOSE" />
          </children>
       </HBox>
    </children>


### PR DESCRIPTION
Implementing a ViewModel to detach some of the pathMap state into the ViewModel

This can further be utilized to also detach the TimelineController from more state, like its done in the new FilterMenuController.

This PR also added the bonus feature that any changes in the FilterMenu are now instantly updated in the Timeline itself.