### PR TITLE
Refresh text of options when navigator changes.

### DIFF
--- a/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterTitledPaneSkin.java
+++ b/kview/src/main/java/dev/ikm/komet/kview/controls/skin/FilterTitledPaneSkin.java
@@ -132,7 +132,9 @@ public class FilterTitledPaneSkin extends TitledPaneSkin {
         control.pseudoClassStateChanged(SINGLE_SELECT_OPTION, !multiSelectionAllowed);
 
         FilterOptions.Option currentOption = option.copy();
-        selectedOption.setText(getOptionText(currentOption));
+        // whenever the navigator changes, update the option text
+        subscription = subscription.and(control.navigatorProperty().subscribe(_ ->
+                selectedOption.setText(getOptionText(currentOption))));
 
         // add toggles only once
         if (contentBox.getChildren().size() == 1) {


### PR DESCRIPTION
Changing the language to Spanish now refreshes the text of FilterOptions popup options:

<img width="835" height="839" alt="image" src="https://github.com/user-attachments/assets/f5653bcb-f39b-44fe-8db3-b73526f0715d" />
