### PR TITLE
Feature/finished/iia 2909 identifier copy to clipboard button

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/PublicIDControl.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/PublicIDControl.java
@@ -1,8 +1,6 @@
 package dev.ikm.komet.kview.controls;
 
 import dev.ikm.komet.kview.controls.skin.PublicIDControlSkin;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.scene.control.Control;
@@ -14,32 +12,18 @@ public class PublicIDControl extends Control {
 
      /// The public ID (UUID) property
     private StringProperty publicId = new SimpleStringProperty(this, "publicId");
-    /// The showLabel property which controls if the ID label is displayed
-    private BooleanProperty showLabel = new SimpleBooleanProperty(this, "showLabel", true);
-    /// The trimIdentifier tells the PublicIDControlSkin to trim the identifier value from the colon in the prefix
-    private BooleanProperty trimIdentifier = new SimpleBooleanProperty(this, "trimIdentifier", false);
 
     public PublicIDControl() {
          super();
     }
 
-    public PublicIDControl(boolean showLabel, String publicId, boolean trimIdentifier) {
+    public PublicIDControl(String publicId) {
         super();
         setPublicId(publicId);
-        setShowLabel(showLabel);
-        setTrimIdentifier(trimIdentifier);
     }
 
     public StringProperty publicIdProperty() {
         return publicId;
-    }
-
-    public BooleanProperty showLabelProperty() {
-        return showLabel;
-    }
-
-    public BooleanProperty trimIdentifierProperty() {
-        return trimIdentifier;
     }
 
     public String getPublicId() {
@@ -48,22 +32,6 @@ public class PublicIDControl extends Control {
 
     public void setPublicId(String publicId) {
         publicIdProperty().set(publicId);
-    }
-
-    public boolean getShowLabel() {
-        return showLabelProperty().get();
-    }
-
-    public void setShowLabel(boolean showLabel) {
-        showLabelProperty().set(showLabel);
-    }
-
-    public boolean getTrimIdentifier() {
-        return trimIdentifierProperty().get();
-    }
-
-    public void setTrimIdentifier(boolean trimIdentifier) {
-        trimIdentifierProperty().set(trimIdentifier);
     }
 
     /** {@inheritDoc} */

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/PublicIDControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/PublicIDControlSkin.java
@@ -2,7 +2,6 @@ package dev.ikm.komet.kview.controls.skin;
 
 import dev.ikm.komet.kview.controls.PublicIDControl;
 import dev.ikm.komet.kview.mvvm.view.common.SVGConstants;
-import javafx.application.Platform;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.SkinBase;
@@ -12,7 +11,6 @@ import javafx.scene.input.ClipboardContent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.shape.FillRule;
 import javafx.scene.shape.SVGPath;
-import javafx.scene.text.Text;
 import javafx.util.Subscription;
 
 /// Provides the Skin for the PublicIDControl.
@@ -93,26 +91,6 @@ public class PublicIDControlSkin extends SkinBase<PublicIDControl> {
             identifier = publicId;
             publicIdTooltip.setText(identifier);
             publicIdLabel.setText(identifier);
-
-            Platform.runLater(() -> {
-                // set the preferredWidth of the TextField to completely show the identifier text
-
-                Text text = new Text(identifier); // Create a temporary Text node with the new text
-                text.setFont(publicIdLabel.getFont()); // Set the same font as the TextField
-                double labelWidth = text.getLayoutBounds().getWidth() +
-                        publicIdLabel.getLabelPadding().getLeft() +
-                        publicIdLabel.getLabelPadding().getRight() +
-                        publicIdLabel.getPadding().getLeft() +
-                        publicIdLabel.getPadding().getRight() + 2; // Add padding and a small buffer
-
-//                publicIdLabel.setPrefWidth(labelWidth);
-//                publicIdLabel.setMaxWidth(labelWidth);
-
-                double borderWidth = labelWidth + 10 + copyToClipboardButton.getPrefWidth();
-
-//                rootBorderPane.setPrefWidth(borderWidth);
-//                rootBorderPane.setMaxWidth(borderWidth);
-            });
         });
     }
 

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/PublicIDListControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/PublicIDListControlSkin.java
@@ -42,7 +42,7 @@ public class PublicIDListControlSkin extends SkinBase<PublicIDListControl> {
 
             if (publicIdList != null && !publicIdList.isEmpty()) {
                 for (String identifier : publicIdList) {
-                    PublicIDControl publicIDControl = new PublicIDControl(false, identifier, true);
+                    PublicIDControl publicIDControl = new PublicIDControl(identifier);
 
                     identifierVBox.getChildren().add(publicIDControl);
                 }
@@ -55,6 +55,7 @@ public class PublicIDListControlSkin extends SkinBase<PublicIDListControl> {
     @Override
     protected void layoutChildren(double x, double y, double w, double h) {
         rootScrollPane.resizeRelocate(x, y, w, h);
+        identifierVBox.setPrefWidth(w);
     }
 
     /// Unsubscribes from the subscription to stop receiving the publicIdProperty change events

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/PublicIDListControlSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/PublicIDListControlSkin.java
@@ -2,6 +2,7 @@ package dev.ikm.komet.kview.controls.skin;
 
 import dev.ikm.komet.kview.controls.PublicIDControl;
 import dev.ikm.komet.kview.controls.PublicIDListControl;
+import javafx.scene.control.ScrollBar;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.SkinBase;
 import javafx.scene.layout.VBox;
@@ -52,10 +53,37 @@ public class PublicIDListControlSkin extends SkinBase<PublicIDListControl> {
         getChildren().add(rootScrollPane);
     }
 
+    /// Determines if the vertical scroll bar is visible
+    private boolean isVerticalScrollBarVisible() {
+        boolean isVisible = false;
+        // the vertical scroll bar must be looked up each time this method is called
+        // because the ScrollBar object changes during the life of a ScrollPane
+        ScrollBar verticalScrollBar = (ScrollBar) rootScrollPane.lookup(".scroll-bar:vertical");;
+
+        if (verticalScrollBar != null) {
+            isVisible = verticalScrollBar.isVisible();
+        }
+
+        return isVisible;
+    }
+
+    /// Layout the children, which includes the ScrollPane and the VBox.
+    /// This method sets the width of the VBox for optimal display, which is
+    /// based on the visibility of the vertical ScrollBar.
     @Override
     protected void layoutChildren(double x, double y, double w, double h) {
         rootScrollPane.resizeRelocate(x, y, w, h);
-        identifierVBox.setPrefWidth(w);
+
+        // if the vertical scroll bar is visible set the width of the
+        // vbox to the viewport width
+        if (isVerticalScrollBarVisible()) {
+            var viewPortBounds = rootScrollPane.getViewportBounds();
+
+            identifierVBox.setPrefWidth(viewPortBounds.getWidth());
+        } else {
+            // if not visible, set the width to the same as the PublicIDListControlSkin (this) width
+            identifierVBox.setPrefWidth(w);
+        }
     }
 
     /// Unsubscribes from the subscription to stop receiving the publicIdProperty change events

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/public-id-control.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/public-id-control.css
@@ -9,35 +9,22 @@
     -fx-pref-height: -public-id-height;
     -fx-min-height: -public-id-height;
 
-    /* the spacing for the HBoxes in the control, is inherited in child nodes */
-    -fx-spacing: 4;
+    /* -fx-background-color: #00FF00;  for debugging */
 }
 
-.public-id > .public-id-box {
-    -fx-spacing: inherit;
-}
-
-.public-id > .title-label {
-   -fx-font-family: "Noto Sans Bold";
-   -fx-font-size: 12px;
-   -fx-text-fill: black;
-}
-
-.public-id > .public-id-box > .public-id-textfield {
+.public-id > .public-id-label {
     /* The preferred width, set to display the first public ID in the TextField.
        This value will change based on the -fx-font-size setting above.
        The value used must work on the Concept, Pattern, and Semantic windows. */
-    -fx-pref-width: 195;
+    /* -fx-pref-width: 195; */
     -fx-font-family: "Noto Sans";
     -fx-font-size: 10;
     -fx-text-fill: -Grey-10;
-}
-
-.public-id-text {
     -fx-font-weight: normal;
+    -fx-text-alignment: left;
 }
 
-.public-id > .public-id-box > .copy-to-clipboard-button {
+.public-id > .copy-to-clipboard-button {
     -fx-padding: 2;
     -fx-border-insets: 0;
     -fx-border-radius: 4;
@@ -54,19 +41,19 @@
     -fx-background-color: transparent;
 }
 
-.public-id > .public-id-box > .copy-to-clipboard-button:hover {
+.public-id > .copy-to-clipboard-button:hover {
     -fx-background-color: -Grey-3;
 }
 
-.public-id > .public-id-box > .copy-to-clipboard-button:pressed {
+.public-id > .copy-to-clipboard-button:pressed {
     -fx-background-color: -Grey-5;
 }
 
-.public-id > .public-id-box > .copy-to-clipboard-button:disabled {
+.public-id > .copy-to-clipboard-button:disabled {
     -fx-fill: -Grey-3;
 }
 
-.public-id > .public-id-box > .copy-to-clipboard-button > .copy-to-clipboard-svg {
+.public-id > .copy-to-clipboard-button > .copy-to-clipboard-svg {
     -icon-scale: 0.7;
 
     -fx-fill: -Grey-10;

--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/public-id-list-control.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/public-id-list-control.css
@@ -13,4 +13,7 @@
 
 .identifier-vbox  {
     -fx-spacing: 0;
+    -fx-fill-width: false;
+
+    /* -fx-background-color: #ff0000;  for debugging */
 }


### PR DESCRIPTION
Jira ticket:  https://ikmdev.atlassian.net/browse/IIA-2909

Summary of changes:

- Simplified PublicIDControl, now that all three windows Concept, Pattern and Semantic are using the same PublicIDListControl for identifier display
- With permission from Jieun, changed the TextField to a Label in PublicIDControl

Before changes:  The Copy to clipboard is not visible when the width of the Concept window is reduced

<img width="466" height="624" alt="image" src="https://github.com/user-attachments/assets/0bf5ec73-98e5-41f9-91de-4dc3600297c0" />


After changes:  The Copy to clipboard button is visible

<img width="463" height="625" alt="image" src="https://github.com/user-attachments/assets/bc2b5d45-efc4-472c-9d36-d6123e93d5d9" />
