### PR TITLE
Update Navigator when nodeView changes

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/FilterOptionsUtils.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/FilterOptionsUtils.java
@@ -420,7 +420,6 @@ public class FilterOptionsUtils {
         // remove previous subscriptions
         unsubscribeOptions();
 
-        ObservableView observableViewForFilter = filterOptions.observableViewForFilterProperty();
         FilterOptions.MainFilterCoordinates mainCoordinates = filterOptions.getMainCoordinates();
         List<FilterOptions.LanguageFilterCoordinates> languageCoordinatesList = filterOptions.getLanguageCoordinatesList();
 

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterOptionsPopupSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterOptionsPopupSkin.java
@@ -372,10 +372,6 @@ public class FilterOptionsPopupSkin implements Skin<FilterOptionsPopup> {
                 pane.setDefaultLangCoordinates(defaultFilterOptions.getLanguageCoordinates(pane.getOrdinal())));
         // finally, setup filter with default options
         setupFilter(defaultFilterOptions);
-        if (control.getFilterOptions() == null) {
-            // and update control with default options, if there are no options yet
-            currentFilterOptionsProperty.set(defaultFilterOptions);
-        }
     }
 
     private void setDefaultOptions(FilterOptions filterOptions) {

--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/LangFilterTitledPaneSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/LangFilterTitledPaneSkin.java
@@ -164,6 +164,7 @@ public class LangFilterTitledPaneSkin extends TitledPaneSkin {
         }));
 
         subscription = subscription.and(control.langCoordinatesProperty().subscribe((_, _) -> setupTitledPane()));
+        subscription = subscription.and(control.navigatorProperty().subscribe((_, _) -> setupTitledPane()));
         updateModifiedState(currentLangCoordinates);
     }
 

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/navigation/ConceptPatternNavController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/navigation/ConceptPatternNavController.java
@@ -291,8 +291,13 @@ public class ConceptPatternNavController {
         nodePanel.getStyleClass().add("concept-navigator-container");
         VBox.setVgrow(conceptNavigatorControl, Priority.ALWAYS);
 
-        // When nodeView changes, update the Navigator, which also rebuilds the treeView
-        viewProperties.nodeView().subscribe((_, nv) -> conceptNavigatorControl.setNavigator(new ViewNavigator(nv)));
+        // When nodeView changes, update the Navigator, to update the Search Control and the FilterOptionsPopup, and
+        // also rebuild the ConceptNavigator treeView
+        viewProperties.nodeView().subscribe((_, nv) -> {
+            ViewNavigator nav = new ViewNavigator(nv);
+            searchControl.setNavigator(nav);
+            conceptNavigatorControl.setNavigator(nav);
+        });
 
         return nodePanel;
     }

--- a/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/NextGenSearchController.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/mvvm/view/search/NextGenSearchController.java
@@ -173,8 +173,11 @@ public class NextGenSearchController {
         filterOptionsPopup = new FilterOptionsPopup(FilterOptionsPopup.FILTER_TYPE.SEARCH);
 
         // listen to changes to the current overrideable view, after changes coming from the parentView
-        // or the F.O. popup, and publish event
-        getViewProperties().nodeView().subscribe((_, _) -> doSearch(new ActionEvent(null, null)));
+        // or the FilterOptionsPopup, updating the Navigator, and triggering the search
+        getViewProperties().nodeView().subscribe((_, nv) -> {
+            filterOptionsPopup.setNavigator(new ViewNavigator(nv));
+            doSearch(new ActionEvent(null, null));
+        });
 
         // Subscribe default F.O. to this nodeView, so changes from its menu are propagated to default F.O.
         // Typically, changes to nodeView can come from parentView, if the coordinate has no overrides
@@ -476,7 +479,7 @@ public class NextGenSearchController {
         }
     }
 
-    public ViewProperties getViewProperties() {
+    private ViewProperties getViewProperties() {
         return nextGenSearchViewModel.getPropertyValue(VIEW_PROPERTIES);
     }
 


### PR DESCRIPTION
Allows language change for controls (KLConceptNavigatorControl, KLSearchControl, FilterOptionsPopup), whenever the view language is changed (either from ParentView or NodeView).