### PR TITLE
Update navigator when nodeView changes

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLSearchControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/KLSearchControlSkin.java
@@ -65,9 +65,6 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
     private final StackPane filterPane;
     private Subscription subscription;
 
-    // listen to parent/node view coordinate menu changes
-    private Subscription viewSubscription;
-
     private final ListView<KLSearchControl.SearchResult> resultsPane;
     private final FilterOptionsPopup filterOptionsPopup;
 
@@ -237,30 +234,11 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
         });
 
         subscription = subscription.and((control.viewPropertiesProperty().subscribe(view -> {
-            if (viewSubscription != null) {
-                viewSubscription.unsubscribe();
-            }
-            viewSubscription = Subscription.EMPTY;
             if (view != null) {
-                // listen to changes to the current overrideable view, after changes coming from the parentView
-                // or the F.O. popup, and publish event
-                viewSubscription = viewSubscription.and(view.nodeView().subscribe((_, _) -> {
-                    // publish event to refresh the navigator
-                    EvtBusFactory.getDefaultEvtBus().publish(CALCULATOR_CACHE_TOPIC,
-                            new RefreshCalculatorCacheEvent("child filter menu refresh next gen nav", RefreshCalculatorCacheEvent.GLOBAL_REFRESH));
-                }));
-
                 // Subscribe default F.O. to this nodeView, so changes from its menu are propagated to default F.O.
                 // Typically, changes to nodeView can come from parentView, if the coordinate has no overrides
                 filterOptionsPopup.getFilterOptionsUtils().subscribeFilterOptionsToView(
                         filterOptionsPopup.getInheritedFilterOptions(), view.nodeView());
-
-                // listen to changes to the parent of the current overrideable view, and publish event
-                viewSubscription = viewSubscription.and(view.parentView().subscribe((_, _) -> {
-                    // publish event to refresh the navigator
-                    EvtBusFactory.getDefaultEvtBus().publish(CALCULATOR_CACHE_TOPIC,
-                            new RefreshCalculatorCacheEvent("parent refresh next gen nav", RefreshCalculatorCacheEvent.GLOBAL_REFRESH));
-                }));
             }
         })));
 
@@ -280,9 +258,6 @@ public class KLSearchControlSkin extends SkinBase<KLSearchControl> {
     public void dispose() {
         if (subscription != null) {
             subscription.unsubscribe();
-        }
-        if (viewSubscription != null) {
-            viewSubscription.unsubscribe();
         }
         textField.textProperty().unbind();
         textField.promptTextProperty().unbind();

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/navigation/ConceptPatternNavController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/navigation/ConceptPatternNavController.java
@@ -5,7 +5,6 @@ import dev.ikm.komet.framework.dnd.DragImageMaker;
 import dev.ikm.komet.framework.dnd.KometClipboard;
 import dev.ikm.tinkar.events.EvtBusFactory;
 import dev.ikm.tinkar.events.Subscriber;
-import dev.ikm.komet.framework.events.appevents.RefreshCalculatorCacheEvent;
 import dev.ikm.komet.framework.view.ViewProperties;
 import dev.ikm.komet.kview.controls.ConceptNavigatorTreeItem;
 import dev.ikm.komet.kview.controls.ConceptNavigatorUtils;
@@ -101,7 +100,6 @@ public class ConceptPatternNavController {
     private JournalController journalController;
 
     private Subscriber<PatternSavedEvent> patternCreationEventSubscriber;
-    private Subscriber<RefreshCalculatorCacheEvent> refreshCalculatorEventSubscriber;
 
     private KLConceptNavigatorControl conceptNavigatorControl;
 
@@ -292,6 +290,9 @@ public class ConceptPatternNavController {
         VBox nodePanel = new VBox(searchControl, conceptNavigatorControl);
         nodePanel.getStyleClass().add("concept-navigator-container");
         VBox.setVgrow(conceptNavigatorControl, Priority.ALWAYS);
+
+        // When nodeView changes, update the Navigator, which also rebuilds the treeView
+        viewProperties.nodeView().subscribe((_, nv) -> conceptNavigatorControl.setNavigator(new ViewNavigator(nv)));
 
         return nodePanel;
     }


### PR DESCRIPTION
When nodeView coordinates change, update the Navigator, which ultimately fully recreates the ConceptNavigator treeView control.