### PR TITLE
feature/finished/IIA-2901-changed-IDENTIFIER-to-Komet-ID-in-semantic

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/PublicIDListControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/PublicIDListControl.java
@@ -3,9 +3,7 @@ package dev.ikm.komet.kview.controls;
 import dev.ikm.komet.kview.controls.skin.PublicIDListControlSkin;
 import dev.ikm.komet.kview.mvvm.model.DataModelHelper;
 import dev.ikm.tinkar.coordinate.view.calculator.ViewCalculator;
-import dev.ikm.tinkar.terms.ConceptFacade;
 import dev.ikm.tinkar.terms.EntityFacade;
-import dev.ikm.tinkar.terms.PatternFacade;
 import javafx.beans.property.SimpleListProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -41,26 +39,10 @@ public class PublicIDListControl extends Control {
         publicIdListProperty().set(obsList);
     }
 
-    // Convenience methods for creating the List<String> from the viewCalculator and facade
-
-    /// Creates a Public ID List from the provided viewCalculator and ConceptFacade.
-    /// @param viewCalculator the view calculator to use to determine identifiers
-    /// @param conceptFacade the concept facade to use to determine identifiers
-    public void updatePublicIdList(ViewCalculator viewCalculator, ConceptFacade conceptFacade) {
-        updatePublicIdList(viewCalculator, (EntityFacade) conceptFacade);
-    }
-
-    /// Creates a Public ID List from the provided viewCalculator and PatternFacade.
-    /// @param viewCalculator the view calculator to use to determine identifiers
-    /// @param patternFacade the pattern facade to use to determine identifiers
-    public void updatePublicIdList(ViewCalculator viewCalculator, PatternFacade patternFacade) {
-        updatePublicIdList(viewCalculator, (EntityFacade) patternFacade);
-    }
-
     /// Creates a Public ID List from the provided viewCalculator and EntityFacade.
     /// @param viewCalculator the view calculator to use to determine identifiers
     /// @param entityFacade the entity facade to use to determine identifiers
-    private void updatePublicIdList(ViewCalculator viewCalculator, EntityFacade entityFacade) {
+    public void updatePublicIdList(ViewCalculator viewCalculator, EntityFacade entityFacade) {
         if (viewCalculator != null && entityFacade != null) {
             List<String> idList = entityFacade.publicId().asUuidList().stream()
                     .map(UUID::toString)

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingDetailsController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/genediting/GenEditingDetailsController.java
@@ -17,14 +17,6 @@ package dev.ikm.komet.kview.mvvm.view.genediting;
 
 import dev.ikm.komet.framework.Identicon;
 import dev.ikm.komet.framework.controls.TimeUtils;
-import dev.ikm.komet.kview.common.ViewCalculatorUtils;
-import dev.ikm.komet.kview.controls.StampViewControl;
-import dev.ikm.komet.kview.events.ClosePropertiesPanelEvent;
-import dev.ikm.komet.kview.events.StampEvent;
-import dev.ikm.komet.kview.mvvm.viewmodel.stamp.StampFormViewModelBase;
-import dev.ikm.tinkar.events.EvtBusFactory;
-import dev.ikm.tinkar.events.EvtType;
-import dev.ikm.tinkar.events.Subscriber;
 import dev.ikm.komet.framework.observable.ObservableEntity;
 import dev.ikm.komet.framework.observable.ObservableField;
 import dev.ikm.komet.framework.observable.ObservablePattern;
@@ -35,18 +27,22 @@ import dev.ikm.komet.framework.observable.ObservableSemanticSnapshot;
 import dev.ikm.komet.framework.observable.ObservableSemanticVersion;
 import dev.ikm.komet.framework.view.ViewMenuModel;
 import dev.ikm.komet.framework.view.ViewProperties;
+import dev.ikm.komet.kview.common.ViewCalculatorUtils;
 import dev.ikm.komet.kview.controls.ComponentItem;
 import dev.ikm.komet.kview.controls.KLReadOnlyBaseControl;
 import dev.ikm.komet.kview.controls.KLReadOnlyComponentControl;
+import dev.ikm.komet.kview.controls.PublicIDListControl;
+import dev.ikm.komet.kview.controls.StampViewControl;
 import dev.ikm.komet.kview.controls.Toast;
-import dev.ikm.komet.kview.controls.PublicIDControl;
+import dev.ikm.komet.kview.events.ClosePropertiesPanelEvent;
+import dev.ikm.komet.kview.events.StampEvent;
 import dev.ikm.komet.kview.events.genediting.GenEditingEvent;
 import dev.ikm.komet.kview.events.genediting.PropertyPanelEvent;
 import dev.ikm.komet.kview.fxutils.SlideOutTrayHelper;
 import dev.ikm.komet.kview.klfields.KlFieldHelper;
-import dev.ikm.komet.kview.mvvm.model.DataModelHelper;
 import dev.ikm.komet.kview.mvvm.view.stamp.StampEditController;
 import dev.ikm.komet.kview.mvvm.viewmodel.GenEditingViewModel;
+import dev.ikm.komet.kview.mvvm.viewmodel.stamp.StampFormViewModelBase;
 import dev.ikm.tinkar.coordinate.language.calculator.LanguageCalculator;
 import dev.ikm.tinkar.coordinate.stamp.calculator.Latest;
 import dev.ikm.tinkar.coordinate.view.calculator.ViewCalculator;
@@ -60,7 +56,12 @@ import dev.ikm.tinkar.entity.PatternVersionRecord;
 import dev.ikm.tinkar.entity.SemanticEntity;
 import dev.ikm.tinkar.entity.SemanticEntityVersion;
 import dev.ikm.tinkar.entity.transaction.Transaction;
-import dev.ikm.tinkar.terms.*;
+import dev.ikm.tinkar.events.EvtBusFactory;
+import dev.ikm.tinkar.events.EvtType;
+import dev.ikm.tinkar.events.Subscriber;
+import dev.ikm.tinkar.terms.EntityFacade;
+import dev.ikm.tinkar.terms.PatternFacade;
+import dev.ikm.tinkar.terms.State;
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.event.ActionEvent;
@@ -94,10 +95,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import static dev.ikm.komet.kview.events.ClosePropertiesPanelEvent.CLOSE_PROPERTIES;
 import static dev.ikm.komet.kview.events.genediting.GenEditingEvent.PUBLISH;
@@ -214,7 +213,7 @@ public class GenEditingDetailsController {
     private ImageView identiconImageView;
 
     @FXML
-    private PublicIDControl identifierControl;
+    private PublicIDListControl identifierControl;
 
     @InjectViewModel
     private GenEditingViewModel genEditingViewModel;
@@ -355,17 +354,9 @@ public class GenEditingDetailsController {
 
     private void updateDisplayUUID() {
         EntityFacade semanticComponent = genEditingViewModel.getPropertyValue(SEMANTIC);
-        if (semanticComponent == null) {
-            return;
+        if (semanticComponent != null) {
+            identifierControl.updatePublicIdList(genEditingViewModel.getViewProperties().calculator(), semanticComponent);
         }
-
-        List<String> idList = semanticComponent.publicId().asUuidList().stream()
-                .map(UUID::toString)
-                .collect(Collectors.toList());
-        idList.addAll(DataModelHelper.getIdsToAppend(genEditingViewModel.getViewProperties().calculator(), semanticComponent.toProxy()));
-        String idString = String.join(", ", idList);
-
-        identifierControl.setPublicId(idString);
     }
 
     private void updateIdenticon(ObjectProperty<EntityFacade> refComponent) {

--- a/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
+++ b/kview/src/main/resources/dev/ikm/komet/kview/mvvm/view/genediting/genediting-details.fxml
@@ -1,19 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import dev.ikm.komet.kview.controls.KLReadOnlyComponentControl?>
-<?import dev.ikm.komet.kview.controls.PublicIDControl?>
+<?import dev.ikm.komet.kview.controls.PublicIDListControl?>
 <?import dev.ikm.komet.kview.controls.StampViewControl?>
 <?import dev.ikm.komet.kview.mvvm.view.common.SVGConstants?>
-<?import javafx.geometry.*?>
-<?import javafx.scene.control.*?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.MenuButton?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.Separator?>
+<?import javafx.scene.control.TitledPane?>
+<?import javafx.scene.control.ToggleButton?>
+<?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.Cursor?>
 <?import javafx.scene.Group?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.*?>
-<?import javafx.scene.shape.*?>
-<?import javafx.scene.text.*?>
-<?import java.lang.*?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.shape.Ellipse?>
+<?import javafx.scene.shape.Rectangle?>
+<?import javafx.scene.shape.SVGPath?>
+<?import javafx.scene.text.Font?>
+<?import javafx.scene.text.Text?>
+<?import java.lang.String?>
 <BorderPane xmlns:fx="http://javafx.com/fxml/1" fx:id="detailsOuterBorderPane" maxHeight="1.7976931348623157E308"
             maxWidth="1.7976931348623157E308" prefWidth="727.0" stylesheets="@../kview.css"
             xmlns="http://javafx.com/javafx/24.0.1"
@@ -248,7 +267,7 @@
                            GridPane.rowIndex="3" GridPane.columnIndex="2" GridPane.valignment="TOP"/>
                     
                     
-                    <PublicIDControl fx:id="identifierControl" GridPane.columnSpan="4"
+                    <PublicIDListControl fx:id="identifierControl" GridPane.columnSpan="4"
                                      GridPane.rowIndex="4" GridPane.columnIndex="0" GridPane.valignment="BOTTOM"
                                      GridPane.halignment="LEFT"/>
                     


### PR DESCRIPTION
Jira ticket: https://ikmdev.atlassian.net/browse/IIA-2901

Summary of changes:

- Modified PublicIDListControl to now accept any EntityFacade, to be able to support the SemanticFacade
- Modified the GenEditing fxml and controller to use the PublicIDListControl

Before changes:  "IDENTIFIER:" was displayed

<img width="674" height="631" alt="image" src="https://github.com/user-attachments/assets/5c9cec56-8c59-4036-917d-ccc3eea20744" />


After changes:  "Komet ID:" is now displayed

<img width="674" height="651" alt="image" src="https://github.com/user-attachments/assets/fd3689ab-04c4-4b67-88c1-43f7225f415c" />
