### PR TITLE
Feature/finished/IIA-2928: [Semantic STAMP] Semantic stamp fields are cut off and misaligned for large module and path values

### DIFF
--- a/kview/src/main/resources/dev/ikm/komet/kview/controls/stamp-view-control.css
+++ b/kview/src/main/resources/dev/ikm/komet/kview/controls/stamp-view-control.css
@@ -13,6 +13,8 @@
     -fx-font-family: "Noto Sans Bold";
     -fx-font-size: 12px;
     -fx-text-fill: #444;
+
+    -fx-min-width: 35px;
 }
 
 .stamp-view-control .stamp-container .stamp-text {


### PR DESCRIPTION
Fixes: https://ikmdev.atlassian.net/browse/IIA-2928

-------

Stamp labels were getting cut out in some datasets

<img width="3840" height="2076" alt="image" src="https://github.com/user-attachments/assets/a7737889-9c89-44e7-942d-99d66fe5337f" />
