### PR TITLE
Feature/finished/iia 2900 now updating identifier when pattern published

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PatternDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PatternDetailsController.java
@@ -453,9 +453,7 @@ public class PatternDetailsController {
             }
         });
 
-        ViewCalculator viewCalculator = getViewProperties().calculator();
-
-        updateDisplayIdentifier(viewCalculator);
+        updateDisplayIdentifier();
 
         // capture pattern definition information
         purposeText.textProperty().bind(patternViewModel.getProperty(PURPOSE_TEXT));
@@ -591,7 +589,8 @@ public class PatternDetailsController {
     }
 
     /// Show the public ID
-    private void updateDisplayIdentifier(ViewCalculator viewCalculator) {
+    private void updateDisplayIdentifier() {
+        ViewCalculator viewCalculator = getViewProperties().calculator();
         PatternFacade patternFacade = (PatternFacade) patternViewModel.getProperty(PATTERN).getValue();
 
         if (patternFacade != null) {
@@ -907,9 +906,7 @@ public class PatternDetailsController {
                 updateStampControlFromViewModel();
 
                 // now in EDIT mode, update the identifier
-                ViewCalculator viewCalculator = getViewProperties().calculator();
-
-                updateDisplayIdentifier(viewCalculator);
+                updateDisplayIdentifier();
 
                 stampFormViewModel.getBooleanProperty(IS_CONFIRMED_OR_SUBMITTED).subscribe(isSubmitted -> {
                     if (isSubmitted) {

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PatternDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/pattern/PatternDetailsController.java
@@ -905,6 +905,12 @@ public class PatternDetailsController {
 
             if (newMode.equals(EDIT)) {
                 updateStampControlFromViewModel();
+
+                // now in EDIT mode, update the identifier
+                ViewCalculator viewCalculator = getViewProperties().calculator();
+
+                updateDisplayIdentifier(viewCalculator);
+
                 stampFormViewModel.getBooleanProperty(IS_CONFIRMED_OR_SUBMITTED).subscribe(isSubmitted -> {
                     if (isSubmitted) {
                         updateStampControlFromViewModel();


### PR DESCRIPTION
Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-2900

Summary of changes:  now calling updateDisplayIdentifer() when the Pattern window goes into EDIT mode

Before changes:  The identifier was not being displayed

After changes:  Now the identifier is being displayed

Create a new Pattern, press the Submit button on the toolbar

<img width="1203" height="476" alt="image" src="https://github.com/user-attachments/assets/aa423b6d-037b-472a-aa28-ad69fff5f724" />

The Komet ID is now being displayed in the Pattern window

<img width="1201" height="475" alt="image" src="https://github.com/user-attachments/assets/5d92918d-2b33-49e7-81ad-f9075931ffe6" />
